### PR TITLE
Develop - WearOS - Device controls and info sync support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.sameerasw.essentials"
         minSdk = 26
         targetSdk = 36
-        versionCode = 41
-        versionName = "13.2"
+        versionCode = 42
+        versionName = "13.3"
 
         val whatsNewCounter = 1
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -296,6 +296,15 @@
             android:exported="false"
             android:foregroundServiceType="specialUse" />
 
+        <service
+            android:name=".services.EssentialsWearableListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/request_device_info_sync" />
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".services.ScreenOffWidgetProvider"
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -301,7 +301,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
-                <data android:scheme="wear" android:host="*" android:pathPrefix="/request_device_info_sync" />
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/" />
             </intent-filter>
         </service>
 
@@ -689,6 +689,8 @@
                 <action android:name="com.sameerasw.essentials.ACTION_FLASHLIGHT_INCREASE" />
                 <action android:name="com.sameerasw.essentials.ACTION_FLASHLIGHT_DECREASE" />
                 <action android:name="com.sameerasw.essentials.ACTION_FLASHLIGHT_OFF" />
+                <action android:name="com.sameerasw.essentials.ACTION_FLASHLIGHT_TOGGLE" />
+                <action android:name="com.sameerasw.essentials.ACTION_SET_INTENSITY" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/sameerasw/essentials/EssentialsApp.kt
+++ b/app/src/main/java/com/sameerasw/essentials/EssentialsApp.kt
@@ -41,6 +41,7 @@ class EssentialsApp : Application() {
         com.sameerasw.essentials.domain.diy.DIYRepository.init(this)
         com.sameerasw.essentials.services.automation.AutomationManager.init(this)
         com.sameerasw.essentials.services.CalendarSyncManager.init(this)
+        com.sameerasw.essentials.services.DeviceInfoSyncManager.init(this)
         com.sameerasw.essentials.utils.ServiceUtils.startRequiredServices(this)
 
         initSentry()

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -359,6 +359,10 @@ class FeatureSettingsActivity : AppCompatActivity() {
                             }
 
                             if (featureId == "Watch") {
+                                val context = androidx.compose.ui.platform.LocalContext.current
+                                LaunchedEffect(Unit) {
+                                    watchViewModel.check(context)
+                                }
                                 WatchSettingsUI(
                                     viewModel = watchViewModel,
                                     modifier = Modifier.padding(top = 16.dp)

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -610,6 +610,15 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                         )
                                     }
 
+                                    "Lock from Watch" -> {
+                                        com.sameerasw.essentials.ui.composables.configs.RemoteLockSettingsUI(
+                                            mainViewModel = viewModel,
+                                            watchViewModel = watchViewModel,
+                                            modifier = Modifier.padding(top = 16.dp),
+                                            highlightSetting = highlightSetting
+                                        )
+                                    }
+
                                     "Maps power saving mode" -> {
                                         MapsPowerSavingSettingsUI(
                                             viewModel = viewModel,

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -176,6 +176,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_CALENDAR_SYNC_ENABLED = "calendar_sync_enabled"
         const val KEY_CALENDAR_SYNC_SELECTED_CALENDARS = "calendar_sync_selected_calendars"
         const val KEY_CALENDAR_SYNC_PERIODIC_ENABLED = "calendar_sync_periodic_enabled"
+        const val KEY_REMOTE_LOCK_MODE = "remote_lock_mode" // 0: Screen off, 1: Lock
 
         const val KEY_GITHUB_ACCESS_TOKEN = "github_access_token"
         const val KEY_GITHUB_USER_PROFILE = "github_user_profile"

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -964,6 +964,21 @@ object FeatureRegistry {
             override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) =
                 viewModel.setCalendarSyncEnabled(enabled, context)
         },
+        
+        object : Feature(
+            id = "Lock from Watch",
+            title = R.string.feat_lock_from_watch_title,
+            iconRes = R.drawable.rounded_lock_24,
+            category = R.string.cat_tools,
+            description = R.string.feat_lock_from_watch_desc,
+            aboutDescription = R.string.feat_lock_from_watch_desc,
+            parentFeatureId = "Watch",
+            hasMoreSettings = true,
+            showToggle = false
+        ) {
+            override fun isEnabled(viewModel: MainViewModel) = true
+            override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {}
+        },
 
 
         object : Feature(

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -1,0 +1,77 @@
+package com.sameerasw.essentials.services
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+
+object DeviceInfoSyncManager {
+    private const val TAG = "DeviceInfoSyncManager"
+    private const val SYNC_PATH = "/device_info"
+    private val handler = Handler(Looper.getMainLooper())
+    private var isInitialized = false
+
+    private val syncRunnable = object : Runnable {
+        override fun run() {
+            syncDeviceInfo(currentContext ?: return)
+            handler.postDelayed(this, 5 * 60 * 1000) // Sync every 5 minutes
+        }
+    }
+
+    private var currentContext: Context? = null
+
+    fun init(context: Context) {
+        if (isInitialized) return
+        currentContext = context.applicationContext
+        isInitialized = true
+        
+        // Initial sync
+        syncDeviceInfo(context)
+        
+        // Start periodic sync
+        handler.postDelayed(syncRunnable, 5 * 60 * 1000)
+    }
+
+    fun forceSync(context: Context) {
+        Log.d(TAG, "forceSync: Manually triggering sync")
+        syncDeviceInfo(context)
+    }
+
+    private fun syncDeviceInfo(context: Context) {
+        val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
+            context.registerReceiver(null, ifilter)
+        }
+
+        val level: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val batteryPct = if (level != -1 && scale != -1) (level / scale.toFloat() * 100).toInt() else -1
+        
+        val status: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL
+
+        Log.d(TAG, "Syncing device info: Battery=$batteryPct%, Charging=$isCharging")
+
+        val putDataMapReq = PutDataMapRequest.create(SYNC_PATH)
+        val dataMap = putDataMapReq.dataMap
+        dataMap.putInt("battery_level", batteryPct)
+        dataMap.putBoolean("is_charging", isCharging)
+        dataMap.putLong("timestamp", System.currentTimeMillis())
+
+        val putDataReq = putDataMapReq.asPutDataRequest()
+        putDataReq.setUrgent()
+
+        Wearable.getDataClient(context).putDataItem(putDataReq)
+            .addOnSuccessListener {
+                Log.d(TAG, "Successfully synced device info to wearable")
+            }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to sync device info to wearable", e)
+            }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -7,6 +7,8 @@ import android.os.BatteryManager
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.hardware.camera2.CameraManager
+import com.sameerasw.essentials.utils.FlashlightUtil
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 
@@ -15,6 +17,42 @@ object DeviceInfoSyncManager {
     private const val SYNC_PATH = "/device_info"
     private val handler = Handler(Looper.getMainLooper())
     private var isInitialized = false
+    
+    private var isTorchOn = false
+    private var torchLevel = 1
+    private var maxTorchLevel = 1
+    private var isIntensitySupported = false
+
+    private val torchCallback = object : CameraManager.TorchCallback() {
+        override fun onTorchModeChanged(cameraId: String, enabled: Boolean) {
+            val context = currentContext ?: return
+            val primaryId = FlashlightUtil.getCameraId(context)
+            if (cameraId == primaryId) {
+                isTorchOn = enabled
+                
+                var level = FlashlightUtil.getCurrentLevel(context, cameraId)
+                // Fallback to last known intensity if system returns default level 1
+                if (enabled && level <= 1) {
+                    val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+                    level = prefs.getInt("flashlight_last_intensity", level)
+                }
+                
+                torchLevel = level
+                maxTorchLevel = FlashlightUtil.getMaxLevel(context, cameraId)
+                isIntensitySupported = FlashlightUtil.isIntensitySupported(context, cameraId)
+                syncDeviceInfo(context)
+            }
+        }
+
+        override fun onTorchStrengthLevelChanged(cameraId: String, newStrengthLevel: Int) {
+            val context = currentContext ?: return
+            val primaryId = FlashlightUtil.getCameraId(context)
+            if (cameraId == primaryId) {
+                torchLevel = newStrengthLevel
+                syncDeviceInfo(context)
+            }
+        }
+    }
 
     private val syncRunnable = object : Runnable {
         override fun run() {
@@ -42,14 +80,35 @@ object DeviceInfoSyncManager {
                 syncDeviceInfo(context)
             }
         }, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+
+        // Sync on flashlight change
+        val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        cameraManager.registerTorchCallback(torchCallback, handler)
+        
+        // Get initial flashlight state
+        val id = FlashlightUtil.getCameraId(context)
+        if (id != null) {
+            isIntensitySupported = FlashlightUtil.isIntensitySupported(context, id)
+            maxTorchLevel = FlashlightUtil.getMaxLevel(context, id)
+            torchLevel = FlashlightUtil.getCurrentLevel(context, id)
+        }
     }
 
-    fun forceSync(context: Context) {
-        Log.d(TAG, "forceSync: Manually triggering sync")
-        syncDeviceInfo(context)
+    private val syncDebouncer = Runnable {
+        currentContext?.let { performSync(it) }
     }
 
     private fun syncDeviceInfo(context: Context) {
+        handler.removeCallbacks(syncDebouncer)
+        handler.postDelayed(syncDebouncer, 250L)
+    }
+
+    fun forceSync(context: Context) {
+        handler.removeCallbacks(syncDebouncer)
+        performSync(context)
+    }
+
+    private fun performSync(context: Context) {
         val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
             context.registerReceiver(null, ifilter)
         }
@@ -66,23 +125,19 @@ object DeviceInfoSyncManager {
                 plugged == BatteryManager.BATTERY_PLUGGED_USB ||
                 plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
 
-        Log.d(TAG, "syncDeviceInfo: Battery=$batteryPct%, Status=$status, Plugged=$plugged, isCharging=$isCharging")
-
         val putDataMapReq = PutDataMapRequest.create(SYNC_PATH)
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
+        dataMap.putBoolean("flashlight_on", isTorchOn)
+        dataMap.putInt("flashlight_level", torchLevel)
+        dataMap.putInt("flashlight_max_level", maxTorchLevel)
+        dataMap.putBoolean("flashlight_intensity_supported", isIntensitySupported)
         dataMap.putLong("timestamp", System.currentTimeMillis())
 
         val putDataReq = putDataMapReq.asPutDataRequest()
         putDataReq.setUrgent()
 
         Wearable.getDataClient(context).putDataItem(putDataReq)
-            .addOnSuccessListener {
-                Log.d(TAG, "Successfully synced device info to wearable")
-            }
-            .addOnFailureListener { e ->
-                Log.e(TAG, "Failed to sync device info to wearable", e)
-            }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -134,6 +134,8 @@ object DeviceInfoSyncManager {
 
         val putDataMapReq = PutDataMapRequest.create(SYNC_PATH)
         val ringerMode = (context.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager)?.ringerMode ?: 2
+        val deviceName = android.provider.Settings.Global.getString(context.contentResolver, android.provider.Settings.Global.DEVICE_NAME)
+            ?: android.os.Build.MODEL
 
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
@@ -143,6 +145,7 @@ object DeviceInfoSyncManager {
         dataMap.putInt("flashlight_max_level", maxTorchLevel)
         dataMap.putBoolean("flashlight_intensity_supported", isIntensitySupported)
         dataMap.putInt("ringer_mode", ringerMode)
+        dataMap.putString("device_name", deviceName)
         dataMap.putLong("timestamp", System.currentTimeMillis())
 
         val putDataReq = putDataMapReq.asPutDataRequest()

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -81,6 +81,13 @@ object DeviceInfoSyncManager {
             }
         }, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
 
+        // Sync on ringer mode change
+        context.registerReceiver(object : android.content.BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                syncDeviceInfo(context)
+            }
+        }, IntentFilter(android.media.AudioManager.RINGER_MODE_CHANGED_ACTION))
+
         // Sync on flashlight change
         val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         cameraManager.registerTorchCallback(torchCallback, handler)
@@ -126,6 +133,8 @@ object DeviceInfoSyncManager {
                 plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
 
         val putDataMapReq = PutDataMapRequest.create(SYNC_PATH)
+        val ringerMode = (context.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager)?.ringerMode ?: 2
+
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
@@ -133,6 +142,7 @@ object DeviceInfoSyncManager {
         dataMap.putInt("flashlight_level", torchLevel)
         dataMap.putInt("flashlight_max_level", maxTorchLevel)
         dataMap.putBoolean("flashlight_intensity_supported", isIntensitySupported)
+        dataMap.putInt("ringer_mode", ringerMode)
         dataMap.putLong("timestamp", System.currentTimeMillis())
 
         val putDataReq = putDataMapReq.asPutDataRequest()

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -35,6 +35,13 @@ object DeviceInfoSyncManager {
         
         // Start periodic sync
         handler.postDelayed(syncRunnable, 5 * 60 * 1000)
+
+        // Sync on battery change
+        context.registerReceiver(object : android.content.BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                syncDeviceInfo(context)
+            }
+        }, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
     }
 
     fun forceSync(context: Context) {
@@ -52,10 +59,14 @@ object DeviceInfoSyncManager {
         val batteryPct = if (level != -1 && scale != -1) (level / scale.toFloat() * 100).toInt() else -1
         
         val status: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val plugged: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1) ?: -1
         val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                status == BatteryManager.BATTERY_STATUS_FULL
+                status == BatteryManager.BATTERY_STATUS_FULL ||
+                plugged == BatteryManager.BATTERY_PLUGGED_AC ||
+                plugged == BatteryManager.BATTERY_PLUGGED_USB ||
+                plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
 
-        Log.d(TAG, "Syncing device info: Battery=$batteryPct%, Charging=$isCharging")
+        Log.d(TAG, "syncDeviceInfo: Battery=$batteryPct%, Status=$status, Plugged=$plugged, isCharging=$isCharging")
 
         val putDataMapReq = PutDataMapRequest.create(SYNC_PATH)
         val dataMap = putDataMapReq.dataMap

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -35,6 +35,9 @@ class EssentialsWearableListenerService : WearableListenerService() {
                 }
                 sendBroadcast(intent)
             }
+            "/toggle_sound_mode" -> {
+                com.sameerasw.essentials.services.handlers.SoundModeHandler(this).cycleNextMode()
+            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -1,0 +1,19 @@
+package com.sameerasw.essentials.services
+
+import android.util.Log
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+
+class EssentialsWearableListenerService : WearableListenerService() {
+    companion object {
+        private const val TAG = "EssentialsWearableListener"
+        private const val PATH_REQUEST_SYNC = "/request_device_info_sync"
+    }
+
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        Log.d(TAG, "onMessageReceived: ${messageEvent.path}")
+        if (messageEvent.path == PATH_REQUEST_SYNC) {
+            DeviceInfoSyncManager.forceSync(this)
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -11,9 +11,30 @@ class EssentialsWearableListenerService : WearableListenerService() {
     }
 
     override fun onMessageReceived(messageEvent: MessageEvent) {
-        Log.d(TAG, "onMessageReceived: ${messageEvent.path}")
-        if (messageEvent.path == PATH_REQUEST_SYNC) {
-            DeviceInfoSyncManager.forceSync(this)
+        super.onMessageReceived(messageEvent)
+        
+        when (messageEvent.path) {
+            PATH_REQUEST_SYNC -> {
+                DeviceInfoSyncManager.forceSync(this)
+            }
+            "/toggle_flashlight" -> {
+                val intent = android.content.Intent(this, com.sameerasw.essentials.services.receivers.FlashlightActionReceiver::class.java).apply {
+                    action = com.sameerasw.essentials.services.receivers.FlashlightActionReceiver.ACTION_TOGGLE
+                }
+                sendBroadcast(intent)
+            }
+            "/set_flashlight_intensity" -> {
+                val intensity = try {
+                    String(messageEvent.data).toInt()
+                } catch (e: Exception) {
+                    1
+                }
+                val intent = android.content.Intent(this, com.sameerasw.essentials.services.receivers.FlashlightActionReceiver::class.java).apply {
+                    action = com.sameerasw.essentials.services.receivers.FlashlightActionReceiver.ACTION_SET_INTENSITY
+                    putExtra(com.sameerasw.essentials.services.receivers.FlashlightActionReceiver.EXTRA_INTENSITY, intensity)
+                }
+                sendBroadcast(intent)
+            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -38,6 +38,25 @@ class EssentialsWearableListenerService : WearableListenerService() {
             "/toggle_sound_mode" -> {
                 com.sameerasw.essentials.services.handlers.SoundModeHandler(this).cycleNextMode()
             }
+            "/lock_device" -> {
+                val repository = com.sameerasw.essentials.data.repository.SettingsRepository(this)
+                val mode = repository.getInt(com.sameerasw.essentials.data.repository.SettingsRepository.KEY_REMOTE_LOCK_MODE, 0)
+                
+                if (mode == 1) {
+                    // Device Admin Lock
+                    val dpm = getSystemService(android.content.Context.DEVICE_POLICY_SERVICE) as android.app.admin.DevicePolicyManager
+                    val adminComponent = android.content.ComponentName(this, com.sameerasw.essentials.services.receivers.SecurityDeviceAdminReceiver::class.java)
+                    if (dpm.isAdminActive(adminComponent)) {
+                        dpm.lockNow()
+                    }
+                } else {
+                    // Accessibility Lock
+                    val intent = android.content.Intent(this, com.sameerasw.essentials.services.tiles.ScreenOffAccessibilityService::class.java).apply {
+                        action = "LOCK_SCREEN"
+                    }
+                    startService(intent)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -110,6 +110,14 @@ class ScreenOffAccessibilityService : AccessibilityService(), SensorEventListene
                     "FORCE_TURN_OFF_AOD" -> {
                         aodForceTurnOffHandler.forceTurnOff()
                     }
+
+                    FlashlightActionReceiver.ACTION_TOGGLE,
+                    FlashlightActionReceiver.ACTION_OFF,
+                    FlashlightActionReceiver.ACTION_SET_INTENSITY,
+                    FlashlightActionReceiver.ACTION_INCREASE,
+                    FlashlightActionReceiver.ACTION_DECREASE -> {
+                        flashlightHandler.handleIntent(intent)
+                    }
                 }
             }
         }
@@ -120,6 +128,11 @@ class ScreenOffAccessibilityService : AccessibilityService(), SensorEventListene
             addAction(InputEventListenerService.ACTION_VOLUME_LONG_PRESSED)
             addAction("SHOW_AMBIENT_GLANCE")
             addAction("FORCE_TURN_OFF_AOD")
+            addAction(FlashlightActionReceiver.ACTION_TOGGLE)
+            addAction(FlashlightActionReceiver.ACTION_OFF)
+            addAction(FlashlightActionReceiver.ACTION_SET_INTENSITY)
+            addAction(FlashlightActionReceiver.ACTION_INCREASE)
+            addAction(FlashlightActionReceiver.ACTION_DECREASE)
         }
         registerReceiver(screenReceiver, filter, RECEIVER_EXPORTED)
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/RemoteLockSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/RemoteLockSettingsUI.kt
@@ -1,0 +1,113 @@
+package com.sameerasw.essentials.ui.composables.configs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.ui.components.cards.ConfigPickerItem
+import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
+import com.sameerasw.essentials.ui.modifiers.highlight
+import com.sameerasw.essentials.utils.PermissionUtils
+import com.sameerasw.essentials.viewmodels.MainViewModel
+import com.sameerasw.essentials.viewmodels.WatchViewModel
+
+@Composable
+fun RemoteLockSettingsUI(
+    mainViewModel: MainViewModel,
+    watchViewModel: WatchViewModel,
+    modifier: Modifier = Modifier,
+    highlightSetting: String? = null
+) {
+    val context = LocalContext.current
+    val settingsRepository = remember { SettingsRepository(context) }
+    var showPermissionSheet by remember { mutableStateOf(false) }
+    
+    val isAccessibilityEnabled by mainViewModel.isAccessibilityEnabled
+    val isDeviceAdminEnabled by mainViewModel.isDeviceAdminEnabled
+    val remoteLockMode by watchViewModel.remoteLockMode
+
+    LaunchedEffect(Unit) {
+        watchViewModel.load(settingsRepository)
+    }
+
+    if (showPermissionSheet) {
+        com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet(
+            onDismissRequest = { showPermissionSheet = false },
+            featureTitle = R.string.feat_lock_from_watch_title,
+            permissions = listOf(
+                com.sameerasw.essentials.ui.components.sheets.PermissionItem(
+                    iconRes = R.drawable.rounded_settings_accessibility_24,
+                    title = R.string.perm_accessibility_title,
+                    description = R.string.perm_accessibility_desc_common,
+                    dependentFeatures = listOf(R.string.feat_lock_from_watch_title),
+                    actionLabel = R.string.perm_action_enable,
+                    action = { PermissionUtils.openAccessibilitySettings(context) },
+                    isGranted = isAccessibilityEnabled
+                ),
+                com.sameerasw.essentials.ui.components.sheets.PermissionItem(
+                    iconRes = R.drawable.rounded_security_24,
+                    title = R.string.perm_device_admin_title,
+                    description = R.string.perm_device_admin_desc,
+                    dependentFeatures = listOf(R.string.feat_lock_from_watch_title),
+                    actionLabel = R.string.perm_action_grant,
+                    action = { mainViewModel.requestDeviceAdmin(context) },
+                    isGranted = isDeviceAdminEnabled
+                )
+            )
+        )
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.remote_lock_mode_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        RoundedCardContainer {
+            com.sameerasw.essentials.ui.components.pickers.SegmentedPicker(
+                items = listOf(0, 1),
+                selectedItem = remoteLockMode,
+                onItemSelected = { mode ->
+                    val hasPermission = when (mode) {
+                        0 -> isAccessibilityEnabled
+                        1 -> isDeviceAdminEnabled
+                        else -> false
+                    }
+                    if (!hasPermission) {
+                        showPermissionSheet = true
+                    } else {
+                        watchViewModel.setRemoteLockMode(mode, settingsRepository)
+                    }
+                },
+                labelProvider = { mode ->
+                    when (mode) {
+                        0 -> context.getString(R.string.remote_lock_mode_screen_off)
+                        1 -> context.getString(R.string.remote_lock_mode_lock)
+                        else -> ""
+                    }
+                },
+                modifier = Modifier.highlight(highlightSetting == "remote_lock_mode")
+            )
+        }
+        
+        Text(
+            text = stringResource(R.string.remote_lock_mode_admin_note),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 12.dp, start = 16.dp, end = 16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchSettingsUI.kt
@@ -1,18 +1,16 @@
 package com.sameerasw.essentials.ui.composables.configs
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.sameerasw.essentials.R
@@ -24,16 +22,64 @@ fun WatchSettingsUI(
     viewModel: WatchViewModel,
     modifier: Modifier = Modifier
 ) {
-    LocalContext.current
     val uriHandler = LocalUriHandler.current
     val isWatchDetected = viewModel.isWatchDetected.value
+    val connectedWatchName = viewModel.connectedWatchName.value
 
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
     ) {
-        if (!isWatchDetected) {
+        if (isWatchDetected) {
+            RoundedCardContainer(
+                modifier = Modifier
+                    .padding(bottom = 18.dp)
+                    .fillMaxWidth(),
+                cornerRadius = 24.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.dp)
+                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(100.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                                shape = CircleShape
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.rounded_watch_24),
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Text(
+                        text = connectedWatchName ?: stringResource(R.string.watch_unknown_name),
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Text(
+                        text = stringResource(R.string.watch_connected_status),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        } else {
             RoundedCardContainer(
                 modifier = Modifier
                     .padding(bottom = 18.dp)

--- a/app/src/main/java/com/sameerasw/essentials/utils/FlashlightUtil.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/FlashlightUtil.kt
@@ -170,4 +170,33 @@ object FlashlightUtil {
         return fadeFlashlight(context, cameraId, currentLevel, targetLevel, durationMs, steps)
     }
 
+    fun getCameraId(context: Context): String? {
+        val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        try {
+            var targetCameraId: String? = null
+            for (id in cameraManager.cameraIdList) {
+                val chars = cameraManager.getCameraCharacteristics(id)
+                val flashAvailable = chars.get(CameraCharacteristics.FLASH_INFO_AVAILABLE) ?: false
+                val lensFacing = chars.get(CameraCharacteristics.LENS_FACING)
+                if (flashAvailable && lensFacing == CameraCharacteristics.LENS_FACING_BACK) {
+                    targetCameraId = id
+                    break
+                }
+            }
+            if (targetCameraId == null) {
+                for (id in cameraManager.cameraIdList) {
+                    val chars = cameraManager.getCameraCharacteristics(id)
+                    if (chars.get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true) {
+                        targetCameraId = id
+                        break
+                    }
+                }
+            }
+            return targetCameraId
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting camera ID", e)
+        }
+        return null
+    }
+
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
@@ -258,4 +258,15 @@ object PermissionUtils {
         } catch (_: Exception) {
         }
     }
+
+    fun openDeviceAdminSettings(context: Context) {
+        try {
+            val intent = Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
+            val adminComponent = ComponentName(context, SecurityDeviceAdminReceiver::class.java)
+            intent.putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, adminComponent)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } catch (e: Exception) {
+        }
+    }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/WatchViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/WatchViewModel.kt
@@ -9,6 +9,7 @@ import com.sameerasw.essentials.data.repository.SettingsRepository
 
 class WatchViewModel : ViewModel() {
     val isWatchDetected = mutableStateOf(false)
+    val connectedWatchName = mutableStateOf<String?>(null)
     val remoteLockMode = mutableStateOf(0) // 0: Screen off, 1: Lock
 
     fun load(repository: SettingsRepository) {
@@ -24,8 +25,10 @@ class WatchViewModel : ViewModel() {
         val nodeClient = Wearable.getNodeClient(context)
         nodeClient.connectedNodes.addOnSuccessListener { nodes ->
             isWatchDetected.value = nodes.isNotEmpty()
+            connectedWatchName.value = nodes.firstOrNull()?.displayName
         }.addOnFailureListener {
             isWatchDetected.value = false
+            connectedWatchName.value = null
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/WatchViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/WatchViewModel.kt
@@ -5,8 +5,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.google.android.gms.wearable.Wearable
 
+import com.sameerasw.essentials.data.repository.SettingsRepository
+
 class WatchViewModel : ViewModel() {
     val isWatchDetected = mutableStateOf(false)
+    val remoteLockMode = mutableStateOf(0) // 0: Screen off, 1: Lock
+
+    fun load(repository: SettingsRepository) {
+        remoteLockMode.value = repository.getInt(SettingsRepository.KEY_REMOTE_LOCK_MODE, 0)
+    }
+
+    fun setRemoteLockMode(mode: Int, repository: SettingsRepository) {
+        remoteLockMode.value = mode
+        repository.putInt(SettingsRepository.KEY_REMOTE_LOCK_MODE, mode)
+    }
 
     fun check(context: Context) {
         val nodeClient = Wearable.getNodeClient(context)

--- a/app/src/main/res/drawable/rounded_lock_24.xml
+++ b/app/src/main/res/drawable/rounded_lock_24.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M240,880Q207,880 183.5,856.5Q160,833 160,800L160,400Q160,367 183.5,343.5Q207,320 240,320L280,320L280,240Q280,157 338.5,98.5Q397,40 480,40Q563,40 621.5,98.5Q680,157 680,240L680,320L720,320Q753,320 776.5,343.5Q800,367 800,400L800,800Q800,833 776.5,856.5Q753,880 720,880L240,880ZM240,800L720,800Q720,800 720,800Q720,800 720,800L720,400Q720,400 720,400Q720,400 720,400L240,400Q240,400 240,400Q240,400 240,400L240,800Q240,800 240,800Q240,800 240,800ZM536.5,656.5Q560,633 560,600Q560,567 536.5,543.5Q513,520 480,520Q447,520 423.5,543.5Q400,567 400,600Q400,633 423.5,656.5Q447,680 480,680Q513,680 536.5,656.5ZM360,320L600,320L600,240Q600,190 565,155Q530,120 480,120Q430,120 395,155Q360,190 360,240L360,320ZM240,800Q240,800 240,800Q240,800 240,800L240,400Q240,400 240,400Q240,400 240,400L240,400Q240,400 240,400Q240,400 240,400L240,800Q240,800 240,800Q240,800 240,800Z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -454,6 +454,8 @@
     <string name="remote_lock_mode_screen_off">Screen off</string>
     <string name="remote_lock_mode_lock">Lock</string>
     <string name="remote_lock_mode_admin_note">Using device admin lock will disable biometrics</string>
+    <string name="watch_connected_status">Connected</string>
+    <string name="watch_unknown_name">Unknown Watch</string>
     <string name="watermark_style_overlay">Overlay</string>
     <string name="watermark_style_frame">Frame</string>
     <string name="watermark_show_brand">Device Brand</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,7 +447,13 @@
     <string name="feat_always_on_display_title">Always on Display</string>
     <string name="feat_always_on_display_desc">Show time and info while screen off</string>
     <string name="feat_calendar_sync_title">Calendar Sync</string>
-    <string name="feat_calendar_sync_desc">Sync events to your watch</string>
+    <string name="feat_calendar_sync_desc">Sync your phone calendar to your watch</string>
+    <string name="feat_lock_from_watch_title">Lock from Watch</string>
+    <string name="feat_lock_from_watch_desc">Lock your phone remotely</string>
+    <string name="remote_lock_mode_title">Lock Mode</string>
+    <string name="remote_lock_mode_screen_off">Screen off</string>
+    <string name="remote_lock_mode_lock">Lock</string>
+    <string name="remote_lock_mode_admin_note">Using device admin lock will disable biometrics</string>
     <string name="watermark_style_overlay">Overlay</string>
     <string name="watermark_style_frame">Frame</string>
     <string name="watermark_show_brand">Device Brand</string>


### PR DESCRIPTION
This pull request introduces major enhancements for integrating smartwatch (Wear OS) features, particularly enabling remote device locking and flashlight control from a connected watch. It adds new services, UI components, and settings to facilitate device info sync, remote lock configuration, and flashlight actions via wearable communication.

Key changes include:

**Wear OS Integration & Device Sync:**

- Added `DeviceInfoSyncManager` to handle periodic and on-demand syncing of device information (battery, ringer mode, flashlight state, etc.) with connected Wear OS devices, including flashlight intensity support and debounced updates. (`DeviceInfoSyncManager.kt`)
- Registered `EssentialsWearableListenerService` in the manifest to listen for messages from Wear OS (e.g., requests to sync device info, toggle flashlight, change sound mode, or lock the device). (`AndroidManifest.xml`, `EssentialsWearableListenerService.kt`) [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR299-R307) [[2]](diffhunk://#diff-919cb922a85c987bb153f26f69397935da767a57f5ce377d29c72835be91da84R1-R62)

**Remote Lock from Watch Feature:**

- Introduced the "Lock from Watch" feature in the registry, allowing users to configure remote locking behavior (screen off or device admin lock) from the watch. (`FeatureRegistry.kt`, `SettingsRepository.kt`, `RemoteLockSettingsUI.kt`) [[1]](diffhunk://#diff-24845de72ed4d362c708778c76734f4c7ebe02be324274ede2d7bfcc2bbfd23dR968-R982) [[2]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R179) [[3]](diffhunk://#diff-fb9ce40453e75c4bd3bd1475a18fe50a9887d9e617e5bd34c192b881dbfdc5eaR1-R113)
- Integrated the remote lock settings UI into the feature settings activity, with permission prompts for accessibility and device admin modes. (`FeatureSettingsActivity.kt`)

**Flashlight Control Improvements:**

- Expanded the flashlight broadcast receiver to support new actions for toggling and setting intensity, and ensured these actions can be triggered via the accessibility service for remote control. (`AndroidManifest.xml`, `ScreenOffAccessibilityService.kt`) [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR692-R693) [[2]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R113-R120) [[3]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R131-R135)

**UI & ViewModel Enhancements:**

- Updated the watch settings UI and view model to support the new features and ensure correct initialization when accessing watch-related settings. (`FeatureSettingsActivity.kt`, `WatchSettingsUI.kt`) [[1]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R362-R365) [[2]](diffhunk://#diff-a266951f24449eaa563fa66d7793c25f017387d1456048fd66231dabc48300ceL4-R13)

These changes collectively provide robust support for smartwatch-driven device management, including secure remote locking and advanced flashlight control.

**References:**  
[[1]](diffhunk://#diff-a036fd4f3d5a75f513ada383787a8ba845ff665c91b414de8f7fa57375bd511aR1-R156) [[2]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR299-R307) [[3]](diffhunk://#diff-919cb922a85c987bb153f26f69397935da767a57f5ce377d29c72835be91da84R1-R62) [[4]](diffhunk://#diff-24845de72ed4d362c708778c76734f4c7ebe02be324274ede2d7bfcc2bbfd23dR968-R982) [[5]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R179) [[6]](diffhunk://#diff-fb9ce40453e75c4bd3bd1475a18fe50a9887d9e617e5bd34c192b881dbfdc5eaR1-R113) [[7]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R617-R625) [[8]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR692-R693) [[9]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R113-R120) [[10]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R131-R135) [[11]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R362-R365) [[12]](diffhunk://#diff-a266951f24449eaa563fa66d7793c25f017387d1456048fd66231dabc48300ceL4-R13)