### PR TITLE
fix: route short-press volume to active stream during calls

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/services/InputEventListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/InputEventListenerService.kt
@@ -168,9 +168,9 @@ class InputEventListenerService : Service() {
                                             android.media.AudioManager.ADJUST_RAISE
                                         else
                                             android.media.AudioManager.ADJUST_LOWER
-                                    am.adjustStreamVolume(
-                                        android.media.AudioManager.STREAM_MUSIC,
+                                    am.adjustSuggestedStreamVolume(
                                         direction,
+                                        android.media.AudioManager.USE_DEFAULT_STREAM_TYPE,
                                         android.media.AudioManager.FLAG_SHOW_UI
                                     )
                                 }
@@ -196,9 +196,9 @@ class InputEventListenerService : Service() {
                                         android.media.AudioManager.ADJUST_RAISE
                                     else
                                         android.media.AudioManager.ADJUST_LOWER
-                                am.adjustStreamVolume(
-                                    android.media.AudioManager.STREAM_MUSIC,
+                                am.adjustSuggestedStreamVolume(
                                     dirKey,
+                                    android.media.AudioManager.USE_DEFAULT_STREAM_TYPE,
                                     android.media.AudioManager.FLAG_SHOW_UI
                                 )
                             }

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/ButtonRemapHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/ButtonRemapHandler.kt
@@ -150,9 +150,9 @@ class ButtonRemapHandler(
                 val am = service.getSystemService(Context.AUDIO_SERVICE) as AudioManager
                 val direction =
                     if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) AudioManager.ADJUST_RAISE else AudioManager.ADJUST_LOWER
-                am.adjustStreamVolume(
-                    AudioManager.STREAM_MUSIC,
+                am.adjustSuggestedStreamVolume(
                     direction,
+                    AudioManager.USE_DEFAULT_STREAM_TYPE,
                     AudioManager.FLAG_SHOW_UI
                 )
             }


### PR DESCRIPTION
## Problem

With Button Remap enabled and a mapping on Vol+ / Vol-, a single short press always changed media volume — even during a phone call. This overrode Android's default stream routing (STREAM_VOICE_CALL during calls, STREAM_RING while ringing, etc.).

## Cause

The accessibility service path consumes the volume DOWN event via `FLAG_REQUEST_FILTER_KEY_EVENTS` and re-simulates default volume behaviour on UP if no long-press fired. Three call sites in that re-simulation hardcoded `STREAM_MUSIC`, so every short press always adjusted media volume regardless of what stream Android would have picked.

## Fix

Replace the hardcoded `adjustStreamVolume(STREAM_MUSIC, …)` with `adjustSuggestedStreamVolume(direction, USE_DEFAULT_STREAM_TYPE, FLAG_SHOW_UI)` at the three sites. This is the documented Android API for *"do exactly what hardware volume keys would normally do"* — the system itself picks `STREAM_VOICE_CALL` during calls, `STREAM_RING` while ringing, `STREAM_MUSIC` while music plays, and falls back to the suggestion when nothing is active. Ref: [`AudioManager.adjustSuggestedStreamVolume`](https://developer.android.com/reference/android/media/AudioManager#adjustSuggestedStreamVolume(int,%20int,%20int)).

## Sites changed

- `app/src/main/java/com/sameerasw/essentials/services/handlers/ButtonRemapHandler.kt:153` — accessibility-service path, screen-on
- `app/src/main/java/com/sameerasw/essentials/services/InputEventListenerService.kt:171` — Shizuku `/dev/input` path, torch-on branch
- `app/src/main/java/com/sameerasw/essentials/services/InputEventListenerService.kt:199` — Shizuku `/dev/input` path, torch-off branch

## Intentionally untouched

`toggleMediaVolume()` at `ButtonRemapHandler.kt:244,251` keeps `STREAM_MUSIC`. That helper backs the user-selected **Toggle media volume** mapping action, which by design must act on media volume regardless of active stream.

## Out of scope

The ~500 ms perceived latency on short-press is structural to the consume-then-replay design (DOWN is consumed, only UP-before-timeout re-simulates) and is not what this PR addresses. Worth a separate UX pass.

## Verification

- `./gradlew assembleDebug` — green; no new warnings on the edited lines.
- Grep sweep: zero `adjustStreamVolume` calls remain in the re-simulation paths; three `adjustSuggestedStreamVolume` calls at the edited lines.
- On-device matrix to exercise after merge: idle → ringtone slider; music playing → music slider; cellular call (screen on / proximity off) → in-call slider; VoIP (Signal, Meet) → communication slider; long-press → mapped action still fires, slider stays put.

Diff: 6 changed lines across two files.