### PR TITLE
fix: catch SecurityException reading hidden settings in ShutUpShortcut

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/ShutUpShortcutActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ShutUpShortcutActivity.kt
@@ -1,8 +1,10 @@
 package com.sameerasw.essentials
 
+import android.content.ContentResolver
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -139,15 +141,15 @@ class ShutUpShortcutActivity : ComponentActivity() {
                 )
 
                 secureSettings.forEach { key ->
-                    Settings.Secure.getString(contentResolver, key)
+                    safeReadSetting(contentResolver, SettingsTable.SECURE, key)
                         ?.let { originalSettings["secure:$key"] = it }
                 }
                 systemSettings.forEach { key ->
-                    Settings.System.getString(contentResolver, key)
+                    safeReadSetting(contentResolver, SettingsTable.SYSTEM, key)
                         ?.let { originalSettings["system:$key"] = it }
                 }
                 globalSettings.forEach { key ->
-                    Settings.Global.getString(contentResolver, key)
+                    safeReadSetting(contentResolver, SettingsTable.GLOBAL, key)
                         ?.let { originalSettings["global:$key"] = it }
                 }
 
@@ -163,7 +165,8 @@ class ShutUpShortcutActivity : ComponentActivity() {
             // as some apps check this specific setting directly.
             if (config.disableUsbDebugging) {
                 val current =
-                    Settings.Global.getString(contentResolver, Settings.Global.ADB_ENABLED) ?: "0"
+                    safeReadSetting(contentResolver, SettingsTable.GLOBAL, Settings.Global.ADB_ENABLED)
+                        ?: "0"
                 if (current == "1") {
                     if (!originalSettings.containsKey("global:${Settings.Global.ADB_ENABLED}")) {
                         originalSettings["global:${Settings.Global.ADB_ENABLED}"] = "1"
@@ -173,7 +176,8 @@ class ShutUpShortcutActivity : ComponentActivity() {
             }
 
             if (config.disableWirelessDebugging) {
-                val current = Settings.Global.getString(contentResolver, "adb_wifi_enabled") ?: "0"
+                val current =
+                    safeReadSetting(contentResolver, SettingsTable.GLOBAL, "adb_wifi_enabled") ?: "0"
                 if (current == "1") {
                     if (!originalSettings.containsKey("global:adb_wifi_enabled")) {
                         originalSettings["global:adb_wifi_enabled"] = "1"
@@ -183,8 +187,9 @@ class ShutUpShortcutActivity : ComponentActivity() {
             }
 
             if (config.disableAccessibility) {
-                val current = Settings.Secure.getString(
+                val current = safeReadSetting(
                     contentResolver,
+                    SettingsTable.SECURE,
                     Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
                 )
                 if (!current.isNullOrEmpty()) {
@@ -202,6 +207,28 @@ class ShutUpShortcutActivity : ComponentActivity() {
                 repository.saveShutUpOriginalSettings(originalSettings)
             }
         }
+    }
+
+    private enum class SettingsTable { SYSTEM, SECURE, GLOBAL }
+
+    // Android 12+ throws SecurityException reading @hide settings that aren't
+    // @Readable (e.g. show_key_presses). WRITE_SECURE_SETTINGS doesn't cover reads.
+    private fun safeReadSetting(
+        resolver: ContentResolver,
+        table: SettingsTable,
+        key: String
+    ): String? = try {
+        when (table) {
+            SettingsTable.SYSTEM -> Settings.System.getString(resolver, key)
+            SettingsTable.SECURE -> Settings.Secure.getString(resolver, key)
+            SettingsTable.GLOBAL -> Settings.Global.getString(resolver, key)
+        }
+    } catch (e: SecurityException) {
+        Log.w("ShutUpShortcut", "Skipping unreadable setting $table:$key", e)
+        null
+    } catch (e: Exception) {
+        Log.w("ShutUpShortcut", "Failed to read setting $table:$key", e)
+        null
     }
 
     private fun launchApp(packageName: String) {

--- a/app/src/main/java/com/sameerasw/essentials/ShutUpShortcutActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ShutUpShortcutActivity.kt
@@ -226,9 +226,6 @@ class ShutUpShortcutActivity : ComponentActivity() {
     } catch (e: SecurityException) {
         Log.w("ShutUpShortcut", "Skipping unreadable setting $table:$key", e)
         null
-    } catch (e: Exception) {
-        Log.w("ShutUpShortcut", "Failed to read setting $table:$key", e)
-        null
     }
 
     private fun launchApp(packageName: String) {


### PR DESCRIPTION
## Summary

Fixes the `SecurityException: Settings key: <show_key_presses> is not readable` crash on Android 12+ when launching a Shut Up shortcut. Reported in #443 on Pixel 7, Pixel 10 Pro, and a Samsung device, all running Android 16.

## Root cause

`ShutUpShortcutActivity.applyShutUpSettings()` reads a list of dev-options keys via `Settings.{System,Secure,Global}.getString()` to back them up before flipping `DEVELOPMENT_SETTINGS_ENABLED` off.

Since Android 12 (API 31), reading any `@hide` settings key that isn't annotated `@Readable` throws `SecurityException`:

> Settings key: <show_key_presses> is not readable. From S+, settings keys annotated with @hide are restricted to system_server and system apps only, unless they are annotated with @Readable.

`WRITE_SECURE_SETTINGS` (granted via Shizuku) covers writes, not reads, so the Shizuku permission doesn't help. `show_key_presses` happens to be one of those non-`@Readable` hidden keys, and which keys get the annotation varies by OEM/build. That's why the crash reproduces on some Android 16 devices but not the maintainer's.

Other keys in the same backup lists would crash the same way: `anr_show_background`, `secure_overlay_settings`, `mock_location`, `display_density_forced`, `disable_window_blurs`, `force_desktop_mode_on_external_displays`, and others.

## Fix

Route every `Settings.*.getString` read in `ShutUpShortcutActivity` through a `safeReadSetting()` helper that catches `SecurityException` and returns `null`. The existing `?.let { … }` callers then skip unreadable keys. `DEVELOPMENT_SETTINGS_ENABLED` still gets flipped off, `launchApp(packageName)` still runs, and behavior is unchanged for any key that *is* readable.

Skipping the backup is harmless in practice: flipping `DEVELOPMENT_SETTINGS_ENABLED` already resets the dev toggles, and those keys are system-managed defaults that couldn't have been restored anyway.

`AppFlowHandler.restoreShutUpSettings()` already wraps each iteration in `try/catch`, so the restore path was never affected.

## Test plan

- [x] Builds cleanly with AGP 9.2.1 / JDK 21 (`./gradlew :app:assembleDebug`).
- [x] Tested on Pixel 7 (Android 16): the Shut Up shortcut now launches the target app instead of crashing.

Closes #443