### PR TITLE
fix crash with placeholder icon cache

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/domain/diy/Action.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/diy/Action.kt
@@ -45,8 +45,8 @@ sealed interface Action {
     }
 
     data class DimWallpaper(val dimAmount: Float = 0f) : Action {
-        override val title: Int = R.string.diy_action_dim_wallpaper
-        override val icon: Int = R.drawable.rounded_mobile_screensaver_24
+        override val title: Int get() = R.string.diy_action_dim_wallpaper
+        override val icon: Int get() = R.drawable.rounded_mobile_screensaver_24
         override val permissions: List<String> = listOf("shizuku", "root")
         override val isConfigurable: Boolean = true
     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/diy/AutomationItem.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/diy/AutomationItem.kt
@@ -53,6 +53,7 @@ import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenu
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
 import com.sameerasw.essentials.utils.HapticUtil
+import androidx.compose.ui.platform.LocalContext
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -167,8 +168,17 @@ fun AutomationItem(
                                 .fillMaxHeight(),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
+                            val context = LocalContext.current
+                            val validatedIcon = remember(icon) {
+                                try {
+                                    if (context.resources.getResourceTypeName(icon) == "drawable") icon
+                                    else R.drawable.rounded_do_not_disturb_on_24
+                                } catch (e: Exception) {
+                                    R.drawable.rounded_do_not_disturb_on_24
+                                }
+                            }
                             Icon(
-                                painter = painterResource(id = icon),
+                                painter = painterResource(id = validatedIcon),
                                 contentDescription = null,
                                 modifier = Modifier.size(24.dp),
                                 tint = MaterialTheme.colorScheme.onSecondaryContainer
@@ -281,8 +291,18 @@ fun ActionItem(
             modifier = Modifier.padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            val context = LocalContext.current
+            val iconId = action?.icon ?: R.drawable.rounded_do_not_disturb_on_24
+            val validatedIcon = remember(iconId) {
+                try {
+                    if (context.resources.getResourceTypeName(iconId) == "drawable") iconId
+                    else R.drawable.rounded_do_not_disturb_on_24
+                } catch (e: Exception) {
+                    R.drawable.rounded_do_not_disturb_on_24
+                }
+            }
             Icon(
-                painter = painterResource(id = action?.icon ?: R.drawable.rounded_do_not_disturb_on_24),
+                painter = painterResource(id = validatedIcon),
                 contentDescription = null,
                 modifier = Modifier.size(24.dp),
                 tint = MaterialTheme.colorScheme.onSurface


### PR DESCRIPTION
This pull request improves how icons are handled and displayed in the DIY automation UI, making the icon rendering more robust against missing or invalid resources. It also makes a small change to the `Action` interface for consistency.

**Improvements to icon handling:**

* Added validation logic in `AutomationItem` and `ActionItem` composables to ensure the icon resource is of type `drawable` and to fall back to a default icon (`R.drawable.rounded_do_not_disturb_on_24`) if the provided icon is invalid or missing. This prevents crashes from invalid icon references and improves UI stability. [[1]](diffhunk://#diff-4552ea6f41f65e42a56f775bade38da03686a7347d1551514b6363e51d513c0bR171-R181) [[2]](diffhunk://#diff-4552ea6f41f65e42a56f775bade38da03686a7347d1551514b6363e51d513c0bR294-R305)
* Imported `LocalContext` in `AutomationItem.kt` to support the new icon validation logic.

**Code consistency:**

* Updated the `DimWallpaper` action in `Action.kt` to use property getters for `title` and `icon` instead of fixed values, aligning with best practices for property initialization.