### PR TITLE
Intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,10 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" android:protectionLevel="signature" />
     <uses-permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" />
+    <permission android:name="com.sameerasw.essentials.permission.EXTERNAL_CONTROL"
+        android:protectionLevel="dangerous"
+        android:label="@string/perm_external_control_label"
+        android:description="@string/perm_external_control_desc" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
 
@@ -908,6 +912,21 @@
                 android:name="android.service.quicksettings.TILE_CATEGORY"
                 android:value="android.service.quicksettings.CATEGORY_DISPLAY" />
         </service>
+
+        <provider
+            android:name=".external.ExternalControlProvider"
+            android:authorities="${applicationId}.external"
+            android:exported="true"
+            android:permission="com.sameerasw.essentials.permission.EXTERNAL_CONTROL" />
+
+        <receiver
+            android:name=".external.ExternalActionReceiver"
+            android:exported="true"
+            android:permission="com.sameerasw.essentials.permission.EXTERNAL_CONTROL">
+            <intent-filter>
+                <action android:name="com.sameerasw.essentials.action.EXTERNAL_CONTROL" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,10 +36,19 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" android:protectionLevel="signature" />
     <uses-permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" />
+    
+    <permission-group
+        android:name="com.sameerasw.essentials.permission-group.EXTERNAL_CONTROL"
+        android:label="@string/perm_external_control_label"
+        android:description="@string/perm_external_control_desc"
+        android:icon="@drawable/app_logo" />
+
     <permission android:name="com.sameerasw.essentials.permission.EXTERNAL_CONTROL"
+        android:permissionGroup="com.sameerasw.essentials.permission-group.EXTERNAL_CONTROL"
         android:protectionLevel="dangerous"
         android:label="@string/perm_external_control_label"
