### PR TITLE
Develop - Shut up bug fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.sameerasw.essentials"
         minSdk = 26
         targetSdk = 37
-        versionCode = 47
-        versionName = "15.3"
+        versionCode = 48
+        versionName = "15.4"
 
         val whatsNewCounter = 2
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AppFlowHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AppFlowHandler.kt
@@ -76,6 +76,7 @@ class AppFlowHandler(
     private var lastLockRequestTime: Long = 0
     var currentPackage: String? = null
         private set
+    private var currentUsageStatsPackage: String? = null
 
     // App Automation State
     private val activeAppAutomationIds = mutableSetOf<String>()
@@ -96,25 +97,28 @@ class AppFlowHandler(
         val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
         val useUsageAccess = prefs.getBoolean("use_usage_access", false)
 
+        if (isFromUsageStats) {
+            val oldUsagePackage = currentUsageStatsPackage
+            currentUsageStatsPackage = packageName
+            if (oldUsagePackage != null && oldUsagePackage != packageName) {
+                checkShutUpRestore(oldUsagePackage, packageName)
+            }
+        }
+
         val oldPackage = currentPackage
-        currentPackage = packageName
-
-        if (oldPackage != null && oldPackage != packageName) {
-            lastLeaveTimes[oldPackage] = System.currentTimeMillis()
-        }
-
-        if (packageName != context.packageName && packageName != lockingPackage) {
-            lockingPackage = null
-        }
-
         if (isFromUsageStats == useUsageAccess) {
+            currentPackage = packageName
+            if (oldPackage != null && oldPackage != packageName) {
+                lastLeaveTimes[oldPackage] = System.currentTimeMillis()
+            }
+            if (packageName != context.packageName && packageName != lockingPackage) {
+                lockingPackage = null
+            }
             checkAppLock(packageName)
             checkHighlightNightLight(packageName)
             checkAppAutomations(packageName)
             checkGestureBarAutomation(packageName)
-            checkShutUpRestore(oldPackage, packageName)
         }
-
     }
 
     fun onAuthenticated(packageName: String) {

--- a/app/src/main/java/com/sameerasw/essentials/utils/ServiceUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/ServiceUtils.kt
@@ -39,7 +39,7 @@ object ServiceUtils {
         val hasShutUpApps = shutUpConfigs.any { it.isEnabled }
 
         val shouldRun =
-            isUseUsageAccess && (isAppLockEnabled || isDynamicNightLightEnabled || isHideGestureBarOnLauncherEnabled || hasAppAutomations || hasShutUpApps)
+            (isUseUsageAccess && (isAppLockEnabled || isDynamicNightLightEnabled || isHideGestureBarOnLauncherEnabled || hasAppAutomations)) || hasShutUpApps
 
         val intent = Intent(context, AppDetectionService::class.java)
         if (shouldRun) {


### PR DESCRIPTION
This pull request introduces a new version of the app (15.4) and includes improvements to app flow handling, particularly around usage stats and the "Shut Up" feature. The most significant changes involve better management of app package transitions, especially when using usage access, and a tweak to service startup logic.

**App flow and usage stats handling:**

* Added a new `currentUsageStatsPackage` property to `AppFlowHandler` to separately track the package detected via usage stats. This allows for more accurate handling of app transitions when usage access is enabled.
* Modified the logic in `AppFlowHandler.handleAppChanged` to ensure that `checkShutUpRestore` is called correctly when the package detected by usage stats changes, and to update `currentPackage` only when appropriate. This improves the reliability of app state transitions and feature triggers.

**Service startup logic:**

* Updated the `ServiceUtils.shouldRun` logic so that the "Shut Up" feature can trigger the service independently of the usage access setting, ensuring it works even if usage access is not enabled.

**Version update:**

* Bumped `versionCode` to 48 and `versionName` to "15.4" in `build.gradle.kts` to reflect the new release.