-        android:description="@string/perm_external_control_desc" />
+        android:description="@string/perm_external_control_desc"
+        android:icon="@drawable/app_logo" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
 

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalActionReceiver.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalActionReceiver.kt
@@ -1,0 +1,31 @@
+package com.sameerasw.essentials.external
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class ExternalActionReceiver : BroadcastReceiver() {
+    companion object {
+        const val ACTION_EXTERNAL_CONTROL = "com.sameerasw.essentials.action.EXTERNAL_CONTROL"
+        const val EXTRA_PATH = "path"
+        const val EXTRA_ACTION = "action"
+        const val EXTRA_VALUE = "value"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_EXTERNAL_CONTROL) return
+
+        val path = intent.getStringExtra(EXTRA_PATH) ?: return
+        val action = intent.getStringExtra(EXTRA_ACTION)
+        val value = intent.getStringExtra(EXTRA_VALUE)
+
+        Log.d("ExternalActionReceiver", "Received external control request: path=$path, action=$action, value=$value")
+
+        if (action == "update") {
+            ExternalRouter.update(context, path, value, intent.extras)
+        } else if (action != null) {
+            ExternalRouter.action(context, path, action, intent.extras)
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalControlProvider.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalControlProvider.kt
@@ -1,0 +1,70 @@
+package com.sameerasw.essentials.external
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.Bundle
+
+class ExternalControlProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        return true
+    }
+
+    @Suppress("DEPRECATION")
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? {
+        val context = context ?: return null
+        val path = uri.path ?: return null
+        val result = ExternalRouter.query(context, path, null) ?: return null
+
+        val cursor = MatrixCursor(arrayOf("key", "value", "type"))
+        val key = path.substringAfterLast('/')
+        val value = result.get("value")
+        val type = result.getString("type", "")
+        cursor.addRow(arrayOf(key, value, type))
+        return cursor
+    }
+
+    override fun getType(uri: Uri): String? {
+        return "vnd.android.cursor.item/vnd.com.sameerasw.essentials.external"
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? {
+        return null
+    }
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int {
+        return 0
+    }
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int {
+        val context = context ?: return 0
+        val path = uri.path ?: return 0
+        val value = values?.getAsString("value") ?: return 0
+        val success = ExternalRouter.update(context, path, value, null)
+        return if (success) 1 else 0
+    }
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        val context = context ?: return null
+        if (method == "action") {
+            val path = arg ?: return null
+            val action = extras?.getString("action")
+            return ExternalRouter.action(context, path, action, extras)
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalControlProvider.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalControlProvider.kt
@@ -13,7 +13,6 @@ class ExternalControlProvider : ContentProvider() {
         return true
     }
 
-    @Suppress("DEPRECATION")
     override fun query(
         uri: Uri,
         projection: Array<out String>?,
@@ -23,14 +22,7 @@ class ExternalControlProvider : ContentProvider() {
     ): Cursor? {
         val context = context ?: return null
         val path = uri.path ?: return null
-        val result = ExternalRouter.query(context, path, null) ?: return null
-
-        val cursor = MatrixCursor(arrayOf("key", "value", "type"))
-        val key = path.substringAfterLast('/')
-        val value = result.get("value")
-        val type = result.getString("type", "")
-        cursor.addRow(arrayOf(key, value, type))
-        return cursor
+        return ExternalRouter.query(context, path, null)
     }
 
     override fun getType(uri: Uri): String? {

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalHandler.kt
@@ -1,0 +1,12 @@
+package com.sameerasw.essentials.external
+
+import android.content.Context
+import android.os.Bundle
+
+interface ExternalHandler {
+    val path: String
+
+    fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Bundle?
+    fun onUpdate(context: Context, remainingPath: String, value: String?, extras: Bundle?): Boolean
+    fun onAction(context: Context, remainingPath: String, action: String?, extras: Bundle?): Bundle?
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalHandler.kt
@@ -1,12 +1,13 @@
 package com.sameerasw.essentials.external
 
 import android.content.Context
+import android.database.Cursor
 import android.os.Bundle
 
 interface ExternalHandler {
     val path: String
 
-    fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Bundle?
+    fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Cursor?
     fun onUpdate(context: Context, remainingPath: String, value: String?, extras: Bundle?): Boolean
     fun onAction(context: Context, remainingPath: String, action: String?, extras: Bundle?): Bundle?
 }

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalRouter.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalRouter.kt
@@ -1,0 +1,44 @@
+package com.sameerasw.essentials.external
+
+import android.content.Context
+import android.os.Bundle
+
+object ExternalRouter {
+    private val handlers = mutableMapOf<String, ExternalHandler>()
+
+    init {
+        registerHandler(SettingsExternalHandler())
+    }
+
+    fun registerHandler(handler: ExternalHandler) {
+        handlers[handler.path] = handler
+    }
+
+    private fun getHandlerAndRemainingPath(fullPath: String): Pair<ExternalHandler, String>? {
+        val cleanPath = fullPath.trim('/')
+        for ((registeredPath, handler) in handlers) {
+            if (cleanPath == registeredPath) {
+                return Pair(handler, "")
+            } else if (cleanPath.startsWith("$registeredPath/")) {
+                val remaining = cleanPath.substring(registeredPath.length + 1)
+                return Pair(handler, remaining)
+            }
+        }
+        return null
+    }
+
+    fun query(context: Context, path: String, extras: Bundle?): Bundle? {
+        val (handler, remaining) = getHandlerAndRemainingPath(path) ?: return null
+        return handler.onQuery(context, remaining, extras)
+    }
+
+    fun update(context: Context, path: String, value: String?, extras: Bundle?): Boolean {
+        val (handler, remaining) = getHandlerAndRemainingPath(path) ?: return false
+        return handler.onUpdate(context, remaining, value, extras)
+    }
+
+    fun action(context: Context, path: String, action: String?, extras: Bundle?): Bundle? {
+        val (handler, remaining) = getHandlerAndRemainingPath(path) ?: return null
+        return handler.onAction(context, remaining, action, extras)
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/ExternalRouter.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/ExternalRouter.kt
@@ -1,6 +1,7 @@
 package com.sameerasw.essentials.external
 
 import android.content.Context
+import android.database.Cursor
 import android.os.Bundle
 
 object ExternalRouter {
@@ -8,6 +9,7 @@ object ExternalRouter {
 
     init {
         registerHandler(SettingsExternalHandler())
+        registerHandler(LocationAlarmExternalHandler())
     }
 
     fun registerHandler(handler: ExternalHandler) {
@@ -27,7 +29,7 @@ object ExternalRouter {
         return null
     }
 
-    fun query(context: Context, path: String, extras: Bundle?): Bundle? {
+    fun query(context: Context, path: String, extras: Bundle?): Cursor? {
         val (handler, remaining) = getHandlerAndRemainingPath(path) ?: return null
         return handler.onQuery(context, remaining, extras)
     }

--- a/app/src/main/java/com/sameerasw/essentials/external/LocationAlarmExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/LocationAlarmExternalHandler.kt
@@ -1,0 +1,73 @@
+package com.sameerasw.essentials.external
+
+import android.content.Context
+import android.content.Intent
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.Bundle
+import com.sameerasw.essentials.data.repository.LocationReachedRepository
+import com.sameerasw.essentials.services.LocationReachedService
+
+class LocationAlarmExternalHandler : ExternalHandler {
+    override val path: String = "location_alarm"
+
+    override fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Cursor? {
+        val repository = LocationReachedRepository(context)
+        if (remainingPath == "list") {
+            val alarms = repository.getAlarms()
+            val activeId = repository.getActiveAlarmId()
+
+            val cursor = MatrixCursor(arrayOf(
+                "id",
+                "name",
+                "latitude",
+                "longitude",
+                "radius",
+                "isEnabled",
+                "isPaused",
+                "lastTravelled",
+                "isActive"
+            ))
+
+            for (alarm in alarms) {
+                cursor.addRow(arrayOf<Any?>(
+                    alarm.id,
+                    alarm.name,
+                    alarm.latitude,
+                    alarm.longitude,
+                    alarm.radius,
+                    if (alarm.isEnabled) 1 else 0,
+                    if (alarm.isPaused) 1 else 0,
+                    alarm.lastTravelled ?: 0L,
+                    if (alarm.id == activeId) 1 else 0
+                ))
+            }
+            return cursor
+        }
+        return null
+    }
+
+    override fun onUpdate(context: Context, remainingPath: String, value: String?, extras: Bundle?): Boolean {
+        return false
+    }
+
+    override fun onAction(context: Context, remainingPath: String, action: String?, extras: Bundle?): Bundle? {
+        val repository = LocationReachedRepository(context)
+        when (action) {
+            "start" -> {
+                val alarmId = extras?.getString("id") ?: return null
+                repository.saveActiveAlarmId(alarmId)
+                LocationReachedService.start(context)
+                return Bundle().apply { putBoolean("success", true) }
+            }
+            "stop" -> {
+                val intent = Intent(context, LocationReachedService::class.java).apply {
+                    this.action = LocationReachedService.ACTION_STOP
+                }
+                context.startService(intent)
+                return Bundle().apply { putBoolean("success", true) }
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/LocationAlarmExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/LocationAlarmExternalHandler.kt
@@ -26,7 +26,8 @@ class LocationAlarmExternalHandler : ExternalHandler {
                 "isEnabled",
                 "isPaused",
                 "lastTravelled",
-                "isActive"
+                "isActive",
+                "iconResName"
             ))
 
             for (alarm in alarms) {
@@ -39,7 +40,8 @@ class LocationAlarmExternalHandler : ExternalHandler {
                     if (alarm.isEnabled) 1 else 0,
                     if (alarm.isPaused) 1 else 0,
                     alarm.lastTravelled ?: 0L,
-                    if (alarm.id == activeId) 1 else 0
+                    if (alarm.id == activeId) 1 else 0,
+                    alarm.iconResName
                 ))
             }
             return cursor
@@ -53,7 +55,8 @@ class LocationAlarmExternalHandler : ExternalHandler {
 
     override fun onAction(context: Context, remainingPath: String, action: String?, extras: Bundle?): Bundle? {
         val repository = LocationReachedRepository(context)
-        when (action) {
+        val targetAction = action ?: remainingPath
+        when (targetAction) {
             "start" -> {
                 val alarmId = extras?.getString("id") ?: return null
                 repository.saveActiveAlarmId(alarmId)
@@ -61,6 +64,7 @@ class LocationAlarmExternalHandler : ExternalHandler {
                 return Bundle().apply { putBoolean("success", true) }
             }
             "stop" -> {
+                repository.saveActiveAlarmId(null)
                 val intent = Intent(context, LocationReachedService::class.java).apply {
                     this.action = LocationReachedService.ACTION_STOP
                 }

--- a/app/src/main/java/com/sameerasw/essentials/external/SettingsExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/SettingsExternalHandler.kt
@@ -1,0 +1,66 @@
+package com.sameerasw.essentials.external
+
+import android.content.Context
+import android.os.Bundle
+import com.sameerasw.essentials.data.repository.SettingsRepository
+
+class SettingsExternalHandler : ExternalHandler {
+    override val path: String = "settings"
+
+    override fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Bundle? {
+        val key = remainingPath
+        val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
+        if (!prefs.contains(key)) return null
+
+        val value = prefs.all[key] ?: return null
+        val bundle = Bundle()
+        when (value) {
+            is Boolean -> bundle.putBoolean("value", value)
+            is String -> bundle.putString("value", value)
+            is Int -> bundle.putInt("value", value)
+            is Float -> bundle.putFloat("value", value)
+            is Long -> bundle.putLong("value", value)
+            else -> bundle.putString("value", value.toString())
+        }
+        bundle.putString("type", value.javaClass.simpleName)
+        return bundle
+    }
+
+    override fun onUpdate(context: Context, remainingPath: String, value: String?, extras: Bundle?): Boolean {
+        val key = remainingPath
+        val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
+        if (!prefs.contains(key)) return false
+
+        val currentValue = prefs.all[key] ?: return false
+        val repository = SettingsRepository(context)
+
+        return try {
+            when (currentValue) {
+                is Boolean -> repository.putBoolean(key, value?.toBoolean() ?: false)
+                is String -> repository.putString(key, value)
+                is Int -> repository.putInt(key, value?.toInt() ?: 0)
+                is Float -> repository.putFloat(key, value?.toFloat() ?: 0f)
+                is Long -> repository.putLong(key, value?.toLong() ?: 0L)
+                else -> false
+            }
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    override fun onAction(context: Context, remainingPath: String, action: String?, extras: Bundle?): Bundle? {
+        if (action == "toggle") {
+            val key = remainingPath
+            val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
+            val currentValue = prefs.all[key]
+            if (currentValue is Boolean) {
+                val repository = SettingsRepository(context)
+                val newValue = !currentValue
+                repository.putBoolean(key, newValue)
+                return Bundle().apply { putBoolean("value", newValue) }
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/external/SettingsExternalHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/external/SettingsExternalHandler.kt
@@ -1,29 +1,23 @@
 package com.sameerasw.essentials.external
 
 import android.content.Context
+import android.database.Cursor
+import android.database.MatrixCursor
 import android.os.Bundle
 import com.sameerasw.essentials.data.repository.SettingsRepository
 
 class SettingsExternalHandler : ExternalHandler {
     override val path: String = "settings"
 
-    override fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Bundle? {
+    override fun onQuery(context: Context, remainingPath: String, extras: Bundle?): Cursor? {
         val key = remainingPath
         val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
         if (!prefs.contains(key)) return null
 
         val value = prefs.all[key] ?: return null
-        val bundle = Bundle()
-        when (value) {
-            is Boolean -> bundle.putBoolean("value", value)
-            is String -> bundle.putString("value", value)
-            is Int -> bundle.putInt("value", value)
-            is Float -> bundle.putFloat("value", value)
-            is Long -> bundle.putLong("value", value)
-            else -> bundle.putString("value", value.toString())
-        }
-        bundle.putString("type", value.javaClass.simpleName)
-        return bundle
+        val cursor = MatrixCursor(arrayOf("key", "value", "type"))
+        cursor.addRow(arrayOf(key, value, value.javaClass.simpleName))
+        return cursor
     }
 
     override fun onUpdate(context: Context, remainingPath: String, value: String?, extras: Bundle?): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1556,4 +1556,7 @@
     <string name="favorites_widget_name">Favorite Features</string>
     <string name="favorites_widget_description">View and launch your favorite features at a glance.</string>
     <string name="favorites_widget_empty_state">No favorite features pinned yet. Open the app to pin some!</string>
+    <!-- External Control Permission -->
+    <string name="perm_external_control_label">Control Essentials features</string>
+    <string name="perm_external_control_desc">Allows the app to read, update and control Essentials features and settings.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1557,6 +1557,6 @@
     <string name="favorites_widget_description">View and launch your favorite features at a glance.</string>
     <string name="favorites_widget_empty_state">No favorite features pinned yet. Open the app to pin some!</string>
     <!-- External Control Permission -->
-    <string name="perm_external_control_label">Control Essentials features</string>
-    <string name="perm_external_control_desc">Allows the app to read, update and control Essentials features and settings.</string>
+    <string name="perm_external_control_label">control Essentials features</string>
+    <string name="perm_external_control_desc">read, update and control Essentials features and settings</string>
 </resources>


### PR DESCRIPTION
This pull request introduces a new external control API, allowing other apps or services to query, update, and trigger actions on Essentials features and settings through a permission-protected interface. It defines a new dangerous permission, adds a content provider and broadcast receiver, and implements a modular routing system for handling external requests. The initial handlers support querying/updating app settings and controlling location alarms.

**External Control API infrastructure:**

* Added a new dangerous permission (`com.sameerasw.essentials.permission.EXTERNAL_CONTROL`) and a permission group to the manifest, with appropriate user-facing labels and descriptions. [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR39-R51) [[2]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R1559-R1561)
* Declared a new `ExternalControlProvider` (content provider) and `ExternalActionReceiver` (broadcast receiver) in the manifest, both protected by the new permission.
* Implemented `ExternalControlProvider` to handle external queries, updates, and actions via the content provider interface, delegating to a routing system.
* Implemented `ExternalActionReceiver` to handle external broadcast actions, also delegating to the routing system.

**Routing and handler design:**

* Introduced the `ExternalHandler` interface and `ExternalRouter` singleton to register and route requests to feature-specific handlers based on path. [[1]](diffhunk://#diff-dde93789540eed5d8e4a928bfdfbfbbc8c0c012340609d7e9d54a0d9551c77b1R1-R13) [[2]](diffhunk://#diff-a7181f1aa9dee35f3c7bf838d908d3625691087faacd15dd91c87c7b022c77f8R1-R46)

**Feature-specific external handlers:**

* Added `SettingsExternalHandler` to allow querying, updating, and toggling of app settings externally.
* Added `LocationAlarmExternalHandler` to support querying alarms and starting/stopping location alarm features externally.