### PR TITLE
Develop - Ultra HDR watermark, Pixel searchbar replacement, shizuku and permission improvements, A lot of new wearOS features, swipe tabs are back, and a lot more fixes 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.sameerasw.essentials"
         minSdk = 26
         targetSdk = 37
-        versionCode = 48
-        versionName = "15.4"
+        versionCode = 49
+        versionName = "15.5"
 
         val whatsNewCounter = 2
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,27 @@
         </activity>
 
         <activity
+            android:name=".PixelSearchActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:excludeFromRecents="true"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.WEB_SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".ui.activities.PixelSearchbarSettingsActivity"
+            android:exported="true"
+            android:label="@string/pixel_searchbar_settings_title" />
+
+        <activity
             android:name=".FeatureSettingsActivity"
             android:exported="false"
             android:label="Feature Settings"
@@ -369,6 +390,19 @@
                 <data android:scheme="wear" android:host="*" android:pathPrefix="/" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".services.widgets.PixelSearchbarWidgetReceiver"
+            android:label="@string/feat_pixel_searchbar_title"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="android.intent.action.CONFIGURATION_CHANGED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/pixel_searchbar_widget_info" />
+        </receiver>
 
         <receiver
             android:name=".services.ScreenOffWidgetProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -215,6 +215,16 @@
             android:excludeFromRecents="true"
             android:taskAffinity="com.sameerasw.essentials.action" />
 
+        <activity
+            android:name=".ui.activities.PixelSearchbarTapActivity"
+            android:exported="true"
+            android:icon="@drawable/rounded_search_24"
+            android:label="@string/feat_pixel_searchbar_title"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:launchMode="singleTask"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.sameerasw.essentials.pixelsearchbar" />
+
         <activity-alias
             android:name=".ActionShortcutLauncher"
             android:targetActivity=".ui.activities.ActionShortcutActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -931,6 +931,14 @@
         </receiver>
 
         <receiver
+            android:name=".services.receivers.ShizukuActionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.sameerasw.essentials.ACTION_RESTART_SHIZUKU" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".services.automation.receivers.TimeAutomationReceiver"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -797,6 +797,7 @@
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
             </intent-filter>
             <meta-data android:name="android.service.quicksettings.TILE_CATEGORY"
                 android:value="android.service.quicksettings.CATEGORY_UTILITIES" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
 
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" tools:ignore="UnusedAttribute" />
+    <uses-permission android:name="android.permission.BIND_APPWIDGET" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" android:protectionLevel="signature" />
     <uses-permission android:name="com.sameerasw.permission.ESSENTIALS_AIRSYNC_BRIDGE" />
@@ -413,6 +414,16 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/pixel_searchbar_widget_info" />
         </receiver>
+
+        <service
+            android:name=".services.widgets.WidgetScraperService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse"
+            android:permission="android.permission.BIND_APPWIDGET">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="widgetScraper" />
+        </service>
 
         <receiver
             android:name=".services.ScreenOffWidgetProvider"

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -83,6 +83,7 @@ import com.sameerasw.essentials.ui.composables.configs.SoundModeTileSettingsUI
 import com.sameerasw.essentials.ui.composables.configs.StatusBarIconSettingsUI
 import com.sameerasw.essentials.ui.composables.configs.TextAnimationsSettingsUI
 import com.sameerasw.essentials.ui.composables.configs.WatchSettingsUI
+import com.sameerasw.essentials.ui.composables.configs.WatchControlsSettingsUI
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
@@ -411,7 +412,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                             )
                     ) {
                         val hasScroll =
-                            featureId != "Sound mode tile" && featureId != "Quick settings tiles" && featureId != "Location reached"
+                            featureId != "Sound mode tile" && featureId != "Quick settings tiles" && featureId != "Location reached" && featureId != "Watch Controls"
                         Column(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -708,6 +709,13 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                             viewModel = viewModel,
                                             modifier = Modifier.padding(top = 16.dp),
                                             highlightKey = highlightSetting
+                                        )
+                                    }
+
+                                    "Watch Controls" -> {
+                                        WatchControlsSettingsUI(
+                                            modifier = Modifier.padding(top = 16.dp),
+                                            highlightSetting = highlightSetting
                                         )
                                     }
 

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -218,6 +218,21 @@ class FeatureSettingsActivity : AppCompatActivity() {
                     val isReadPhoneStateEnabled by viewModel.isReadPhoneStateEnabled
                     val isShizukuPermissionGranted by viewModel.isShizukuPermissionGranted
 
+                    var watchAdbWifiEnabled by remember {
+                        mutableStateOf(prefs.getBoolean("watch_adb_wifi_enabled", false))
+                    }
+                    androidx.compose.runtime.DisposableEffect(prefs) {
+                        val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { p, key ->
+                            if (key == "watch_adb_wifi_enabled") {
+                                watchAdbWifiEnabled = p.getBoolean(key, false)
+                            }
+                        }
+                        prefs.registerOnSharedPreferenceChangeListener(listener)
+                        onDispose {
+                            prefs.unregisterOnSharedPreferenceChangeListener(listener)
+                        }
+                    }
+
                     // FAB State for Notification Lighting
                     var fabExpanded by remember { mutableStateOf(true) }
                     LaunchedEffect(featureId) {
@@ -522,7 +537,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                             title = child.title,
                                             description = child.description,
                                             iconRes = child.iconRes,
-                                            isEnabled = child.isEnabled(viewModel),
+                                            isEnabled = if (child.id == "Watch Wireless Debugging") watchAdbWifiEnabled else child.isEnabled(viewModel),
                                             isToggleEnabled = child.isToggleEnabled(
                                                 viewModel,
                                                 context

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -221,10 +221,15 @@ class FeatureSettingsActivity : AppCompatActivity() {
                     var watchAdbWifiEnabled by remember {
                         mutableStateOf(prefs.getBoolean("watch_adb_wifi_enabled", false))
                     }
+                    var watchSyncSoundModeEnabled by remember {
+                        mutableStateOf(prefs.getBoolean("watch_sync_sound_mode_enabled", false))
+                    }
                     androidx.compose.runtime.DisposableEffect(prefs) {
                         val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { p, key ->
                             if (key == "watch_adb_wifi_enabled") {
                                 watchAdbWifiEnabled = p.getBoolean(key, false)
+                            } else if (key == "watch_sync_sound_mode_enabled") {
+                                watchSyncSoundModeEnabled = p.getBoolean(key, false)
                             }
                         }
                         prefs.registerOnSharedPreferenceChangeListener(listener)
@@ -537,7 +542,11 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                             title = child.title,
                                             description = child.description,
                                             iconRes = child.iconRes,
-                                            isEnabled = if (child.id == "Watch Wireless Debugging") watchAdbWifiEnabled else child.isEnabled(viewModel),
+                                            isEnabled = when (child.id) {
+                                                "Watch Wireless Debugging" -> watchAdbWifiEnabled
+                                                "Sync sound mode" -> watchSyncSoundModeEnabled
+                                                else -> child.isEnabled(viewModel)
+                                            },
                                             isToggleEnabled = child.isToggleEnabled(
                                                 viewModel,
                                                 context

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -86,6 +86,7 @@ import com.sameerasw.essentials.ui.composables.configs.WatchSettingsUI
 import com.sameerasw.essentials.ui.composables.configs.WatchControlsSettingsUI
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
+import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.BiometricSecurityHelper
 import com.sameerasw.essentials.utils.HapticUtil
@@ -548,6 +549,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                         }
 
                                         FeatureCard(
+                                            modifier = Modifier.highlight(highlightSetting == child.id),
                                             title = child.title,
                                             description = child.description,
                                             iconRes = child.iconRes,

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -246,6 +246,15 @@ class FeatureSettingsActivity : AppCompatActivity() {
                             delay(3000)
                             fabExpanded = false
                         }
+                        if (featureId == "Watch") {
+                            val messageClient = com.google.android.gms.wearable.Wearable.getMessageClient(context)
+                            val nodeClient = com.google.android.gms.wearable.Wearable.getNodeClient(context)
+                            nodeClient.connectedNodes.addOnSuccessListener { nodes ->
+                                for (node in nodes) {
+                                    messageClient.sendMessage(node.id, "/request_watch_status", byteArrayOf())
+                                }
+                            }
+                        }
                     }
 
                     // Help Sheet State

--- a/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
@@ -24,6 +24,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -261,11 +263,10 @@ class MainActivity : AppCompatActivity() {
                         val index = tabs.indexOf(defaultTab)
                         if (index != -1) index else 0
                     }
-                    var currentPage by remember {
-                        androidx.compose.runtime.mutableIntStateOf(
-                            initialPage
-                        )
-                    }
+                    val pagerState = rememberPagerState(
+                        initialPage = initialPage,
+                        pageCount = { tabs.size }
+                    )
 
                     LaunchedEffect(intent) {
                         intent?.getStringExtra("target_tab")?.let { tabName ->
@@ -273,7 +274,7 @@ class MainActivity : AppCompatActivity() {
                                 val tab = DIYTabs.valueOf(tabName)
                                 val index = tabs.indexOf(tab)
                                 if (index != -1) {
-                                    currentPage = index
+                                    pagerState.scrollToPage(index)
                                     intent.removeExtra("target_tab")
                                 }
                             } catch (e: Exception) {
@@ -285,12 +286,14 @@ class MainActivity : AppCompatActivity() {
                     val scope = rememberCoroutineScope()
 
                     // Handle predictive back button for tab navigation
-                    PredictiveBackHandler(enabled = currentPage != initialPage) { progress ->
+                    PredictiveBackHandler(enabled = pagerState.currentPage != initialPage) { progress ->
                         try {
                             progress.collect { backEvent ->
                                 backProgress.snapTo(backEvent.progress)
                             }
-                            currentPage = initialPage
+                            scope.launch {
+                                pagerState.animateScrollToPage(initialPage)
+                            }
                             scope.launch {
                                 backProgress.animateTo(
                                     targetValue = 0f,
@@ -309,8 +312,8 @@ class MainActivity : AppCompatActivity() {
 
                     // Gracefully handle tab removal (e.g. disabling Developer Mode)
                     LaunchedEffect(tabs) {
-                        if (currentPage >= tabs.size) {
-                            currentPage = 0
+                        if (pagerState.currentPage >= tabs.size) {
+                            pagerState.scrollToPage(0)
                         }
                     }
                     val exitAlwaysScrollBehavior =
@@ -460,8 +463,8 @@ class MainActivity : AppCompatActivity() {
                                         direction = BlurDirection.TOP
                                     )
                             ) {
-                                val currentTab = remember(tabs, currentPage) {
-                                    tabs.getOrNull(currentPage) ?: tabs.firstOrNull()
+                                val currentTab = remember(tabs, pagerState.currentPage) {
+                                    tabs.getOrNull(pagerState.currentPage) ?: tabs.firstOrNull()
                                     ?: DIYTabs.ESSENTIALS
                                 }
 
@@ -469,14 +472,16 @@ class MainActivity : AppCompatActivity() {
                                     modifier = Modifier
                                         .align(Alignment.BottomCenter)
                                         .zIndex(1f),
-                                    selectedIndex = currentPage,
+                                    selectedIndex = pagerState.currentPage,
                                     items = tabs.mapIndexed { index, tab ->
                                         ToolbarItem(
                                             iconRes = tab.iconRes,
                                             labelRes = tab.title,
                                             onClick = {
                                                 HapticUtil.performUIHaptic(view)
-                                                currentPage = index
+                                                scope.launch {
+                                                    pagerState.animateScrollToPage(index)
+                                                }
                                             },
                                             hasBadge = false
                                         )
@@ -551,22 +556,8 @@ class MainActivity : AppCompatActivity() {
                                     }
                                 )
 
-                                AnimatedContent(
-                                    targetState = currentPage,
-                                    transitionSpec = {
-                                        val animationSpec = tween<Float>(durationMillis = 400)
-                                        val slideOffset = 150
-
-                                        (fadeIn(animationSpec = animationSpec) + slideInVertically(
-                                            animationSpec = tween(durationMillis = 400),
-                                            initialOffsetY = { slideOffset }
-                                        )).togetherWith(
-                                            fadeOut(animationSpec = animationSpec) + slideOutVertically(
-                                                animationSpec = tween(durationMillis = 400),
-                                                targetOffsetY = { slideOffset }
-                                            )
-                                        )
-                                    },
+                                HorizontalPager(
+                                    state = pagerState,
                                     modifier = Modifier
                                         .scale(1f - (backProgress.value * 0.05f))
                                         .alpha(1f - (backProgress.value * 0.3f))
@@ -575,7 +566,7 @@ class MainActivity : AppCompatActivity() {
                                             height = with(androidx.compose.ui.platform.LocalDensity.current) { 130.dp.toPx() },
                                             direction = BlurDirection.BOTTOM
                                         ),
-                                    label = "Tab Transition"
+                                    userScrollEnabled = true
                                 ) { targetPage ->
                                     val statusBarHeight = WindowInsets.statusBars.asPaddingValues()
                                         .calculateTopPadding()

--- a/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -282,6 +283,36 @@ class MainActivity : AppCompatActivity() {
                                 // Ignore
                             }
                         }
+                    }
+
+                    // Haptic feedback on tab page change
+                    LaunchedEffect(pagerState) {
+                        var isFirst = true
+                        snapshotFlow { pagerState.currentPage }
+                            .collect {
+                                if (isFirst) {
+                                    isFirst = false
+                                } else if (isSwipeTabsEnabled) {
+                                    HapticUtil.performHeavyHaptic(view)
+                                }
+                            }
+                    }
+
+                    // Bucketed rumble haptic while swiping between tabs
+                    var lastSwipeHapticBucket by androidx.compose.runtime.mutableIntStateOf(0)
+                    LaunchedEffect(pagerState) {
+                        snapshotFlow { pagerState.currentPageOffsetFraction }
+                            .collect { offset ->
+                                if (!isSwipeTabsEnabled) return@collect
+                                val fraction = kotlin.math.abs(offset)
+                                val currentBucket = (fraction * 10).toInt()
+                                if (currentBucket != lastSwipeHapticBucket) {
+                                    if (fraction > 0f) {
+                                        HapticUtil.performSliderHaptic(view)
+                                    }
+                                    lastSwipeHapticBucket = currentBucket
+                                }
+                            }
                     }
                     val backProgress = remember { Animatable(0f) }
                     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
@@ -212,6 +212,7 @@ class MainActivity : AppCompatActivity() {
         setContent {
             val isPitchBlackThemeEnabled by viewModel.isPitchBlackThemeEnabled
             val isBlurEnabled by viewModel.isBlurEnabled
+            val isSwipeTabsEnabled by viewModel.isSwipeTabsEnabled
             EssentialsTheme(pitchBlackTheme = isPitchBlackThemeEnabled) {
                 androidx.compose.runtime.CompositionLocalProvider(
                     com.sameerasw.essentials.ui.state.LocalMenuStateManager provides remember { com.sameerasw.essentials.ui.state.MenuStateManager() }
@@ -566,7 +567,7 @@ class MainActivity : AppCompatActivity() {
                                             height = with(androidx.compose.ui.platform.LocalDensity.current) { 130.dp.toPx() },
                                             direction = BlurDirection.BOTTOM
                                         ),
-                                    userScrollEnabled = true
+                                    userScrollEnabled = isSwipeTabsEnabled
                                 ) { targetPage ->
                                     val statusBarHeight = WindowInsets.statusBars.asPaddingValues()
                                         .calculateTopPadding()

--- a/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/MainActivity.kt
@@ -266,6 +266,21 @@ class MainActivity : AppCompatActivity() {
                             initialPage
                         )
                     }
+
+                    LaunchedEffect(intent) {
+                        intent?.getStringExtra("target_tab")?.let { tabName ->
+                            try {
+                                val tab = DIYTabs.valueOf(tabName)
+                                val index = tabs.indexOf(tab)
+                                if (index != -1) {
+                                    currentPage = index
+                                    intent.removeExtra("target_tab")
+                                }
+                            } catch (e: Exception) {
+                                // Ignore
+                            }
+                        }
+                    }
                     val backProgress = remember { Animatable(0f) }
                     val scope = rememberCoroutineScope()
 

--- a/app/src/main/java/com/sameerasw/essentials/PixelSearchActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/PixelSearchActivity.kt
@@ -1,0 +1,11 @@
+package com.sameerasw.essentials
+
+import android.app.Activity
+import android.os.Bundle
+
+class PixelSearchActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -428,6 +428,14 @@ fun SettingsContent(
                 onTabSelected = { viewModel.setDefaultTab(it, context) },
                 options = availableTabs
             )
+
+            IconToggleItem(
+                iconRes = R.drawable.rounded_touch_app_24,
+                title = stringResource(R.string.setting_swipe_tabs_title),
+                description = stringResource(R.string.setting_swipe_tabs_desc),
+                isChecked = viewModel.isSwipeTabsEnabled.value,
+                onCheckedChange = { viewModel.setSwipeTabsEnabled(it) }
+            )
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -244,6 +244,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_DISABLE_ROTATION_SUGGESTION = "disable_rotation_suggestion"
         const val KEY_PIXEL_SEARCHBAR = "pixel_searchbar"
         const val KEY_PIXEL_SEARCHBAR_TYPE = "pixel_searchbar_type"
+        const val KEY_PIXEL_SEARCHBAR_DATE_FORMAT = "pixel_searchbar_date_format"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -890,6 +891,12 @@ class SettingsRepository(private val context: Context) {
 
     fun setPixelSearchbarType(type: String) =
         putString(KEY_PIXEL_SEARCHBAR_TYPE, type)
+
+    fun getPixelSearchbarDateFormat(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_DATE_FORMAT, "EEEE, MMMM d") ?: "EEEE, MMMM d"
+
+    fun setPixelSearchbarDateFormat(format: String) =
+        putString(KEY_PIXEL_SEARCHBAR_DATE_FORMAT, format)
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -211,6 +211,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_AOD_FORCE_TURN_OFF_ENABLED = "aod_force_turn_off_enabled"
         const val KEY_AUTO_ACCESSIBILITY_ENABLED = "auto_accessibility_enabled"
         const val KEY_USE_BLUR = "use_blur"
+        const val KEY_SWIPE_TABS = "swipe_tabs"
         const val KEY_SENTRY_REPORT_MODE = "sentry_report_mode"
         const val KEY_ONBOARDING_COMPLETED = "onboarding_completed"
         const val KEY_PRIVATE_DNS_PRESETS = "private_dns_presets"

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -242,6 +242,8 @@ class SettingsRepository(private val context: Context) {
         const val KEY_SHIZUKU_AUTH_TOKEN = "shizuku_auth_token"
         const val KEY_EDGE_LIGHTING_SWEEP_SELECTED_SHAPES = "edge_lighting_sweep_selected_shapes"
         const val KEY_DISABLE_ROTATION_SUGGESTION = "disable_rotation_suggestion"
+        const val KEY_PIXEL_SEARCHBAR = "pixel_searchbar"
+        const val KEY_PIXEL_SEARCHBAR_TYPE = "pixel_searchbar_type"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -882,6 +884,12 @@ class SettingsRepository(private val context: Context) {
 
     fun setShizukuAuthToken(token: String) =
         putString(KEY_SHIZUKU_AUTH_TOKEN, token)
+
+    fun getPixelSearchbarType(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_TYPE, "empty") ?: "empty"
+
+    fun setPixelSearchbarType(type: String) =
+        putString(KEY_PIXEL_SEARCHBAR_TYPE, type)
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -254,6 +254,9 @@ class SettingsRepository(private val context: Context) {
         const val KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_V = "pixel_searchbar_widget_padding_v"
         const val KEY_PIXEL_SEARCHBAR_TAP_ACTION_ENABLED = "pixel_searchbar_tap_action_enabled"
         const val KEY_PIXEL_SEARCHBAR_WIDGET_REVISION = "pixel_searchbar_widget_revision"
+        const val KEY_PIXEL_SEARCHBAR_MUSIC_TITLE = "pixel_searchbar_music_title"
+        const val KEY_PIXEL_SEARCHBAR_MUSIC_ARTIST = "pixel_searchbar_music_artist"
+        const val KEY_PIXEL_SEARCHBAR_MUSIC_PACKAGE = "pixel_searchbar_music_package"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -963,6 +966,24 @@ class SettingsRepository(private val context: Context) {
         val current = getPixelSearchbarWidgetRevision()
         prefs.edit().putInt(KEY_PIXEL_SEARCHBAR_WIDGET_REVISION, current + 1).apply()
     }
+
+    fun getPixelSearchbarMusicTitle(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_MUSIC_TITLE, "") ?: ""
+
+    fun setPixelSearchbarMusicTitle(value: String) =
+        putString(KEY_PIXEL_SEARCHBAR_MUSIC_TITLE, value)
+
+    fun getPixelSearchbarMusicArtist(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_MUSIC_ARTIST, "") ?: ""
+
+    fun setPixelSearchbarMusicArtist(value: String) =
+        putString(KEY_PIXEL_SEARCHBAR_MUSIC_ARTIST, value)
+
+    fun getPixelSearchbarMusicPackage(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_MUSIC_PACKAGE, "") ?: ""
+
+    fun setPixelSearchbarMusicPackage(value: String) =
+        putString(KEY_PIXEL_SEARCHBAR_MUSIC_PACKAGE, value)
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -246,6 +246,10 @@ class SettingsRepository(private val context: Context) {
         const val KEY_PIXEL_SEARCHBAR_TYPE = "pixel_searchbar_type"
         const val KEY_PIXEL_SEARCHBAR_DATE_FORMAT = "pixel_searchbar_date_format"
         const val KEY_PIXEL_SEARCHBAR_BACKGROUND_PILL = "pixel_searchbar_background_pill"
+        const val KEY_PIXEL_SEARCHBAR_WIDGET_ID = "pixel_searchbar_widget_id"
+        const val KEY_PIXEL_SEARCHBAR_WIDGET_PROVIDER = "pixel_searchbar_widget_provider"
+        const val KEY_PIXEL_SEARCHBAR_SCRAPED_LINE1 = "pixel_searchbar_scraped_line1"
+        const val KEY_PIXEL_SEARCHBAR_SCRAPED_LINE2 = "pixel_searchbar_scraped_line2"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -904,6 +908,31 @@ class SettingsRepository(private val context: Context) {
 
     fun setPixelSearchbarBackgroundPill(enabled: Boolean) =
         putBoolean(KEY_PIXEL_SEARCHBAR_BACKGROUND_PILL, enabled)
+
+    fun getPixelSearchbarWidgetId(): Int =
+        prefs.getInt(KEY_PIXEL_SEARCHBAR_WIDGET_ID, android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID)
+
+    fun setPixelSearchbarWidgetId(id: Int) =
+        prefs.edit().putInt(KEY_PIXEL_SEARCHBAR_WIDGET_ID, id).apply()
+
+    fun getPixelSearchbarWidgetProvider(): String? =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_WIDGET_PROVIDER, null)
+
+    fun setPixelSearchbarWidgetProvider(provider: String?) =
+        if (provider == null) prefs.edit().remove(KEY_PIXEL_SEARCHBAR_WIDGET_PROVIDER).apply()
+        else putString(KEY_PIXEL_SEARCHBAR_WIDGET_PROVIDER, provider)
+
+    fun getPixelSearchbarScrapedLine1(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_SCRAPED_LINE1, "") ?: ""
+
+    fun setPixelSearchbarScrapedLine1(text: String) =
+        putString(KEY_PIXEL_SEARCHBAR_SCRAPED_LINE1, text)
+
+    fun getPixelSearchbarScrapedLine2(): String =
+        prefs.getString(KEY_PIXEL_SEARCHBAR_SCRAPED_LINE2, "") ?: ""
+
+    fun setPixelSearchbarScrapedLine2(text: String) =
+        putString(KEY_PIXEL_SEARCHBAR_SCRAPED_LINE2, text)
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -245,6 +245,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_PIXEL_SEARCHBAR = "pixel_searchbar"
         const val KEY_PIXEL_SEARCHBAR_TYPE = "pixel_searchbar_type"
         const val KEY_PIXEL_SEARCHBAR_DATE_FORMAT = "pixel_searchbar_date_format"
+        const val KEY_PIXEL_SEARCHBAR_BACKGROUND_PILL = "pixel_searchbar_background_pill"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -897,6 +898,12 @@ class SettingsRepository(private val context: Context) {
 
     fun setPixelSearchbarDateFormat(format: String) =
         putString(KEY_PIXEL_SEARCHBAR_DATE_FORMAT, format)
+
+    fun getPixelSearchbarBackgroundPill(): Boolean =
+        prefs.getBoolean(KEY_PIXEL_SEARCHBAR_BACKGROUND_PILL, false)
+
+    fun setPixelSearchbarBackgroundPill(enabled: Boolean) =
+        putBoolean(KEY_PIXEL_SEARCHBAR_BACKGROUND_PILL, enabled)
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -250,6 +250,10 @@ class SettingsRepository(private val context: Context) {
         const val KEY_PIXEL_SEARCHBAR_WIDGET_PROVIDER = "pixel_searchbar_widget_provider"
         const val KEY_PIXEL_SEARCHBAR_SCRAPED_LINE1 = "pixel_searchbar_scraped_line1"
         const val KEY_PIXEL_SEARCHBAR_SCRAPED_LINE2 = "pixel_searchbar_scraped_line2"
+        const val KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_H = "pixel_searchbar_widget_padding_h"
+        const val KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_V = "pixel_searchbar_widget_padding_v"
+        const val KEY_PIXEL_SEARCHBAR_TAP_ACTION_ENABLED = "pixel_searchbar_tap_action_enabled"
+        const val KEY_PIXEL_SEARCHBAR_WIDGET_REVISION = "pixel_searchbar_widget_revision"
 
         const val KEY_LOCK_SCREEN_CLOCK_WEIGHT = "lock_screen_clock_weight"
         const val KEY_LOCK_SCREEN_CLOCK_WIDTH = "lock_screen_clock_width"
@@ -933,6 +937,32 @@ class SettingsRepository(private val context: Context) {
 
     fun setPixelSearchbarScrapedLine2(text: String) =
         putString(KEY_PIXEL_SEARCHBAR_SCRAPED_LINE2, text)
+
+    fun getPixelSearchbarWidgetPaddingH(): Int =
+        prefs.getInt(KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_H, 0)
+
+    fun setPixelSearchbarWidgetPaddingH(value: Int) =
+        prefs.edit().putInt(KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_H, value).apply()
+
+    fun getPixelSearchbarWidgetPaddingV(): Int =
+        prefs.getInt(KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_V, 0)
+
+    fun setPixelSearchbarWidgetPaddingV(value: Int) =
+        prefs.edit().putInt(KEY_PIXEL_SEARCHBAR_WIDGET_PADDING_V, value).apply()
+
+    fun getPixelSearchbarTapActionEnabled(): Boolean =
+        prefs.getBoolean(KEY_PIXEL_SEARCHBAR_TAP_ACTION_ENABLED, true)
+
+    fun setPixelSearchbarTapActionEnabled(enabled: Boolean) =
+        putBoolean(KEY_PIXEL_SEARCHBAR_TAP_ACTION_ENABLED, enabled)
+
+    fun getPixelSearchbarWidgetRevision(): Int =
+        prefs.getInt(KEY_PIXEL_SEARCHBAR_WIDGET_REVISION, 0)
+
+    fun incrementPixelSearchbarWidgetRevision() {
+        val current = getPixelSearchbarWidgetRevision()
+        prefs.edit().putInt(KEY_PIXEL_SEARCHBAR_WIDGET_REVISION, current + 1).apply()
+    }
 
     fun getEdgeLightingSweepSelectedShapes(): Set<String> {
         val defaultShapes = com.sameerasw.essentials.utils.AmbientMusicShapeHelper.allShapesWithNames.map { it.first }.toSet()

--- a/app/src/main/java/com/sameerasw/essentials/domain/diy/Automation.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/diy/Automation.kt
@@ -27,6 +27,9 @@ data class Automation(
         APP,
 
         @SerializedName("ACTION_SHORTCUT")
-        ACTION_SHORTCUT
+        ACTION_SHORTCUT,
+
+        @SerializedName("PIXEL_SEARCHBAR")
+        PIXEL_SEARCHBAR
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/domain/model/Feature.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/model/Feature.kt
@@ -48,10 +48,10 @@ abstract class Feature(
     abstract fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean)
 
     open fun onClick(context: Context, viewModel: MainViewModel) {
-        val targetFeatureId = parentFeatureId ?: id
+        val targetFeatureId = if (!hasMoreSettings && parentFeatureId != null) parentFeatureId else id
         context.startActivity(Intent(context, FeatureSettingsActivity::class.java).apply {
             putExtra("feature", targetFeatureId)
-            if (parentFeatureId != null) {
+            if (!hasMoreSettings && parentFeatureId != null) {
                 putExtra("highlight_setting", id)
             }
         })

--- a/app/src/main/java/com/sameerasw/essentials/domain/model/Feature.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/model/Feature.kt
@@ -48,8 +48,12 @@ abstract class Feature(
     abstract fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean)
 
     open fun onClick(context: Context, viewModel: MainViewModel) {
+        val targetFeatureId = parentFeatureId ?: id
         context.startActivity(Intent(context, FeatureSettingsActivity::class.java).apply {
-            putExtra("feature", id)
+            putExtra("feature", targetFeatureId)
+            if (parentFeatureId != null) {
+                putExtra("highlight_setting", id)
+            }
         })
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -1071,6 +1071,20 @@ object FeatureRegistry {
             override fun isEnabled(viewModel: MainViewModel) = true
             override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {}
         },
+        object : Feature(
+            id = "Watch Controls",
+            title = R.string.feat_watch_controls_title,
+            iconRes = R.drawable.rounded_edit_24,
+            category = R.string.cat_tools,
+            description = R.string.feat_watch_controls_desc,
+            aboutDescription = R.string.feat_watch_controls_desc,
+            parentFeatureId = "Watch",
+            hasMoreSettings = true,
+            showToggle = false
+        ) {
+            override fun isEnabled(viewModel: MainViewModel) = true
+            override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {}
+        },
 
 
         object : Feature(

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -286,6 +286,7 @@ object FeatureRegistry {
             permissionKeys = listOf("WRITE_SECURE_SETTINGS"),
             showToggle = true,
             hasMoreSettings = true,
+            isBeta = true,
             parentFeatureId = "Widgets"
         ) {
             override fun isEnabled(viewModel: MainViewModel) = viewModel.isPixelSearchbarEnabled.value
@@ -904,7 +905,6 @@ object FeatureRegistry {
             permissionKeys = listOf("WRITE_SECURE_SETTINGS", "USAGE_STATS"),
             showToggle = false,
             hasMoreSettings = true,
-            isBeta = true,
             parentFeatureId = "Security",
             animationRes = R.raw.shutup_animation
         ) {

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -1085,6 +1085,33 @@ object FeatureRegistry {
             override fun isEnabled(viewModel: MainViewModel) = true
             override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {}
         },
+        object : Feature(
+            id = "Watch Wireless Debugging",
+            title = R.string.feat_watch_wireless_debugging_title,
+            iconRes = R.drawable.rounded_adb_24,
+            category = R.string.cat_tools,
+            description = R.string.feat_watch_wireless_debugging_desc,
+            parentFeatureId = "Watch",
+            hasMoreSettings = false,
+            showToggle = true
+        ) {
+            override fun isEnabled(viewModel: MainViewModel): Boolean {
+                val context = EssentialsApp.context
+                val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+                return prefs.getBoolean("watch_adb_wifi_enabled", false)
+            }
+
+            override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {
+                // Send message to watch to toggle ADB Wifi
+                val messageClient = com.google.android.gms.wearable.Wearable.getMessageClient(context)
+                val nodeClient = com.google.android.gms.wearable.Wearable.getNodeClient(context)
+                nodeClient.connectedNodes.addOnSuccessListener { nodes ->
+                    for (node in nodes) {
+                        messageClient.sendMessage(node.id, "/toggle_watch_adb_wifi", byteArrayOf())
+                    }
+                }
+            }
+        },
 
 
         object : Feature(

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -1113,6 +1113,30 @@ object FeatureRegistry {
             }
         },
 
+        object : Feature(
+            id = "Sync sound mode",
+            title = R.string.feat_sync_sound_mode_title,
+            iconRes = R.drawable.rounded_volume_up_24,
+            category = R.string.cat_tools,
+            description = R.string.feat_sync_sound_mode_desc,
+            parentFeatureId = "Watch",
+            hasMoreSettings = false,
+            showToggle = true
+        ) {
+            override fun isEnabled(viewModel: MainViewModel): Boolean {
+                val context = EssentialsApp.context
+                val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+                return prefs.getBoolean("watch_sync_sound_mode_enabled", false)
+            }
+
+            override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {
+                val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+                prefs.edit().putBoolean("watch_sync_sound_mode_enabled", enabled).apply()
+                // Force sync to sync new sound mode status to watch if enabled
+                com.sameerasw.essentials.services.DeviceInfoSyncManager.forceSync(context)
+            }
+        },
+
 
         object : Feature(
             id = "App updates",

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -7,6 +7,7 @@ import com.sameerasw.essentials.R
 import com.sameerasw.essentials.domain.model.Feature
 import com.sameerasw.essentials.domain.model.SearchSetting
 import com.sameerasw.essentials.ui.activities.WatermarkActivity
+import com.sameerasw.essentials.ui.activities.PixelSearchbarSettingsActivity
 import com.sameerasw.essentials.utils.ShellUtils
 import com.sameerasw.essentials.viewmodels.MainViewModel
 
@@ -273,6 +274,29 @@ object FeatureRegistry {
         ) {
             override fun isEnabled(viewModel: MainViewModel) = true
             override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {}
+        },
+ 
+        object : Feature(
+            id = "Pixel Searchbar",
+            title = R.string.feat_pixel_searchbar_title,
+            iconRes = R.drawable.rounded_search_24,
+            category = R.string.cat_interface,
+            description = R.string.feat_pixel_searchbar_desc,
+            aboutDescription = R.string.about_desc_pixel_searchbar,
+            permissionKeys = listOf("WRITE_SECURE_SETTINGS"),
+            showToggle = true,
+            hasMoreSettings = true,
+            parentFeatureId = "Widgets"
+        ) {
+            override fun isEnabled(viewModel: MainViewModel) = viewModel.isPixelSearchbarEnabled.value
+            override fun isToggleEnabled(viewModel: MainViewModel, context: Context) =
+                viewModel.isWriteSecureSettingsEnabled.value || viewModel.isShizukuPermissionGranted.value || viewModel.isRootPermissionGranted.value
+            override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {
+                viewModel.setPixelSearchbarEnabled(enabled, context)
+            }
+            override fun onClick(context: Context, viewModel: MainViewModel) {
+                context.startActivity(Intent(context, PixelSearchbarSettingsActivity::class.java))
+            }
         },
 
         object : Feature(

--- a/app/src/main/java/com/sameerasw/essentials/domain/watermark/WatermarkEngine.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/watermark/WatermarkEngine.kt
@@ -154,12 +154,43 @@ class WatermarkEngine(
         withContext(Dispatchers.Default) {
             val exifData = metadataProvider.extractExif(uri)
 
+            // Extract original gainmap if it exists (API 34+)
+            var currentGainmap: android.graphics.Gainmap? = null
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (bitmap.hasGainmap()) {
+                    currentGainmap = bitmap.gainmap
+                }
+            }
+
             // Apply Rotation
             val rotated = if (options.rotation != 0) {
                 val matrix =
                     android.graphics.Matrix().apply { postRotate(options.rotation.toFloat()) }
                 val rb =
                     Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+                
+                // If we have a gainmap, rotate its contents as well to align with the base image
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE && currentGainmap != null) {
+                    try {
+                        val gmContents = currentGainmap.gainmapContents
+                        val rotatedGmContents = Bitmap.createBitmap(gmContents, 0, 0, gmContents.width, gmContents.height, matrix, true)
+                        val newGm = android.graphics.Gainmap(rotatedGmContents)
+                        
+                        newGm.setRatioMin(currentGainmap.ratioMin[0], currentGainmap.ratioMin[1], currentGainmap.ratioMin[2])
+                        newGm.setRatioMax(currentGainmap.ratioMax[0], currentGainmap.ratioMax[1], currentGainmap.ratioMax[2])
+                        newGm.setGamma(currentGainmap.gamma[0], currentGainmap.gamma[1], currentGainmap.gamma[2])
+                        newGm.setEpsilonSdr(currentGainmap.epsilonSdr[0], currentGainmap.epsilonSdr[1], currentGainmap.epsilonSdr[2])
+                        newGm.setEpsilonHdr(currentGainmap.epsilonHdr[0], currentGainmap.epsilonHdr[1], currentGainmap.epsilonHdr[2])
+                        newGm.displayRatioForFullHdr = currentGainmap.displayRatioForFullHdr
+                        newGm.minDisplayRatioForHdrTransition = currentGainmap.minDisplayRatioForHdrTransition
+                        
+                        currentGainmap = newGm
+                        rb.gainmap = newGm
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+                
                 if (rb != bitmap) bitmap.recycle()
                 rb
             } else {
@@ -171,7 +202,106 @@ class WatermarkEngine(
                 WatermarkStyle.FRAME -> drawFrame(rotated, exifData, options)
             }
 
-            applyBorder(result, options)
+            val finalResult = applyBorder(result, options)
+
+            // Re-apply/propagate the processed gainmap to the final output
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE && currentGainmap != null) {
+                try {
+                    val gmContents = currentGainmap.gainmapContents
+                    val scale = gmContents.width.toFloat() / rotated.width.toFloat()
+                    
+                    var xOffset = 0f
+                    var yOffset = 0f
+
+                    // Offset from drawFrame
+                    if (options.style == WatermarkStyle.FRAME) {
+                        val baseFrameHeight = (rotated.height * 0.10f).roundToInt()
+                        val brandScale = 0.5f + (options.brandTextSize / 100f)
+                        val dataScale = 0.5f + (options.dataTextSize / 100f)
+                        
+                        val brandPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                            textSize = (baseFrameHeight * 0.3f) * brandScale
+                        }
+                        val exifPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                            textSize = (baseFrameHeight * 0.2f) * dataScale
+                        }
+                        
+                        val margin = rotated.width * (options.padding / 1000f)
+                        val maxAvailableWidth = if (options.showDeviceBrand) {
+                            (rotated.width - margin * 2) * 0.6f
+                        } else {
+                            (rotated.width - margin * 2)
+                        }
+                        
+                        var totalExifHeight = 0f
+                        if (options.showExif) {
+                            val exifItems = buildExifList(exifData, options)
+                            if (exifItems.isNotEmpty()) {
+                                val exifRows = wrapExifItems(exifItems, exifPaint, maxAvailableWidth)
+                                totalExifHeight = exifRows.size * (exifPaint.textSize * 1.5f)
+                            }
+                        }
+                        
+                        var leftSideHeight = 0f
+                        if (options.showDeviceBrand) leftSideHeight += brandPaint.textSize
+                        if (options.showCustomText && options.customText.isNotEmpty()) {
+                            val customScale = 0.5f + (options.customTextSize / 100f)
+                            val customPaint = Paint(brandPaint).apply {
+                                textSize = brandPaint.textSize * (customScale / (0.5f + (options.brandTextSize / 100f)))
+                            }
+                            if (options.showDeviceBrand) leftSideHeight += (brandPaint.textSize * 0.2f)
+                            leftSideHeight += customPaint.textSize
+                        }
+                        
+                        val minHeight = max(brandPaint.textSize, exifPaint.textSize) * 2f
+                        val strokeSpacer = (rotated.width * (options.borderStroke / 1000f)).toInt()
+                        val calculatedHeight = max(leftSideHeight, totalExifHeight) + (margin * 2) + strokeSpacer
+                        val finalFrameHeight = max(minHeight.roundToInt(), calculatedHeight.roundToInt())
+                        
+                        if (options.moveToTop) {
+                            yOffset += finalFrameHeight
+                        }
+                    }
+
+                    // Offset from applyBorder
+                    if (options.borderStroke > 0) {
+                        val strokeWidth = (rotated.width * (options.borderStroke / 1000f)).toInt()
+                        xOffset += strokeWidth
+                        yOffset += strokeWidth
+                    }
+
+                    val newGmWidth = (finalResult.width * scale).roundToInt()
+                    val newGmHeight = (finalResult.height * scale).roundToInt()
+                    
+                    val newGmContents = Bitmap.createBitmap(newGmWidth, newGmHeight, Bitmap.Config.ARGB_8888)
+                    val gmCanvas = Canvas(newGmContents)
+                    gmCanvas.drawColor(Color.BLACK) // fill with neutral black
+                    
+                    val destRect = RectF(
+                        xOffset * scale,
+                        yOffset * scale,
+                        (xOffset + rotated.width) * scale,
+                        (yOffset + rotated.height) * scale
+                    )
+                    gmCanvas.drawBitmap(gmContents, null, destRect, null)
+                    
+                    val newGm = android.graphics.Gainmap(newGmContents)
+                    newGm.setRatioMin(currentGainmap.ratioMin[0], currentGainmap.ratioMin[1], currentGainmap.ratioMin[2])
+                    newGm.setRatioMax(currentGainmap.ratioMax[0], currentGainmap.ratioMax[1], currentGainmap.ratioMax[2])
+                    newGm.setGamma(currentGainmap.gamma[0], currentGainmap.gamma[1], currentGainmap.gamma[2])
+                    newGm.setEpsilonSdr(currentGainmap.epsilonSdr[0], currentGainmap.epsilonSdr[1], currentGainmap.epsilonSdr[2])
+                    newGm.setEpsilonHdr(currentGainmap.epsilonHdr[0], currentGainmap.epsilonHdr[1], currentGainmap.epsilonHdr[2])
+                    newGm.displayRatioForFullHdr = currentGainmap.displayRatioForFullHdr
+                    newGm.minDisplayRatioForHdrTransition = currentGainmap.minDisplayRatioForHdrTransition
+                    
+                    finalResult.gainmap = newGm
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    finalResult.gainmap = currentGainmap
+                }
+            }
+
+            finalResult
         }
 
     private fun drawOverlay(bitmap: Bitmap, exifData: ExifData, options: WatermarkOptions): Bitmap {

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -64,6 +64,7 @@ object DeviceInfoSyncManager {
     private var currentContext: Context? = null
     private var prefChangeListener: android.content.SharedPreferences.OnSharedPreferenceChangeListener? = null
     private var aodContentObserver: android.database.ContentObserver? = null
+    private var tapToWakeContentObserver: android.database.ContentObserver? = null
 
     fun init(context: Context) {
         if (isInitialized) return
@@ -102,6 +103,15 @@ object DeviceInfoSyncManager {
             }
         }
         context.contentResolver.registerContentObserver(aodUri, true, aodContentObserver!!)
+
+        // Sync on Tap to wake change
+        val tapToWakeUri = android.provider.Settings.Secure.getUriFor("doze_tap_gesture")
+        tapToWakeContentObserver = object : android.database.ContentObserver(handler) {
+            override fun onChange(selfChange: Boolean) {
+                syncDeviceInfo(context)
+            }
+        }
+        context.contentResolver.registerContentObserver(tapToWakeUri, true, tapToWakeContentObserver!!)
 
         // Sync on preference change (flashlight pulse, glance, watch controls)
         val p = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
@@ -174,6 +184,8 @@ object DeviceInfoSyncManager {
 
         val watchControlsLayout = prefs.getString("watch_controls_layout", "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD") ?: "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD"
 
+        val tapToWakeEnabled = android.provider.Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 1) == 1
+
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
@@ -185,6 +197,7 @@ object DeviceInfoSyncManager {
         dataMap.putString("device_name", deviceName)
         dataMap.putBoolean("flashlight_pulse_enabled", flashlightPulseEnabled)
         dataMap.putInt("aod_state", aodState)
+        dataMap.putBoolean("tap_to_wake_enabled", tapToWakeEnabled)
         dataMap.putString("watch_controls_layout", watchControlsLayout)
         
         dataMap.putBoolean("travel_active", travelActive)

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -62,6 +62,8 @@ object DeviceInfoSyncManager {
     }
 
     private var currentContext: Context? = null
+    private var prefChangeListener: android.content.SharedPreferences.OnSharedPreferenceChangeListener? = null
+    private var aodContentObserver: android.database.ContentObserver? = null
 
     fun init(context: Context) {
         if (isInitialized) return
@@ -92,13 +94,23 @@ object DeviceInfoSyncManager {
         val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         cameraManager.registerTorchCallback(torchCallback, handler)
 
-        // Get initial flashlight state
-        val id = FlashlightUtil.getCameraId(context)
-        if (id != null) {
-            isIntensitySupported = FlashlightUtil.isIntensitySupported(context, id)
-            maxTorchLevel = FlashlightUtil.getMaxLevel(context, id)
-            torchLevel = FlashlightUtil.getCurrentLevel(context, id)
+        // Sync on AOD change
+        val aodUri = android.provider.Settings.Secure.getUriFor("doze_always_on")
+        aodContentObserver = object : android.database.ContentObserver(handler) {
+            override fun onChange(selfChange: Boolean) {
+                syncDeviceInfo(context)
+            }
         }
+        context.contentResolver.registerContentObserver(aodUri, true, aodContentObserver!!)
+
+        // Sync on preference change (flashlight pulse, glance)
+        val p = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+        prefChangeListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == "flashlight_pulse_enabled" || key == "notification_glance_enabled") {
+                syncDeviceInfo(context)
+            }
+        }
+        p.registerOnSharedPreferenceChangeListener(prefChangeListener)
     }
 
     private val syncDebouncer = Runnable {
@@ -153,6 +165,13 @@ object DeviceInfoSyncManager {
         val travelIsPaused = prefs.getBoolean("travel_is_paused", false)
         val travelArrived = prefs.getBoolean("travel_arrived", false)
 
+        val flashlightPulseEnabled = prefs.getBoolean("flashlight_pulse_enabled", false)
+        val aodState = when {
+            prefs.getBoolean("notification_glance_enabled", false) -> 2
+            android.provider.Settings.Secure.getInt(context.contentResolver, "doze_always_on", 0) == 1 -> 1
+            else -> 0
+        }
+
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
@@ -162,6 +181,8 @@ object DeviceInfoSyncManager {
         dataMap.putBoolean("flashlight_intensity_supported", isIntensitySupported)
         dataMap.putInt("ringer_mode", ringerMode)
         dataMap.putString("device_name", deviceName)
+        dataMap.putBoolean("flashlight_pulse_enabled", flashlightPulseEnabled)
+        dataMap.putInt("aod_state", aodState)
         
         dataMap.putBoolean("travel_active", travelActive)
         dataMap.putString("travel_name", travelName)

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -103,10 +103,10 @@ object DeviceInfoSyncManager {
         }
         context.contentResolver.registerContentObserver(aodUri, true, aodContentObserver!!)
 
-        // Sync on preference change (flashlight pulse, glance)
+        // Sync on preference change (flashlight pulse, glance, watch controls)
         val p = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
         prefChangeListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == "flashlight_pulse_enabled" || key == "notification_glance_enabled") {
+            if (key == "flashlight_pulse_enabled" || key == "notification_glance_enabled" || key == "watch_controls_layout") {
                 syncDeviceInfo(context)
             }
         }
@@ -172,6 +172,8 @@ object DeviceInfoSyncManager {
             else -> 0
         }
 
+        val watchControlsLayout = prefs.getString("watch_controls_layout", "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD") ?: "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD"
+
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
@@ -183,6 +185,7 @@ object DeviceInfoSyncManager {
         dataMap.putString("device_name", deviceName)
         dataMap.putBoolean("flashlight_pulse_enabled", flashlightPulseEnabled)
         dataMap.putInt("aod_state", aodState)
+        dataMap.putString("watch_controls_layout", watchControlsLayout)
         
         dataMap.putBoolean("travel_active", travelActive)
         dataMap.putString("travel_name", travelName)

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -143,6 +143,15 @@ object DeviceInfoSyncManager {
         )
             ?: android.os.Build.MODEL
 
+        val prefs = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+        val travelActive = prefs.getBoolean("travel_active", false)
+        val travelName = prefs.getString("travel_name", "") ?: ""
+        val travelProgress = prefs.getFloat("travel_progress", 0f)
+        val travelRemainingTime = prefs.getString("travel_remaining_time", "") ?: ""
+        val travelIconName = prefs.getString("travel_icon_name", "") ?: ""
+        val travelIsPaused = prefs.getBoolean("travel_is_paused", false)
+        val travelArrived = prefs.getBoolean("travel_arrived", false)
+
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
         dataMap.putBoolean("is_charging", isCharging)
@@ -152,6 +161,15 @@ object DeviceInfoSyncManager {
         dataMap.putBoolean("flashlight_intensity_supported", isIntensitySupported)
         dataMap.putInt("ringer_mode", ringerMode)
         dataMap.putString("device_name", deviceName)
+        
+        dataMap.putBoolean("travel_active", travelActive)
+        dataMap.putString("travel_name", travelName)
+        dataMap.putFloat("travel_progress", travelProgress)
+        dataMap.putString("travel_remaining_time", travelRemainingTime)
+        dataMap.putString("travel_icon_name", travelIconName)
+        dataMap.putBoolean("travel_is_paused", travelIsPaused)
+        dataMap.putBoolean("travel_arrived", travelArrived)
+
         dataMap.putLong("timestamp", System.currentTimeMillis())
 
         val putDataReq = putDataMapReq.asPutDataRequest()

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -148,6 +148,7 @@ object DeviceInfoSyncManager {
         val travelName = prefs.getString("travel_name", "") ?: ""
         val travelProgress = prefs.getFloat("travel_progress", 0f)
         val travelRemainingTime = prefs.getString("travel_remaining_time", "") ?: ""
+        val travelRemainingDistance = prefs.getString("travel_remaining_distance", "") ?: ""
         val travelIconName = prefs.getString("travel_icon_name", "") ?: ""
         val travelIsPaused = prefs.getBoolean("travel_is_paused", false)
         val travelArrived = prefs.getBoolean("travel_arrived", false)
@@ -166,6 +167,7 @@ object DeviceInfoSyncManager {
         dataMap.putString("travel_name", travelName)
         dataMap.putFloat("travel_progress", travelProgress)
         dataMap.putString("travel_remaining_time", travelRemainingTime)
+        dataMap.putString("travel_remaining_distance", travelRemainingDistance)
         dataMap.putString("travel_icon_name", travelIconName)
         dataMap.putBoolean("travel_is_paused", travelIsPaused)
         dataMap.putBoolean("travel_arrived", travelArrived)

--- a/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DeviceInfoSyncManager.kt
@@ -116,7 +116,7 @@ object DeviceInfoSyncManager {
         // Sync on preference change (flashlight pulse, glance, watch controls)
         val p = context.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
         prefChangeListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == "flashlight_pulse_enabled" || key == "notification_glance_enabled" || key == "watch_controls_layout") {
+            if (key == "flashlight_pulse_enabled" || key == "notification_glance_enabled" || key == "watch_controls_layout" || key == "watch_sync_sound_mode_enabled") {
                 syncDeviceInfo(context)
             }
         }
@@ -185,6 +185,7 @@ object DeviceInfoSyncManager {
         val watchControlsLayout = prefs.getString("watch_controls_layout", "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD") ?: "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD"
 
         val tapToWakeEnabled = android.provider.Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 1) == 1
+        val watchSyncSoundModeEnabled = prefs.getBoolean("watch_sync_sound_mode_enabled", false)
 
         val dataMap = putDataMapReq.dataMap
         dataMap.putInt("battery_level", batteryPct)
@@ -199,6 +200,7 @@ object DeviceInfoSyncManager {
         dataMap.putInt("aod_state", aodState)
         dataMap.putBoolean("tap_to_wake_enabled", tapToWakeEnabled)
         dataMap.putString("watch_controls_layout", watchControlsLayout)
+        dataMap.putBoolean("watch_sync_sound_mode_enabled", watchSyncSoundModeEnabled)
         
         dataMap.putBoolean("travel_active", travelActive)
         dataMap.putString("travel_name", travelName)

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -130,6 +130,16 @@ class EssentialsWearableListenerService : WearableListenerService() {
                     }
                 }
             }
+
+            "/toggle_tap_to_wake" -> {
+                val isEnabled = android.provider.Settings.Secure.getInt(contentResolver, "doze_tap_gesture", 1) == 1
+                val newState = if (isEnabled) 0 else 1
+                try {
+                    android.provider.Settings.Secure.putInt(contentResolver, "doze_tap_gesture", newState)
+                } catch (_: Exception) {
+                    com.sameerasw.essentials.utils.ShellUtils.runCommand(this, "settings put secure doze_tap_gesture $newState")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -3,6 +3,8 @@ package com.sameerasw.essentials.services
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
 
+import androidx.core.content.edit
+
 class EssentialsWearableListenerService : WearableListenerService() {
     companion object {
         private const val TAG = "EssentialsWearableListener"
@@ -79,6 +81,53 @@ class EssentialsWearableListenerService : WearableListenerService() {
                         action = "LOCK_SCREEN"
                     }
                     startService(intent)
+                }
+            }
+
+            "/toggle_flashlight_pulse" -> {
+                val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+                val enabled = prefs.getBoolean("flashlight_pulse_enabled", false)
+                prefs.edit(commit = true) {
+                    putBoolean("flashlight_pulse_enabled", !enabled)
+                }
+            }
+
+            "/toggle_aod" -> {
+                val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+                val isGlanceEnabled = prefs.getBoolean("notification_glance_enabled", false)
+                val isAodEnabled = android.provider.Settings.Secure.getInt(contentResolver, "doze_always_on", 0) == 1
+
+                when {
+                    isGlanceEnabled -> {
+                        prefs.edit(commit = true) {
+                            putBoolean("notification_glance_enabled", false)
+                        }
+                        try {
+                            android.provider.Settings.Secure.putInt(contentResolver, "doze_always_on", 1)
+                        } catch (_: Exception) {
+                            com.sameerasw.essentials.utils.ShellUtils.runCommand(this, "settings put secure doze_always_on 1")
+                        }
+                    }
+                    isAodEnabled -> {
+                        try {
+                            android.provider.Settings.Secure.putInt(contentResolver, "doze_always_on", 0)
+                        } catch (_: Exception) {
+                            com.sameerasw.essentials.utils.ShellUtils.runCommand(this, "settings put secure doze_always_on 0")
+                        }
+                        prefs.edit(commit = true) {
+                            putBoolean("notification_glance_enabled", false)
+                        }
+                    }
+                    else -> {
+                        prefs.edit(commit = true) {
+                            putBoolean("notification_glance_enabled", true)
+                        }
+                        try {
+                            android.provider.Settings.Secure.putInt(contentResolver, "doze_always_on", 0)
+                        } catch (_: Exception) {
+                            com.sameerasw.essentials.utils.ShellUtils.runCommand(this, "settings put secure doze_always_on 0")
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -140,6 +140,19 @@ class EssentialsWearableListenerService : WearableListenerService() {
                     com.sameerasw.essentials.utils.ShellUtils.runCommand(this, "settings put secure doze_tap_gesture $newState")
                 }
             }
+
+            "/watch_status_update" -> {
+                val data = messageEvent.data
+                if (data != null && data.size >= 2) {
+                    val adbWifiEnabled = data[0].toInt() == 1
+                    val secureSettingsGranted = data[1].toInt() == 1
+                    val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+                    prefs.edit(commit = true) {
+                        putBoolean("watch_adb_wifi_enabled", adbWifiEnabled)
+                        putBoolean("watch_write_secure_settings_granted", secureSettingsGranted)
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/EssentialsWearableListenerService.kt
@@ -3,6 +3,7 @@ package com.sameerasw.essentials.services
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
 
+import android.content.Context
 import androidx.core.content.edit
 
 class EssentialsWearableListenerService : WearableListenerService() {
@@ -150,6 +151,33 @@ class EssentialsWearableListenerService : WearableListenerService() {
                     prefs.edit(commit = true) {
                         putBoolean("watch_adb_wifi_enabled", adbWifiEnabled)
                         putBoolean("watch_write_secure_settings_granted", secureSettingsGranted)
+                    }
+                }
+            }
+
+            "/set_sync_sound_mode" -> {
+                val data = messageEvent.data
+                if (data != null && data.isNotEmpty()) {
+                    val enabled = data[0].toInt() == 1
+                    val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+                    prefs.edit(commit = true) {
+                        putBoolean("watch_sync_sound_mode_enabled", enabled)
+                    }
+                    // Immediately push device info to let watch know
+                    DeviceInfoSyncManager.forceSync(this)
+                }
+            }
+
+            "/set_phone_ringer_mode" -> {
+                val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+                val isSyncEnabled = prefs.getBoolean("watch_sync_sound_mode_enabled", false)
+                if (isSyncEnabled) {
+                    val ringerMode = messageEvent.data?.firstOrNull()?.toInt() ?: 2
+                    val audioManager = getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
+                    try {
+                        audioManager?.ringerMode = ringerMode
+                    } catch (e: Exception) {
+                        // ignore permission issue
                     }
                 }
             }

--- a/app/src/main/java/com/sameerasw/essentials/services/LocationReachedService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/LocationReachedService.kt
@@ -119,14 +119,14 @@ class LocationReachedService : Service() {
         }
 
         repository.saveActiveAlarmId(null)
-        saveTravelProgress(false, null, 0, null)
+        saveTravelProgress(false, null, 0, null, null)
         serviceScope.launch {
             delay(500)
             stopSelf()
         }
     }
 
-    private fun saveTravelProgress(active: Boolean, alarm: LocationAlarm?, progressPercent: Int, etaText: String?) {
+    private fun saveTravelProgress(active: Boolean, alarm: LocationAlarm?, progressPercent: Int, etaText: String?, distanceText: String?) {
         val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
         val editor = prefs.edit()
         if (active && alarm != null) {
@@ -134,9 +134,12 @@ class LocationReachedService : Service() {
             editor.putString("travel_name", alarm.name)
             editor.putFloat("travel_progress", progressPercent.toFloat() / 100f)
             editor.putString("travel_remaining_time", etaText ?: getString(R.string.location_reached_calculating))
+            editor.putString("travel_remaining_distance", distanceText ?: getString(R.string.location_reached_calculating))
             editor.putString("travel_icon_name", alarm.iconResName)
             editor.putBoolean("travel_is_paused", alarm.isPaused)
-            if (progressPercent < 100) {
+            if (progressPercent >= 100) {
+                editor.putBoolean("travel_arrived", true)
+            } else {
                 editor.putBoolean("travel_arrived", false)
             }
         } else {
@@ -154,7 +157,7 @@ class LocationReachedService : Service() {
         val alarms = repository.getAlarms()
         val alarm = alarms.find { it.id == activeId }
         if (alarm != null) {
-            saveTravelProgress(true, alarm, 0, null)
+            saveTravelProgress(true, alarm, 0, null, null)
             updateNotification(null)
         }
     }
@@ -205,10 +208,7 @@ class LocationReachedService : Service() {
     private fun triggerArrivalAlarm() {
         val activeId = repository.getActiveAlarmId()
         val alarm = repository.getAlarms().find { it.id == activeId }
-        saveTravelProgress(alarm != null, alarm, 100, "Arrived")
-        val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
-        prefs.edit().putBoolean("travel_arrived", true).apply()
-        DeviceInfoSyncManager.forceSync(this)
+        saveTravelProgress(alarm != null, alarm, 100, "Arrived", "0 m")
 
         val channelId = "location_reached_channel"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -275,9 +275,14 @@ class LocationReachedService : Service() {
             }
         }
 
+        val distanceText = distanceKm?.let {
+            if (it < 1.0) getString(R.string.location_reached_dist_m, (it * 1000).toInt())
+            else getString(R.string.location_reached_dist_km, it)
+        } ?: getString(R.string.location_reached_calculating)
+
         val activeId = repository.getActiveAlarmId()
         val alarm = repository.getAlarms().find { it.id == activeId }
-        saveTravelProgress(alarm != null, alarm, progressPercent, etaText)
+        saveTravelProgress(alarm != null, alarm, progressPercent, etaText, distanceText)
 
         val notification = buildOngoingNotification(distanceKm, progressPercent, etaText)
         notificationManager.notify(NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/sameerasw/essentials/services/LocationReachedService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/LocationReachedService.kt
@@ -97,10 +97,13 @@ class LocationReachedService : Service() {
                 if (alarm != null) {
                     updateProgress(alarm)
                 } else {
-                    stopSelf()
+                    serviceScope.launch {
+                        delay(500)
+                        stopSelf()
+                    }
                     break
                 }
-                delay(10000)
+                delay(3000)
             }
         }
     }
@@ -116,7 +119,32 @@ class LocationReachedService : Service() {
         }
 
         repository.saveActiveAlarmId(null)
-        stopSelf()
+        saveTravelProgress(false, null, 0, null)
+        serviceScope.launch {
+            delay(500)
+            stopSelf()
+        }
+    }
+
+    private fun saveTravelProgress(active: Boolean, alarm: LocationAlarm?, progressPercent: Int, etaText: String?) {
+        val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+        val editor = prefs.edit()
+        if (active && alarm != null) {
+            editor.putBoolean("travel_active", true)
+            editor.putString("travel_name", alarm.name)
+            editor.putFloat("travel_progress", progressPercent.toFloat() / 100f)
+            editor.putString("travel_remaining_time", etaText ?: getString(R.string.location_reached_calculating))
+            editor.putString("travel_icon_name", alarm.iconResName)
+            editor.putBoolean("travel_is_paused", alarm.isPaused)
+            if (progressPercent < 100) {
+                editor.putBoolean("travel_arrived", false)
+            }
+        } else {
+            editor.putBoolean("travel_active", false)
+            editor.putBoolean("travel_arrived", false)
+        }
+        editor.apply()
+        DeviceInfoSyncManager.forceSync(this)
     }
 
     private fun pauseTracking() {
@@ -126,6 +154,7 @@ class LocationReachedService : Service() {
         val alarms = repository.getAlarms()
         val alarm = alarms.find { it.id == activeId }
         if (alarm != null) {
+            saveTravelProgress(true, alarm, 0, null)
             updateNotification(null)
         }
     }
@@ -174,6 +203,13 @@ class LocationReachedService : Service() {
     }
 
     private fun triggerArrivalAlarm() {
+        val activeId = repository.getActiveAlarmId()
+        val alarm = repository.getAlarms().find { it.id == activeId }
+        saveTravelProgress(alarm != null, alarm, 100, "Arrived")
+        val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
+        prefs.edit().putBoolean("travel_arrived", true).apply()
+        DeviceInfoSyncManager.forceSync(this)
+
         val channelId = "location_reached_channel"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
@@ -238,6 +274,10 @@ class LocationReachedService : Service() {
                 }
             }
         }
+
+        val activeId = repository.getActiveAlarmId()
+        val alarm = repository.getAlarms().find { it.id == activeId }
+        saveTravelProgress(alarm != null, alarm, progressPercent, etaText)
 
         val notification = buildOngoingNotification(distanceKm, progressPercent, etaText)
         notificationManager.notify(NOTIFICATION_ID, notification)

--- a/app/src/main/java/com/sameerasw/essentials/services/NotificationListener.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/NotificationListener.kt
@@ -23,6 +23,11 @@ import com.sameerasw.essentials.services.tiles.ScreenOffAccessibilityService
 import com.sameerasw.essentials.utils.AppUtil
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUtils
+import java.io.File
+import java.io.FileOutputStream
+import com.sameerasw.essentials.services.widgets.PixelSearchbarWidget
+
+import kotlinx.coroutines.launch
 
 class NotificationListener : NotificationListenerService() {
 
@@ -626,10 +631,44 @@ class NotificationListener : NotificationListenerService() {
                 val metadata = controller.metadata
                 val playbackState = controller.playbackState
 
-                val title = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
-                val artist = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST)
+                val title = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE) ?: ""
+                val artist = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST) ?: ""
                 val isPlaying =
                     playbackState?.state == android.media.session.PlaybackState.STATE_PLAYING
+
+                // Extract and save album art
+                val artwork = metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_ALBUM_ART)
+                    ?: metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_ART)
+                    ?: metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_DISPLAY_ICON)
+
+                val filesDirFile = File(filesDir, "music_artwork.png")
+                if (artwork != null) {
+                    try {
+                        FileOutputStream(filesDirFile).use { out ->
+                            artwork.compress(Bitmap.CompressFormat.PNG, 100, out)
+                        }
+                    } catch (_: Exception) {}
+                } else {
+                    if (filesDirFile.exists()) filesDirFile.delete()
+                }
+
+                // Update settings and trigger Glance widget
+                val settingsRepo = SettingsRepository(this)
+                settingsRepo.setPixelSearchbarMusicTitle(title)
+                settingsRepo.setPixelSearchbarMusicArtist(artist)
+                settingsRepo.setPixelSearchbarMusicPackage(sbn.packageName)
+                settingsRepo.incrementPixelSearchbarWidgetRevision()
+
+                kotlinx.coroutines.MainScope().launch {
+                    try {
+                        val managerGlance = androidx.glance.appwidget.GlanceAppWidgetManager(this@NotificationListener)
+                        val widgetGlance = PixelSearchbarWidget()
+                        val glanceIds = managerGlance.getGlanceIds(PixelSearchbarWidget::class.java)
+                        for (glanceId in glanceIds) {
+                            widgetGlance.update(this@NotificationListener, glanceId)
+                        }
+                    } catch (_: Exception) {}
+                }
 
                 val lastState = lastMediaStates[sbn.packageName]
 

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/AutomationManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/AutomationManager.kt
@@ -112,8 +112,8 @@ object AutomationManager {
                     // Handled by AppFlowHandler
                 }
 
-                Automation.Type.ACTION_SHORTCUT -> {
-                    // Triggered manually via ActionShortcutActivity
+                Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> {
+                    // Triggered manually on tap/click
                 }
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/services/receivers/ShizukuActionReceiver.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/receivers/ShizukuActionReceiver.kt
@@ -1,0 +1,43 @@
+package com.sameerasw.essentials.services.receivers
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.data.repository.SettingsRepository
+
+class ShizukuActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "com.sameerasw.essentials.ACTION_RESTART_SHIZUKU") {
+            val notificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+            notificationManager?.cancel(9001)
+
+            val settingsRepository = SettingsRepository(context)
+            val token = settingsRepository.getShizukuAuthToken()
+
+            if (token.isEmpty()) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.toast_enter_shizuku_token),
+                    Toast.LENGTH_LONG
+                ).show()
+            } else {
+                try {
+                    val shizukuIntent = Intent("moe.shizuku.privileged.api.START").apply {
+                        `package` = "moe.shizuku.privileged.api"
+                        putExtra("auth", token)
+                        addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
+                    }
+                    context.sendBroadcast(shizukuIntent)
+                } catch (e: Exception) {
+                    Log.e("ShizukuActionReceiver", "Failed to restart Shizuku", e)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/MusicBroadcastReceiver.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/MusicBroadcastReceiver.kt
@@ -1,0 +1,79 @@
+package com.sameerasw.essentials.services.widgets
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+
+class MusicBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val settings = SettingsRepository(context)
+        val type = settings.getPixelSearchbarType()
+        if (type != "music") return
+
+        // Update media info from the current active session
+        try {
+            val manager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager ?: return
+            val componentName = android.content.ComponentName(context, com.sameerasw.essentials.services.NotificationListener::class.java)
+            val sessions = manager.getActiveSessions(componentName)
+            val activeSession = sessions?.sortedWith(
+                compareByDescending<MediaController> { 
+                    val state = it.playbackState?.state
+                    state == PlaybackState.STATE_PLAYING || state == PlaybackState.STATE_BUFFERING
+                }.thenByDescending {
+                    val state = it.playbackState?.state
+                    state == PlaybackState.STATE_PAUSED
+                }
+            )?.firstOrNull()
+
+            if (activeSession != null) {
+                val metadata = activeSession.metadata
+                val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
+                val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: ""
+                val packageName = activeSession.packageName
+
+                val artwork = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
+                    ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+                    ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON)
+
+                val filesDirFile = File(context.filesDir, "music_artwork.png")
+                if (artwork != null) {
+                    try {
+                        FileOutputStream(filesDirFile).use { out ->
+                            artwork.compress(Bitmap.CompressFormat.PNG, 100, out)
+                        }
+                    } catch (_: Exception) {}
+                } else {
+                    if (filesDirFile.exists()) filesDirFile.delete()
+                }
+
+                settings.setPixelSearchbarMusicTitle(title)
+                settings.setPixelSearchbarMusicArtist(artist)
+                settings.setPixelSearchbarMusicPackage(packageName)
+                settings.incrementPixelSearchbarWidgetRevision()
+
+                // Trigger immediate Glance widget redraw
+                CoroutineScope(Dispatchers.IO).launch {
+                    runCatching {
+                        val managerGlance = androidx.glance.appwidget.GlanceAppWidgetManager(context)
+                        val widgetGlance = PixelSearchbarWidget()
+                        val glanceIds = managerGlance.getGlanceIds(PixelSearchbarWidget::class.java)
+                        for (glanceId in glanceIds) {
+                            widgetGlance.update(context, glanceId)
+                        }
+                    }
+                }
+            }
+        } catch (_: Exception) {}
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/MusicClickActionCallback.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/MusicClickActionCallback.kt
@@ -1,0 +1,24 @@
+package com.sameerasw.essentials.services.widgets
+
+import android.content.Context
+import android.content.Intent
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import com.sameerasw.essentials.data.repository.SettingsRepository
+
+class MusicClickActionCallback : ActionCallback {
+    override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+        val settings = SettingsRepository(context)
+        val packageName = settings.getPixelSearchbarMusicPackage()
+        if (packageName.isNotEmpty()) {
+            try {
+                val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
+                if (launchIntent != null) {
+                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(launchIntent)
+                }
+            } catch (_: Exception) {}
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -1,0 +1,67 @@
+package com.sameerasw.essentials.services.widgets
+
+import android.content.Context
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.text.FontWeight
+import androidx.glance.text.TextAlign
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class PixelSearchbarWidget : GlanceAppWidget() {
+    override val sizeMode = androidx.glance.appwidget.SizeMode.Exact
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val settingsRepository = SettingsRepository(context)
+
+        provideContent {
+            GlanceTheme {
+                val type = settingsRepository.getPixelSearchbarType()
+
+                when (type) {
+                    "empty" -> {
+                        Box(
+                            modifier = GlanceModifier
+                                .fillMaxSize()
+                                .background(android.graphics.Color.TRANSPARENT)
+                        ) {}
+                    }
+                    else -> { // Default / "date"
+                        val dateStr = SimpleDateFormat("EEEE, MMMM d", Locale.getDefault()).format(Date())
+                        Box(
+                            modifier = GlanceModifier
+                                .fillMaxSize()
+                                .background(android.graphics.Color.TRANSPARENT)
+                                .padding(horizontal = 16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = dateStr,
+                                style = TextStyle(
+                                    color = GlanceTheme.colors.onSurface,
+                                    fontSize = 20.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    textAlign = TextAlign.Center
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -1,12 +1,16 @@
 package com.sameerasw.essentials.services.widgets
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.widget.RemoteViews
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.AndroidRemoteViews
 import androidx.glance.appwidget.provideContent
@@ -14,6 +18,7 @@ import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
@@ -21,12 +26,17 @@ import androidx.glance.text.TextStyle
 import androidx.glance.text.FontWeight
 import androidx.glance.text.TextAlign
 import androidx.glance.appwidget.cornerRadius
+import androidx.glance.unit.ColorProvider
 import com.sameerasw.essentials.data.repository.SettingsRepository
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import androidx.glance.action.clickable
 import androidx.glance.action.actionStartActivity
+import androidx.glance.appwidget.action.actionRunCallback
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class PixelSearchbarWidget : GlanceAppWidget() {
     override val sizeMode = androidx.glance.appwidget.SizeMode.Exact
@@ -39,6 +49,15 @@ class PixelSearchbarWidget : GlanceAppWidget() {
         val paddingV = settingsRepository.getPixelSearchbarWidgetPaddingV().dp
         val revision = settingsRepository.getPixelSearchbarWidgetRevision()
 
+        val musicBitmap = if (type == "music") {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val file = File(context.filesDir, "music_artwork.png")
+                    if (file.exists()) BitmapFactory.decodeFile(file.absolutePath) else null
+                }.getOrNull()
+            }
+        } else null
+
         val globalTapAction = if (tapActionEnabled)
             actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)
         else null
@@ -47,7 +66,7 @@ class PixelSearchbarWidget : GlanceAppWidget() {
             GlanceTheme {
                 val boxModifier = GlanceModifier
                     .fillMaxSize()
-                    .background(android.graphics.Color.TRANSPARENT)
+                    .background(Color.Transparent)
                     .padding(horizontal = paddingH, vertical = paddingV)
                     .then(
                         if (globalTapAction != null) {
@@ -87,6 +106,77 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                                     )
                                 )
                             }
+                        }
+                    }
+
+                    "music" -> {
+                        val title = settingsRepository.getPixelSearchbarMusicTitle()
+                        val artist = settingsRepository.getPixelSearchbarMusicArtist()
+
+                        if (title.isNotEmpty() || artist.isNotEmpty()) {
+                            Box(
+                                modifier = boxModifier
+                                    .cornerRadius(28.dp)
+                                    .background(GlanceTheme.colors.background)
+                                    .clickable(actionRunCallback<MusicClickActionCallback>()),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (musicBitmap != null) {
+                                    Image(
+                                        provider = ImageProvider(musicBitmap),
+                                        contentDescription = null,
+                                        modifier = GlanceModifier.fillMaxSize(),
+                                        contentScale = ContentScale.Crop
+                                    )
+                                    Box(
+                                        modifier = GlanceModifier
+                                            .fillMaxSize()
+                                            .background(Color(0, 0, 0, 120))
+                                    ) {}
+                                }
+
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    modifier = GlanceModifier.padding(horizontal = 16.dp)
+                                ) {
+                                    Text(
+                                        text = title,
+                                        style = TextStyle(
+                                            color = if (musicBitmap != null) {
+                                                ColorProvider(Color.White)
+                                            } else {
+                                                GlanceTheme.colors.onSurface
+                                            },
+                                            fontSize = 18.sp,
+                                            fontWeight = FontWeight.Medium,
+                                            fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                            textAlign = TextAlign.Center
+                                        ),
+                                        maxLines = 1
+                                    )
+                                    if (artist.isNotEmpty()) {
+                                        Text(
+                                            text = artist,
+                                            style = TextStyle(
+                                                color = if (musicBitmap != null) {
+                                                    ColorProvider(Color.LightGray)
+                                                } else {
+                                                    GlanceTheme.colors.onSurfaceVariant
+                                                },
+                                                fontSize = 13.sp,
+                                                fontWeight = FontWeight.Normal,
+                                                fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                                textAlign = TextAlign.Center
+                                            ),
+                                            maxLines = 1
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            Box(
+                                modifier = boxModifier
+                            ) {}
                         }
                     }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -41,7 +41,8 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                         ) {}
                     }
                     else -> { // Default / "date"
-                        val dateStr = SimpleDateFormat("EEEE, MMMM d", Locale.getDefault()).format(Date())
+                        val dateFormat = settingsRepository.getPixelSearchbarDateFormat()
+                        val dateStr = SimpleDateFormat(dateFormat, Locale.getDefault()).format(Date())
                         Box(
                             modifier = GlanceModifier
                                 .fillMaxSize()
@@ -55,6 +56,7 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                                     color = GlanceTheme.colors.onSurface,
                                     fontSize = 20.sp,
                                     fontWeight = FontWeight.Medium,
+                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
                                     textAlign = TextAlign.Center
                                 )
                             )

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -17,6 +17,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.text.FontWeight
 import androidx.glance.text.TextAlign
+import androidx.glance.appwidget.cornerRadius
 import com.sameerasw.essentials.data.repository.SettingsRepository
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -42,6 +43,7 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                     }
                     else -> { // Default / "date"
                         val dateFormat = settingsRepository.getPixelSearchbarDateFormat()
+                        val hasPill = settingsRepository.getPixelSearchbarBackgroundPill()
                         val dateStr = SimpleDateFormat(dateFormat, Locale.getDefault()).format(Date())
                         Box(
                             modifier = GlanceModifier
@@ -50,16 +52,37 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                                 .padding(horizontal = 16.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text(
-                                text = dateStr,
-                                style = TextStyle(
-                                    color = GlanceTheme.colors.onSurface,
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Medium,
-                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
-                                    textAlign = TextAlign.Center
+                            if (hasPill) {
+                                Box(
+                                    modifier = GlanceModifier
+                                        .background(GlanceTheme.colors.background)
+                                        .cornerRadius(28.dp)
+                                        .padding(horizontal = 24.dp, vertical = 12.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = dateStr,
+                                        style = TextStyle(
+                                            color = GlanceTheme.colors.onSecondaryContainer,
+                                            fontSize = 20.sp,
+                                            fontWeight = FontWeight.Medium,
+                                            fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                            textAlign = TextAlign.Center
+                                        )
+                                    )
+                                }
+                            } else {
+                                Text(
+                                    text = dateStr,
+                                    style = TextStyle(
+                                        color = GlanceTheme.colors.onSurface,
+                                        fontSize = 20.sp,
+                                        fontWeight = FontWeight.Medium,
+                                        fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                        textAlign = TextAlign.Center
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -1,21 +1,19 @@
 package com.sameerasw.essentials.services.widgets
 
 import android.content.Context
-import android.graphics.BitmapFactory
+import android.widget.RemoteViews
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
-import androidx.glance.Image
-import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.AndroidRemoteViews
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
-import androidx.glance.layout.ContentScale
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
@@ -24,14 +22,11 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.TextAlign
 import androidx.glance.appwidget.cornerRadius
 import com.sameerasw.essentials.data.repository.SettingsRepository
-import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import androidx.glance.action.clickable
 import androidx.glance.action.actionStartActivity
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class PixelSearchbarWidget : GlanceAppWidget() {
     override val sizeMode = androidx.glance.appwidget.SizeMode.Exact
@@ -39,87 +34,58 @@ class PixelSearchbarWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val settingsRepository = SettingsRepository(context)
         val type = settingsRepository.getPixelSearchbarType()
+        val tapActionEnabled = settingsRepository.getPixelSearchbarTapActionEnabled()
+        val paddingH = settingsRepository.getPixelSearchbarWidgetPaddingH().dp
+        val paddingV = settingsRepository.getPixelSearchbarWidgetPaddingV().dp
+        val revision = settingsRepository.getPixelSearchbarWidgetRevision()
 
-        // Load snapshot bitmap before entering provideContent (IO-safe suspend context)
-        val widgetBitmap = if (type == "widget") {
-            withContext(Dispatchers.IO) {
-                runCatching {
-                    val file = File(context.filesDir, WidgetScraperService.SNAPSHOT_FILE)
-                    if (file.exists()) BitmapFactory.decodeFile(file.absolutePath) else null
-                }.getOrNull()
-            }
-        } else null
+        val globalTapAction = if (tapActionEnabled)
+            actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)
+        else null
 
         provideContent {
             GlanceTheme {
+                val boxModifier = GlanceModifier
+                    .fillMaxSize()
+                    .background(android.graphics.Color.TRANSPARENT)
+                    .padding(horizontal = paddingH, vertical = paddingV)
+                    .then(
+                        if (globalTapAction != null) {
+                            GlanceModifier.clickable(globalTapAction)
+                        } else {
+                            GlanceModifier
+                        }
+                    )
+
                 when (type) {
                     "empty" -> {
                         Box(
-                            modifier = GlanceModifier
-                                .fillMaxSize()
-                                .background(android.graphics.Color.TRANSPARENT)
-                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java))
+                            modifier = boxModifier
                         ) {}
                     }
 
                     "widget" -> {
+                        val remoteViews = WidgetScraperService.currentRemoteViews
                         Box(
-                            modifier = GlanceModifier
-                                .fillMaxSize()
-                                .background(android.graphics.Color.TRANSPARENT)
-                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)),
+                            modifier = boxModifier.cornerRadius(28.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            if (widgetBitmap != null) {
-                                Image(
-                                    provider = ImageProvider(widgetBitmap),
-                                    contentDescription = null,
-                                    modifier = GlanceModifier.fillMaxSize(),
-                                    contentScale = ContentScale.Fit
+                            if (remoteViews != null) {
+                                AndroidRemoteViews(
+                                    remoteViews = remoteViews,
+                                    modifier = GlanceModifier.fillMaxSize()
                                 )
                             } else {
-                                // Fallback text while snapshot is not yet available
-                                val line1 = settingsRepository.getPixelSearchbarScrapedLine1()
-                                val line2 = settingsRepository.getPixelSearchbarScrapedLine2()
-                                if (line1.isEmpty() && line2.isEmpty()) {
-                                    Text(
-                                        text = "—",
-                                        style = TextStyle(
-                                            color = GlanceTheme.colors.onSurface,
-                                            fontSize = 16.sp,
-                                            fontWeight = FontWeight.Medium,
-                                            fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
-                                            textAlign = TextAlign.Center
-                                        )
+                                Text(
+                                    text = "—",
+                                    style = TextStyle(
+                                        color = GlanceTheme.colors.onSurface,
+                                        fontSize = 16.sp,
+                                        fontWeight = FontWeight.Medium,
+                                        fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                        textAlign = TextAlign.Center
                                     )
-                                } else {
-                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        if (line1.isNotEmpty()) {
-                                            Text(
-                                                text = line1,
-                                                style = TextStyle(
-                                                    color = GlanceTheme.colors.onSurface,
-                                                    fontSize = 20.sp,
-                                                    fontWeight = FontWeight.Medium,
-                                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
-                                                    textAlign = TextAlign.Center
-                                                )
-                                            )
-                                        }
-                                        if (line2.isNotEmpty()) {
-                                            Text(
-                                                text = line2,
-                                                style = TextStyle(
-                                                    color = GlanceTheme.colors.onSurfaceVariant,
-                                                    fontSize = 14.sp,
-                                                    fontWeight = FontWeight.Normal,
-                                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
-                                                    textAlign = TextAlign.Center
-                                                )
-                                            )
-                                        }
-                                    }
-                                }
+                                )
                             }
                         }
                     }
@@ -129,11 +95,7 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                         val hasPill = settingsRepository.getPixelSearchbarBackgroundPill()
                         val dateStr = SimpleDateFormat(dateFormat, Locale.getDefault()).format(Date())
                         Box(
-                            modifier = GlanceModifier
-                                .fillMaxSize()
-                                .background(android.graphics.Color.TRANSPARENT)
-                                .padding(horizontal = 16.dp)
-                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)),
+                            modifier = boxModifier,
                             contentAlignment = Alignment.Center
                         ) {
                             if (hasPill) {

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -1,16 +1,21 @@
 package com.sameerasw.essentials.services.widgets
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
@@ -19,22 +24,34 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.TextAlign
 import androidx.glance.appwidget.cornerRadius
 import com.sameerasw.essentials.data.repository.SettingsRepository
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import androidx.glance.action.clickable
 import androidx.glance.action.actionStartActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class PixelSearchbarWidget : GlanceAppWidget() {
     override val sizeMode = androidx.glance.appwidget.SizeMode.Exact
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val settingsRepository = SettingsRepository(context)
+        val type = settingsRepository.getPixelSearchbarType()
+
+        // Load snapshot bitmap before entering provideContent (IO-safe suspend context)
+        val widgetBitmap = if (type == "widget") {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val file = File(context.filesDir, WidgetScraperService.SNAPSHOT_FILE)
+                    if (file.exists()) BitmapFactory.decodeFile(file.absolutePath) else null
+                }.getOrNull()
+            }
+        } else null
 
         provideContent {
             GlanceTheme {
-                val type = settingsRepository.getPixelSearchbarType()
-
                 when (type) {
                     "empty" -> {
                         Box(
@@ -44,7 +61,70 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                                 .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java))
                         ) {}
                     }
-                    else -> { // Default / "date"
+
+                    "widget" -> {
+                        Box(
+                            modifier = GlanceModifier
+                                .fillMaxSize()
+                                .background(android.graphics.Color.TRANSPARENT)
+                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (widgetBitmap != null) {
+                                Image(
+                                    provider = ImageProvider(widgetBitmap),
+                                    contentDescription = null,
+                                    modifier = GlanceModifier.fillMaxSize(),
+                                    contentScale = ContentScale.Fit
+                                )
+                            } else {
+                                // Fallback text while snapshot is not yet available
+                                val line1 = settingsRepository.getPixelSearchbarScrapedLine1()
+                                val line2 = settingsRepository.getPixelSearchbarScrapedLine2()
+                                if (line1.isEmpty() && line2.isEmpty()) {
+                                    Text(
+                                        text = "—",
+                                        style = TextStyle(
+                                            color = GlanceTheme.colors.onSurface,
+                                            fontSize = 16.sp,
+                                            fontWeight = FontWeight.Medium,
+                                            fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                            textAlign = TextAlign.Center
+                                        )
+                                    )
+                                } else {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                        if (line1.isNotEmpty()) {
+                                            Text(
+                                                text = line1,
+                                                style = TextStyle(
+                                                    color = GlanceTheme.colors.onSurface,
+                                                    fontSize = 20.sp,
+                                                    fontWeight = FontWeight.Medium,
+                                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                                    textAlign = TextAlign.Center
+                                                )
+                                            )
+                                        }
+                                        if (line2.isNotEmpty()) {
+                                            Text(
+                                                text = line2,
+                                                style = TextStyle(
+                                                    color = GlanceTheme.colors.onSurfaceVariant,
+                                                    fontSize = 14.sp,
+                                                    fontWeight = FontWeight.Normal,
+                                                    fontFamily = androidx.glance.text.FontFamily("google_sans_flex_round"),
+                                                    textAlign = TextAlign.Center
+                                                )
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    else -> { // "date" (default)
                         val dateFormat = settingsRepository.getPixelSearchbarDateFormat()
                         val hasPill = settingsRepository.getPixelSearchbarBackgroundPill()
                         val dateStr = SimpleDateFormat(dateFormat, Locale.getDefault()).format(Date())

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidget.kt
@@ -22,6 +22,8 @@ import com.sameerasw.essentials.data.repository.SettingsRepository
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import androidx.glance.action.clickable
+import androidx.glance.action.actionStartActivity
 
 class PixelSearchbarWidget : GlanceAppWidget() {
     override val sizeMode = androidx.glance.appwidget.SizeMode.Exact
@@ -39,6 +41,7 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                             modifier = GlanceModifier
                                 .fillMaxSize()
                                 .background(android.graphics.Color.TRANSPARENT)
+                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java))
                         ) {}
                     }
                     else -> { // Default / "date"
@@ -49,7 +52,8 @@ class PixelSearchbarWidget : GlanceAppWidget() {
                             modifier = GlanceModifier
                                 .fillMaxSize()
                                 .background(android.graphics.Color.TRANSPARENT)
-                                .padding(horizontal = 16.dp),
+                                .padding(horizontal = 16.dp)
+                                .clickable(actionStartActivity(com.sameerasw.essentials.ui.activities.PixelSearchbarTapActivity::class.java)),
                             contentAlignment = Alignment.Center
                         ) {
                             if (hasPill) {

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidgetReceiver.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/PixelSearchbarWidgetReceiver.kt
@@ -1,0 +1,40 @@
+package com.sameerasw.essentials.services.widgets
+
+import android.content.Context
+import android.content.Intent
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import kotlinx.coroutines.launch
+
+class PixelSearchbarWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = PixelSearchbarWidget()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+
+        val action = intent.action
+        if (action == Intent.ACTION_CONFIGURATION_CHANGED ||
+            action == android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE
+        ) {
+            kotlinx.coroutines.MainScope().launch {
+                try {
+                    val glanceAppWidgetManager = androidx.glance.appwidget.GlanceAppWidgetManager(context)
+                    if (action == Intent.ACTION_CONFIGURATION_CHANGED) {
+                        kotlinx.coroutines.delay(500)
+                    }
+
+                    val glanceIds = glanceAppWidgetManager.getGlanceIds(PixelSearchbarWidget::class.java)
+                    glanceIds.forEach { glanceId ->
+                        glanceAppWidget.update(context, glanceId)
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.e(
+                        "PixelSearchbarWidget",
+                        "Error updating searchbar widget on broadcast",
+                        e
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
@@ -5,8 +5,14 @@ import android.appwidget.AppWidgetHost
 import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -15,11 +21,14 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.RemoteViews
 import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.services.NotificationListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
 
 class WidgetScraperService : Service() {
 
@@ -90,17 +99,45 @@ class WidgetScraperService : Service() {
     private var appWidgetHost: ScrapingWidgetHost? = null
     private val handler = Handler(Looper.getMainLooper())
 
+    // Music playback tracking components
+    private var mediaSessionManager: MediaSessionManager? = null
+    private var currentController: MediaController? = null
+    private var musicBroadcastReceiver: MusicBroadcastReceiver? = null
+
+    private val mediaCallback = object : MediaController.Callback() {
+        override fun onMetadataChanged(metadata: MediaMetadata?) {
+            updateMediaMetadata(currentController)
+        }
+        override fun onPlaybackStateChanged(state: PlaybackState?) {
+            updateMediaMetadata(currentController)
+        }
+    }
+
+    private val activeSessionsListener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+        updateActiveSession(controllers)
+    }
+
     override fun onCreate() {
         super.onCreate()
         settingsRepository = SettingsRepository(this)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        bindAndListen()
+        val type = settingsRepository.getPixelSearchbarType()
+        if (type == "widget") {
+            bindAndListenWidget()
+        } else if (type == "music") {
+            listenToMusicSession()
+        } else {
+            stopSelf()
+        }
         return START_STICKY
     }
 
-    private fun bindAndListen() {
+    private fun bindAndListenWidget() {
+        // Clear any media components
+        cleanupMediaListener()
+
         val widgetId = settingsRepository.getPixelSearchbarWidgetId()
         if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) { stopSelf(); return }
 
@@ -112,6 +149,97 @@ class WidgetScraperService : Service() {
         val info = awm.getAppWidgetInfo(widgetId) ?: run { stopSelf(); return }
 
         handler.post { host.createView(this, widgetId, info) }
+    }
+
+    private fun listenToMusicSession() {
+        // Clear any widget hosting components
+        cleanupWidgetListener()
+
+        try {
+            val manager = getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
+            mediaSessionManager = manager
+            if (manager != null) {
+                val componentName = ComponentName(this, NotificationListener::class.java)
+                val initialSessions = manager.getActiveSessions(componentName)
+                updateActiveSession(initialSessions)
+                manager.addOnActiveSessionsChangedListener(activeSessionsListener, componentName)
+            }
+        } catch (_: Exception) {}
+
+        // Dynamically register the MusicBroadcastReceiver
+        try {
+            if (musicBroadcastReceiver == null) {
+                val receiver = MusicBroadcastReceiver()
+                musicBroadcastReceiver = receiver
+                val filter = android.content.IntentFilter().apply {
+                    addAction("com.android.music.metadatachanged")
+                    addAction("com.android.music.playstatechanged")
+                    addAction("com.android.music.playbackcomplete")
+                    addAction("com.android.music.queuechanged")
+                    addAction("com.spotify.music.metadatachanged")
+                    addAction("com.spotify.music.playbackstatechanged")
+                    addAction("com.htc.music.metadatachanged")
+                    addAction("com.real.music.metadatachanged")
+                    addAction("com.sonyericsson.music.metadatachanged")
+                    addAction("com.sec.android.app.music.metadatachanged")
+                    addAction("com.sec.android.app.music.playstatechanged")
+                    addAction("com.miui.player.metadatachanged")
+                }
+                androidx.core.content.ContextCompat.registerReceiver(
+                    this,
+                    receiver,
+                    filter,
+                    androidx.core.content.ContextCompat.RECEIVER_EXPORTED
+                )
+            }
+        } catch (_: Exception) {}
+    }
+
+    private fun updateActiveSession(controllers: List<MediaController>?) {
+        val active = controllers?.sortedWith(
+            compareByDescending<MediaController> { 
+                val state = it.playbackState?.state
+                state == PlaybackState.STATE_PLAYING || state == PlaybackState.STATE_BUFFERING
+            }.thenByDescending {
+                val state = it.playbackState?.state
+                state == PlaybackState.STATE_PAUSED
+            }
+        )?.firstOrNull()
+
+        if (active != currentController) {
+            currentController?.unregisterCallback(mediaCallback)
+            currentController = active
+            active?.registerCallback(mediaCallback)
+            updateMediaMetadata(active)
+        }
+    }
+
+    private fun updateMediaMetadata(controller: MediaController?) {
+        if (controller == null) return
+        val metadata = controller.metadata
+        val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
+        val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: ""
+        val packageName = controller.packageName
+
+        val artwork = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
+            ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+            ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON)
+
+        val filesDirFile = File(filesDir, "music_artwork.png")
+        if (artwork != null) {
+            try {
+                FileOutputStream(filesDirFile).use { out ->
+                    artwork.compress(Bitmap.CompressFormat.PNG, 100, out)
+                }
+            } catch (_: Exception) {}
+        } else {
+            if (filesDirFile.exists()) filesDirFile.delete()
+        }
+
+        settingsRepository.setPixelSearchbarMusicTitle(title)
+        settingsRepository.setPixelSearchbarMusicArtist(artist)
+        settingsRepository.setPixelSearchbarMusicPackage(packageName)
+        notifyWidgetChanged()
     }
 
     private fun onRemoteViewsReceived(remoteViews: RemoteViews) {
@@ -136,14 +264,36 @@ class WidgetScraperService : Service() {
                     for (glanceId in glanceIds) widget.update(this@WidgetScraperService, glanceId)
                 }
             }
-        }, 100L) // 100ms debounce window
+        }, 100L)
+    }
+
+    private fun cleanupWidgetListener() {
+        appWidgetHost?.stopListening()
+        appWidgetHost = null
+        currentRemoteViews = null
+    }
+
+    private fun cleanupMediaListener() {
+        try {
+            mediaSessionManager?.removeOnActiveSessionsChangedListener(activeSessionsListener)
+        } catch (_: Exception) {}
+        currentController?.unregisterCallback(mediaCallback)
+        currentController = null
+        mediaSessionManager = null
+
+        // Dynamic unregistration
+        try {
+            musicBroadcastReceiver?.let {
+                unregisterReceiver(it)
+            }
+            musicBroadcastReceiver = null
+        } catch (_: Exception) {}
     }
 
     override fun onDestroy() {
         handler.removeCallbacksAndMessages(null)
-        appWidgetHost?.stopListening()
-        appWidgetHost = null
-        currentRemoteViews = null
+        cleanupWidgetListener()
+        cleanupMediaListener()
         serviceScope.cancel()
         super.onDestroy()
     }

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
@@ -1,0 +1,166 @@
+package com.sameerasw.essentials.services.widgets
+
+import android.app.Service
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetHostView
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.RemoteViews
+import android.widget.TextView
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+
+class WidgetScraperService : Service() {
+
+    companion object {
+        const val HOST_ID = 1025
+        const val SNAPSHOT_FILE = "widget_scraper_snapshot.png"
+
+        fun start(context: Context) {
+            context.startService(Intent(context, WidgetScraperService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, WidgetScraperService::class.java))
+        }
+
+        /** Walk an inflated view tree to collect all non-empty TextView text values. */
+        fun collectTexts(view: View, out: MutableList<String>) {
+            when (view) {
+                is TextView -> {
+                    val t = view.text?.toString()?.trim() ?: ""
+                    if (t.isNotEmpty()) out.add(t)
+                }
+                is ViewGroup -> for (i in 0 until view.childCount) collectTexts(view.getChildAt(i), out)
+            }
+        }
+    }
+
+    /**
+     * Intercepts RemoteViews updates from the bound widget provider.
+     */
+    private inner class ScrapingHostView(context: Context) : AppWidgetHostView(context) {
+        override fun updateAppWidget(remoteViews: RemoteViews?) {
+            super.updateAppWidget(remoteViews)
+            if (remoteViews != null) onRemoteViewsReceived(remoteViews)
+        }
+    }
+
+    private inner class ScrapingWidgetHost(context: Context, hostId: Int) : AppWidgetHost(context, hostId) {
+        override fun onCreateView(
+            context: Context,
+            appWidgetId: Int,
+            appWidget: AppWidgetProviderInfo?
+        ): AppWidgetHostView = ScrapingHostView(context)
+    }
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var settingsRepository: SettingsRepository
+    private var appWidgetHost: ScrapingWidgetHost? = null
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreate() {
+        super.onCreate()
+        settingsRepository = SettingsRepository(this)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        bindAndListen()
+        return START_STICKY
+    }
+
+    private fun bindAndListen() {
+        val widgetId = settingsRepository.getPixelSearchbarWidgetId()
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) { stopSelf(); return }
+
+        val awm = AppWidgetManager.getInstance(this)
+        val host = ScrapingWidgetHost(this, HOST_ID)
+        appWidgetHost = host
+        host.startListening()
+
+        val info = awm.getAppWidgetInfo(widgetId) ?: run { stopSelf(); return }
+
+        // createView on main thread wires up update callbacks
+        handler.post { host.createView(this, widgetId, info) }
+    }
+
+    /**
+     * Called on the main thread whenever the bound widget provider pushes new RemoteViews.
+     * Inflates the RemoteViews into a real view tree, measures and lays it out at the device
+     * width, draws it to a Bitmap, saves as PNG, extracts text, then updates the Glance widget.
+     */
+    private fun onRemoteViewsReceived(remoteViews: RemoteViews) {
+        try {
+            val dm = resources.displayMetrics
+            val widthPx = dm.widthPixels
+            // Use the widget info's minHeight as the render height, with a sensible default
+            val heightPx = (80 * dm.density).toInt()
+
+            // Inflate RemoteViews into a real view hierarchy using the widget's own resources
+            val parent = FrameLayout(this)
+            val inflated = remoteViews.apply(this, parent)
+
+            // Measure + layout
+            val wSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
+            val hSpec = View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
+            inflated.measure(wSpec, hSpec)
+            inflated.layout(0, 0, inflated.measuredWidth, inflated.measuredHeight)
+
+            // Render to Bitmap (same as Smartspacer's headless render approach)
+            val bitmap = Bitmap.createBitmap(inflated.measuredWidth, inflated.measuredHeight, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(bitmap)
+            inflated.draw(canvas)
+
+            // Save PNG to filesDir (persists across restarts)
+            val snapshotFile = File(filesDir, SNAPSHOT_FILE)
+            FileOutputStream(snapshotFile).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            bitmap.recycle()
+
+            // Extract text as a fallback / supplementary metadata
+            val texts = mutableListOf<String>()
+            collectTexts(inflated, texts)
+            val sorted = texts.filter { it.length > 1 }.sortedByDescending { it.length }
+            settingsRepository.setPixelSearchbarScrapedLine1(sorted.getOrElse(0) { "" })
+            settingsRepository.setPixelSearchbarScrapedLine2(sorted.getOrElse(1) { "" })
+
+        } catch (_: Exception) {}
+
+        // Push Glance widget refresh on IO thread
+        serviceScope.launch {
+            runCatching {
+                val manager = androidx.glance.appwidget.GlanceAppWidgetManager(this@WidgetScraperService)
+                val widget = PixelSearchbarWidget()
+                val glanceIds = manager.getGlanceIds(PixelSearchbarWidget::class.java)
+                for (glanceId in glanceIds) widget.update(this@WidgetScraperService, glanceId)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacksAndMessages(null)
+        appWidgetHost?.stopListening()
+        appWidgetHost = null
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/widgets/WidgetScraperService.kt
@@ -7,58 +7,57 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
+import android.view.ViewTreeObserver
 import android.widget.RemoteViews
-import android.widget.TextView
 import com.sameerasw.essentials.data.repository.SettingsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.io.File
-import java.io.FileOutputStream
 
 class WidgetScraperService : Service() {
 
-    companion object {
-        const val HOST_ID = 1025
-        const val SNAPSHOT_FILE = "widget_scraper_snapshot.png"
-
-        fun start(context: Context) {
-            context.startService(Intent(context, WidgetScraperService::class.java))
-        }
-
-        fun stop(context: Context) {
-            context.stopService(Intent(context, WidgetScraperService::class.java))
-        }
-
-        /** Walk an inflated view tree to collect all non-empty TextView text values. */
-        fun collectTexts(view: View, out: MutableList<String>) {
-            when (view) {
-                is TextView -> {
-                    val t = view.text?.toString()?.trim() ?: ""
-                    if (t.isNotEmpty()) out.add(t)
-                }
-                is ViewGroup -> for (i in 0 until view.childCount) collectTexts(view.getChildAt(i), out)
-            }
-        }
-    }
-
-    /**
-     * Intercepts RemoteViews updates from the bound widget provider.
-     */
     private inner class ScrapingHostView(context: Context) : AppWidgetHostView(context) {
+        
+        private val drawListener = ViewTreeObserver.OnDrawListener {
+            notifyWidgetChanged()
+        }
+
+        private val layoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+            notifyWidgetChanged()
+        }
+
         override fun updateAppWidget(remoteViews: RemoteViews?) {
             super.updateAppWidget(remoteViews)
             if (remoteViews != null) onRemoteViewsReceived(remoteViews)
+        }
+
+        override fun onAttachedToWindow() {
+            super.onAttachedToWindow()
+            viewTreeObserver.addOnDrawListener(drawListener)
+            viewTreeObserver.addOnGlobalLayoutListener(layoutListener)
+            setOnHierarchyChangeListener(object : OnHierarchyChangeListener {
+                override fun onChildViewAdded(parent: View?, child: View?) {
+                    notifyWidgetChanged()
+                }
+
+                override fun onChildViewRemoved(parent: View?, child: View?) {
+                    notifyWidgetChanged()
+                }
+            })
+        }
+
+        override fun onDetachedFromWindow() {
+            viewTreeObserver.removeOnDrawListener(drawListener)
+            viewTreeObserver.removeOnGlobalLayoutListener(layoutListener)
+            setOnHierarchyChangeListener(null)
+            super.onDetachedFromWindow()
         }
     }
 
@@ -68,6 +67,22 @@ class WidgetScraperService : Service() {
             appWidgetId: Int,
             appWidget: AppWidgetProviderInfo?
         ): AppWidgetHostView = ScrapingHostView(context)
+    }
+
+    companion object {
+        const val HOST_ID = 1025
+
+        @Volatile
+        var currentRemoteViews: RemoteViews? = null
+            private set
+
+        fun start(context: Context) {
+            context.startService(Intent(context, WidgetScraperService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, WidgetScraperService::class.java))
+        }
     }
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -96,68 +111,39 @@ class WidgetScraperService : Service() {
 
         val info = awm.getAppWidgetInfo(widgetId) ?: run { stopSelf(); return }
 
-        // createView on main thread wires up update callbacks
         handler.post { host.createView(this, widgetId, info) }
     }
 
-    /**
-     * Called on the main thread whenever the bound widget provider pushes new RemoteViews.
-     * Inflates the RemoteViews into a real view tree, measures and lays it out at the device
-     * width, draws it to a Bitmap, saves as PNG, extracts text, then updates the Glance widget.
-     */
     private fun onRemoteViewsReceived(remoteViews: RemoteViews) {
-        try {
-            val dm = resources.displayMetrics
-            val widthPx = dm.widthPixels
-            // Use the widget info's minHeight as the render height, with a sensible default
-            val heightPx = (80 * dm.density).toInt()
+        currentRemoteViews = remoteViews
+        notifyWidgetChanged()
+    }
 
-            // Inflate RemoteViews into a real view hierarchy using the widget's own resources
-            val parent = FrameLayout(this)
-            val inflated = remoteViews.apply(this, parent)
+    private var updatePending = false
+    private fun notifyWidgetChanged() {
+        if (updatePending) return
+        updatePending = true
+        
+        handler.postDelayed({
+            updatePending = false
+            settingsRepository.incrementPixelSearchbarWidgetRevision()
 
-            // Measure + layout
-            val wSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
-            val hSpec = View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
-            inflated.measure(wSpec, hSpec)
-            inflated.layout(0, 0, inflated.measuredWidth, inflated.measuredHeight)
-
-            // Render to Bitmap (same as Smartspacer's headless render approach)
-            val bitmap = Bitmap.createBitmap(inflated.measuredWidth, inflated.measuredHeight, Bitmap.Config.ARGB_8888)
-            val canvas = Canvas(bitmap)
-            inflated.draw(canvas)
-
-            // Save PNG to filesDir (persists across restarts)
-            val snapshotFile = File(filesDir, SNAPSHOT_FILE)
-            FileOutputStream(snapshotFile).use { out ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            serviceScope.launch {
+                runCatching {
+                    val manager = androidx.glance.appwidget.GlanceAppWidgetManager(this@WidgetScraperService)
+                    val widget = PixelSearchbarWidget()
+                    val glanceIds = manager.getGlanceIds(PixelSearchbarWidget::class.java)
+                    for (glanceId in glanceIds) widget.update(this@WidgetScraperService, glanceId)
+                }
             }
-            bitmap.recycle()
-
-            // Extract text as a fallback / supplementary metadata
-            val texts = mutableListOf<String>()
-            collectTexts(inflated, texts)
-            val sorted = texts.filter { it.length > 1 }.sortedByDescending { it.length }
-            settingsRepository.setPixelSearchbarScrapedLine1(sorted.getOrElse(0) { "" })
-            settingsRepository.setPixelSearchbarScrapedLine2(sorted.getOrElse(1) { "" })
-
-        } catch (_: Exception) {}
-
-        // Push Glance widget refresh on IO thread
-        serviceScope.launch {
-            runCatching {
-                val manager = androidx.glance.appwidget.GlanceAppWidgetManager(this@WidgetScraperService)
-                val widget = PixelSearchbarWidget()
-                val glanceIds = manager.getGlanceIds(PixelSearchbarWidget::class.java)
-                for (glanceId in glanceIds) widget.update(this@WidgetScraperService, glanceId)
-            }
-        }
+        }, 100L) // 100ms debounce window
     }
 
     override fun onDestroy() {
         handler.removeCallbacksAndMessages(null)
         appWidgetHost?.stopListening()
         appWidgetHost = null
+        currentRemoteViews = null
         serviceScope.cancel()
         super.onDestroy()
     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/AutomationEditorActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/AutomationEditorActivity.kt
@@ -126,6 +126,7 @@ class AutomationEditorActivity : ComponentActivity() {
         val titleRes = when (automationType) {
             Automation.Type.TRIGGER -> if (isEditMode) R.string.diy_editor_edit_title else R.string.diy_editor_new_title
             Automation.Type.ACTION_SHORTCUT -> if (isEditMode) R.string.diy_editor_edit_title else R.string.diy_editor_new_title
+            Automation.Type.PIXEL_SEARCHBAR -> if (isEditMode) R.string.diy_editor_edit_title else R.string.diy_editor_new_title
             Automation.Type.STATE -> if (isEditMode) R.string.diy_editor_edit_title else R.string.diy_editor_new_title
             Automation.Type.APP -> if (isEditMode) R.string.diy_editor_edit_title else R.string.diy_create_app_title
         }
@@ -231,7 +232,7 @@ class AutomationEditorActivity : ComponentActivity() {
 
                 val isValid = when (automationType) {
                     Automation.Type.TRIGGER -> selectedTrigger != null && selectedAction != null
-                    Automation.Type.ACTION_SHORTCUT -> selectedAction != null
+                    Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction != null
                     Automation.Type.STATE -> selectedState != null && (selectedInAction != null || selectedOutAction != null)
                     Automation.Type.APP -> selectedApps.isNotEmpty() && (selectedInAction != null || selectedOutAction != null)
                 }
@@ -434,7 +435,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                                 }
                                             }
                                         }
-                                    } else if (automationType == Automation.Type.ACTION_SHORTCUT) {
+                                    } else if (automationType == Automation.Type.ACTION_SHORTCUT || automationType == Automation.Type.PIXEL_SEARCHBAR) {
                                         Column(
                                             modifier = Modifier
                                                 .fillMaxSize()
@@ -451,9 +452,19 @@ class AutomationEditorActivity : ComponentActivity() {
                                             )
 
                                             RoundedCardContainer(spacing = 2.dp) {
+                                                val editorTitle = if (automationType == Automation.Type.PIXEL_SEARCHBAR) {
+                                                    stringResource(R.string.diy_create_pixel_searchbar_title)
+                                                } else {
+                                                    stringResource(R.string.diy_create_action_shortcut_title)
+                                                }
+                                                val editorIcon = if (automationType == Automation.Type.PIXEL_SEARCHBAR) {
+                                                    R.drawable.rounded_search_24
+                                                } else {
+                                                    R.drawable.rounded_rocket_launch_24
+                                                }
                                                 EditorActionItem(
-                                                    title = stringResource(R.string.diy_create_action_shortcut_title),
-                                                    iconRes = R.drawable.rounded_rocket_launch_24,
+                                                    title = editorTitle,
+                                                    iconRes = editorIcon,
                                                     isSelected = true,
                                                     isConfigurable = false,
                                                     onClick = {}
@@ -605,7 +616,7 @@ class AutomationEditorActivity : ComponentActivity() {
 
                                             val currentSelection = when (automationType) {
                                                 Automation.Type.TRIGGER -> selectedAction
-                                                Automation.Type.ACTION_SHORTCUT -> selectedAction
+                                                Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction
                                                 Automation.Type.STATE -> if (selectedActionTab == 0) selectedInAction else selectedOutAction
                                                 Automation.Type.APP -> if (selectedActionTab == 0) selectedInAction else selectedOutAction
                                             }
@@ -619,7 +630,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                                     when (automationType) {
                                                         Automation.Type.TRIGGER -> selectedAction =
                                                             null
-                                                        Automation.Type.ACTION_SHORTCUT -> selectedAction =
+                                                        Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction =
                                                             null
 
                                                         Automation.Type.STATE, Automation.Type.APP -> {
@@ -645,7 +656,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                                         when (automationType) {
                                                             Automation.Type.TRIGGER -> selectedAction =
                                                                 resolvedAction
-                                                            Automation.Type.ACTION_SHORTCUT -> selectedAction =
+                                                            Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction =
                                                                 resolvedAction
 
                                                             Automation.Type.STATE, Automation.Type.APP -> {
@@ -712,9 +723,9 @@ class AutomationEditorActivity : ComponentActivity() {
                                 onSave = { newAction ->
                                     showDimSettings = false
                                     // Update the selection with configured action
-                                    when (automationType) {
+                                                                    when (automationType) {
                                         Automation.Type.TRIGGER -> selectedAction = newAction
-                                        Automation.Type.ACTION_SHORTCUT -> selectedAction = newAction
+                                        Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction = newAction
                                         Automation.Type.STATE, Automation.Type.APP -> {
                                             if (selectedActionTab == 0) selectedInAction = newAction
                                             else selectedOutAction = newAction
@@ -733,7 +744,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                     showScreenOffSettings = false
                                     when (automationType) {
                                         Automation.Type.TRIGGER -> selectedAction = newAction
-                                        Automation.Type.ACTION_SHORTCUT -> selectedAction = newAction
+                                        Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction = newAction
                                         Automation.Type.STATE, Automation.Type.APP -> {
                                             if (selectedActionTab == 0) selectedInAction = newAction
                                             else selectedOutAction = newAction
@@ -752,7 +763,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                     showDeviceEffectsSettings = false
                                     when (automationType) {
                                         Automation.Type.TRIGGER -> selectedAction = newAction
-                                        Automation.Type.ACTION_SHORTCUT -> selectedAction = newAction
+                                        Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction = newAction
                                         Automation.Type.STATE, Automation.Type.APP -> {
                                             if (selectedActionTab == 0) selectedInAction = newAction
                                             else selectedOutAction = newAction
@@ -771,7 +782,7 @@ class AutomationEditorActivity : ComponentActivity() {
                                     showSoundModeSettings = false
                                     when (automationType) {
                                         Automation.Type.TRIGGER -> selectedAction = newAction
-                                        Automation.Type.ACTION_SHORTCUT -> selectedAction = newAction
+                                        Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction = newAction
                                         Automation.Type.STATE, Automation.Type.APP -> {
                                             if (selectedActionTab == 0) selectedInAction = newAction
                                             else selectedOutAction = newAction
@@ -824,11 +835,11 @@ class AutomationEditorActivity : ComponentActivity() {
                                         if (isEditMode) DIYRepository.updateAutomation(newAutomation) else DIYRepository.addAutomation(
                                             newAutomation
                                         )
-                                    } else if (automationType == Automation.Type.ACTION_SHORTCUT) {
+                                    } else if (automationType == Automation.Type.ACTION_SHORTCUT || automationType == Automation.Type.PIXEL_SEARCHBAR) {
                                         val newAutomation = Automation(
                                             id = if (isEditMode) existingAutomation.id else java.util.UUID.randomUUID()
                                                 .toString(),
-                                            type = Automation.Type.ACTION_SHORTCUT,
+                                            type = automationType,
                                             actions = listOfNotNull(selectedAction)
                                         )
                                         if (isEditMode) DIYRepository.updateAutomation(newAutomation) else DIYRepository.addAutomation(

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -43,6 +43,11 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.RadioButton
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sameerasw.essentials.R
@@ -51,6 +56,16 @@ import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.viewmodels.MainViewModel
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import com.sameerasw.essentials.domain.model.Feature
+import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
+import android.content.Context
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.foundation.layout.navigationBars
+import com.sameerasw.essentials.ui.modifiers.BlurDirection
+import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 
 class PixelSearchbarSettingsActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -64,38 +79,95 @@ class PixelSearchbarSettingsActivity : ComponentActivity() {
             remember(context) { viewModel.check(context) }
 
             val isPitchBlackThemeEnabled by viewModel.isPitchBlackThemeEnabled
+            var showHelpSheet by remember { mutableStateOf(false) }
+
+            val pixelSearchbarFeature = remember {
+                object : Feature(
+                    id = "Pixel Searchbar",
+                    title = R.string.pixel_searchbar_settings_title,
+                    iconRes = R.drawable.rounded_search_24,
+                    category = R.string.cat_display,
+                    description = R.string.feat_pixel_searchbar_desc,
+                    aboutDescription = R.string.about_desc_pixel_searchbar,
+                    permissionKeys = listOf("WRITE_SECURE_SETTINGS"),
+                    showToggle = true,
+                    hasMoreSettings = true
+                ) {
+                    override fun isEnabled(viewModel: MainViewModel) = viewModel.isPixelSearchbarEnabled.value
+                    override fun onToggle(viewModel: MainViewModel, context: Context, enabled: Boolean) {
+                        viewModel.setPixelSearchbarEnabled(enabled, context)
+                    }
+                }
+            }
+
+            val isBlurEnabled by viewModel.isBlurEnabled
 
             EssentialsTheme(pitchBlackTheme = isPitchBlackThemeEnabled) {
-                val statusBarHeight =
-                    WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceContainer)
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                    ) {
-                        Spacer(modifier = Modifier.height(statusBarHeight))
-
-                        PixelSearchbarSettingsUI(
-                            viewModel = viewModel,
-                            modifier = Modifier.padding(top = 16.dp)
-                        )
-
-                        Spacer(modifier = Modifier.height(150.dp))
+                Scaffold(
+                    contentWindowInsets = WindowInsets(0, 0, 0, 0),
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                ) { innerPadding ->
+                    val density = LocalDensity.current
+                    val statusBarHeightPx = with(density) {
+                        WindowInsets.statusBars.asPaddingValues().calculateTopPadding().toPx()
                     }
 
-                    EssentialsFloatingToolbar(
-                        title = stringResource(R.string.pixel_searchbar_settings_title),
-                        onBackClick = { finish() },
+                    Box(
                         modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .zIndex(1f)
-                    )
+                            .fillMaxSize()
+                            .progressiveBlur(
+                                blurRadius = if (isBlurEnabled) 40f else 0f,
+                                height = statusBarHeightPx * 1.15f,
+                                direction = BlurDirection.TOP
+                            )
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .progressiveBlur(
+                                    blurRadius = if (isBlurEnabled) 40f else 0f,
+                                    height = with(density) { 150.dp.toPx() },
+                                    direction = BlurDirection.BOTTOM
+                                )
+                                .verticalScroll(rememberScrollState())
+                        ) {
+                            Spacer(
+                                modifier = Modifier.height(
+                                    WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+                                )
+                            )
+
+                            PixelSearchbarSettingsUI(
+                                viewModel = viewModel,
+                                modifier = Modifier.padding(top = 16.dp)
+                            )
+
+                            Spacer(
+                                modifier = Modifier.height(
+                                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + 150.dp
+                                )
+                            )
+                        }
+
+                        EssentialsFloatingToolbar(
+                            title = stringResource(R.string.pixel_searchbar_settings_title),
+                            onBackClick = { finish() },
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .zIndex(1f),
+                            onHelpClick = {
+                                showHelpSheet = true
+                            }
+                        )
+
+                        if (showHelpSheet) {
+                            FeatureHelpBottomSheet(
+                                onDismissRequest = { showHelpSheet = false },
+                                feature = pixelSearchbarFeature,
+                                viewModel = viewModel
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -197,6 +269,81 @@ fun PixelSearchbarSettingsUI(
                                 style = MaterialTheme.typography.labelLarge,
                                 fontWeight = if (isChecked) FontWeight.Bold else FontWeight.Normal,
                                 maxLines = 1
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = currentType == "date",
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            val currentDateFormat = viewModel.pixelSearchbarDateFormat.value
+            val dateFormats = listOf(
+                "EEEE, MMMM d",
+                "EEEE, MMM d",
+                "EEE, MMM d",
+                "EEEE, d MMMM",
+                "d MMMM",
+                "MMMM d",
+                "EEE, d MMM",
+                "yyyy-MM-dd",
+                "dd/MM/yyyy"
+            )
+            val currentDate = remember { java.util.Date() }
+            val googleSansFlexRound = remember { FontFamily(Font(R.font.google_sans_flex_round)) }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "Date Format",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                RoundedCardContainer(spacing = 2.dp) {
+                    dateFormats.forEach { format ->
+                        val isSelected = currentDateFormat == format
+                        val formattedDate = remember(format, currentDate) {
+                            try {
+                                java.text.SimpleDateFormat(format, java.util.Locale.getDefault()).format(currentDate)
+                            } catch (e: Exception) {
+                                format
+                            }
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.surfaceBright)
+                                .clickable {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    viewModel.setPixelSearchbarDateFormat(format, context)
+                                }
+                                .padding(horizontal = 16.dp, vertical = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = isSelected,
+                                onClick = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    viewModel.setPixelSearchbarDateFormat(format, context)
+                                }
+                            )
+                            Text(
+                                text = formattedDate,
+                                style = MaterialTheme.typography.bodyLarge.copy(
+                                    fontFamily = googleSansFlexRound
+                                ),
+                                modifier = Modifier.padding(start = 16.dp),
+                                color = MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -191,11 +191,12 @@ fun PixelSearchbarSettingsUI(
     var showPermissionSheet by remember { mutableStateOf(false) }
     val currentType = viewModel.pixelSearchbarType.value
 
-    val options = listOf("empty", "date", "widget")
+    val options = listOf("empty", "date", "widget", "music")
     val labels = mapOf(
         "empty" to stringResource(R.string.pixel_searchbar_style_empty),
         "date" to stringResource(R.string.pixel_searchbar_style_date),
-        "widget" to stringResource(R.string.pixel_searchbar_style_widget)
+        "widget" to stringResource(R.string.pixel_searchbar_style_widget),
+        "music" to stringResource(R.string.pixel_searchbar_style_music)
     )
 
     val awm = remember { AppWidgetManager.getInstance(context) }
@@ -282,7 +283,11 @@ fun PixelSearchbarSettingsUI(
                             HapticUtil.performVirtualKeyHaptic(view)
                             when {
                                 type == "widget" -> openWidgetPicker()
-                                currentType == "widget" -> {
+                                type == "music" -> {
+                                    WidgetScraperService.start(context)
+                                    viewModel.setPixelSearchbarType(type, context)
+                                }
+                                currentType == "widget" || currentType == "music" -> {
                                     WidgetScraperService.stop(context)
                                     viewModel.setPixelSearchbarType(type, context)
                                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -1,0 +1,207 @@
+package com.sameerasw.essentials.ui.activities
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.EssentialsFloatingToolbar
+import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.theme.EssentialsTheme
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+class PixelSearchbarSettingsActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            val viewModel: MainViewModel = viewModel()
+            val context = LocalContext.current
+
+            remember(context) { viewModel.check(context) }
+
+            val isPitchBlackThemeEnabled by viewModel.isPitchBlackThemeEnabled
+
+            EssentialsTheme(pitchBlackTheme = isPitchBlackThemeEnabled) {
+                val statusBarHeight =
+                    WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainer)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                    ) {
+                        Spacer(modifier = Modifier.height(statusBarHeight))
+
+                        PixelSearchbarSettingsUI(
+                            viewModel = viewModel,
+                            modifier = Modifier.padding(top = 16.dp)
+                        )
+
+                        Spacer(modifier = Modifier.height(150.dp))
+                    }
+
+                    EssentialsFloatingToolbar(
+                        title = stringResource(R.string.pixel_searchbar_settings_title),
+                        onBackClick = { finish() },
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .zIndex(1f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun PixelSearchbarSettingsUI(
+    viewModel: MainViewModel,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+    val currentType = viewModel.pixelSearchbarType.value
+
+    val options = listOf("empty", "date")
+    val labels = mapOf(
+        "empty" to stringResource(R.string.pixel_searchbar_style_empty),
+        "date" to stringResource(R.string.pixel_searchbar_style_date)
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.pixel_searchbar_settings_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        RoundedCardContainer(spacing = 0.dp) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceBright),
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
+                ListItem(
+                    onClick = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.rounded_home_24),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    },
+                    contentPadding = PaddingValues(
+                        horizontal = 16.dp,
+                        vertical = 16.dp
+                    ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceBright
+                    ),
+                    content = {
+                        Text(
+                            text = stringResource(R.string.feat_pixel_searchbar_title),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+                ) {
+                    options.forEachIndexed { index, type ->
+                        val isChecked = currentType == type
+                        val label = labels[type] ?: type
+
+                        ToggleButton(
+                            checked = isChecked,
+                            onCheckedChange = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                viewModel.setPixelSearchbarType(type, context)
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics { role = Role.RadioButton },
+                            shapes = when {
+                                index == 0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                                index == options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                            },
+                        ) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = if (isChecked) FontWeight.Bold else FontWeight.Normal,
+                                maxLines = 1
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -347,6 +347,7 @@ fun PixelSearchbarSettingsUI(
                 RoundedCardContainer {
                     ListItem(
                         onClick = {
+                            HapticUtil.performVirtualKeyHaptic(view)
                             val intent = Intent(context, com.sameerasw.essentials.MainActivity::class.java).apply {
                                 putExtra("target_tab", com.sameerasw.essentials.domain.DIYTabs.DIY.name)
                             }
@@ -361,22 +362,30 @@ fun PixelSearchbarSettingsUI(
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         },
+                        trailingContent = {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_chevron_right_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                text = stringResource(R.string.pixel_searchbar_tap_action_desc),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
                         colors = ListItemDefaults.colors(
                             containerColor = MaterialTheme.colorScheme.surfaceBright
                         )
                     ) {
-                        Column {
-                            Text(
-                                text = stringResource(R.string.pixel_searchbar_tap_action_title),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Text(
-                                text = stringResource(R.string.pixel_searchbar_tap_action_desc),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
+                        Text(
+                            text = stringResource(R.string.pixel_searchbar_tap_action_title),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -58,6 +58,9 @@ import com.sameerasw.essentials.services.widgets.WidgetScraperService
 import com.sameerasw.essentials.ui.components.EssentialsFloatingToolbar
 import com.sameerasw.essentials.ui.components.cards.IconToggleItem
 import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
+import androidx.compose.material3.Switch
+
 import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
 import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
 import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
@@ -382,46 +385,40 @@ fun PixelSearchbarSettingsUI(
                             }
                         }
 
-                        // Scraped text preview
-                        val line1 = viewModel.pixelSearchbarScrapedLine1.value
-                        val line2 = viewModel.pixelSearchbarScrapedLine2.value
-                        AnimatedVisibility(
-                            visible = widgetProvider != null && (line1.isNotEmpty() || line2.isNotEmpty()),
-                            enter = expandVertically(),
-                            exit = shrinkVertically()
-                        ) {
-                            RoundedCardContainer {
-                                ListItem(
-                                    onClick = {},
-                                    modifier = Modifier.fillMaxWidth(),
-                                    leadingContent = {
-                                        Icon(
-                                            painter = painterResource(id = R.drawable.rounded_info_24),
-                                            contentDescription = null,
-                                            modifier = Modifier.size(24.dp),
-                                            tint = MaterialTheme.colorScheme.primary
-                                        )
-                                    },
-                                    supportingContent = if (line2.isNotEmpty()) {
-                                        {
-                                            Text(
-                                                text = line2,
-                                                style = MaterialTheme.typography.labelMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
-                                    } else null,
-                                    colors = ListItemDefaults.colors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceBright
+                        // Horizontal and Vertical Padding sliders
+                        RoundedCardContainer(spacing = 2.dp) {
+                            ConfigSliderItem(
+                                title = stringResource(R.string.pixel_searchbar_widget_padding_h),
+                                value = viewModel.pixelSearchbarWidgetPaddingH.intValue.toFloat(),
+                                onValueChange = {
+                                    viewModel.pixelSearchbarWidgetPaddingH.intValue = it.toInt()
+                                },
+                                onValueChangeFinished = {
+                                    viewModel.setPixelSearchbarWidgetPaddingH(
+                                        viewModel.pixelSearchbarWidgetPaddingH.intValue,
+                                        context
                                     )
-                                ) {
-                                    Text(
-                                        text = line1.ifEmpty { "—" },
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurface
+                                },
+                                valueRange = 0f..100f,
+                                increment = 4f,
+                                iconRes = R.drawable.rounded_rounded_corner_24
+                            )
+                            ConfigSliderItem(
+                                title = stringResource(R.string.pixel_searchbar_widget_padding_v),
+                                value = viewModel.pixelSearchbarWidgetPaddingV.intValue.toFloat(),
+                                onValueChange = {
+                                    viewModel.pixelSearchbarWidgetPaddingV.intValue = it.toInt()
+                                },
+                                onValueChangeFinished = {
+                                    viewModel.setPixelSearchbarWidgetPaddingV(
+                                        viewModel.pixelSearchbarWidgetPaddingV.intValue,
+                                        context
                                     )
-                                }
-                            }
+                                },
+                                valueRange = 0f..100f,
+                                increment = 4f,
+                                iconRes = R.drawable.rounded_rounded_corner_24
+                            )
                         }
                     }
                 }
@@ -526,13 +523,16 @@ fun PixelSearchbarSettingsUI(
                 )
 
                 RoundedCardContainer {
+                    val tapActionEnabled = viewModel.pixelSearchbarTapActionEnabled.value
                     ListItem(
                         onClick = {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            val intent = Intent(context, com.sameerasw.essentials.MainActivity::class.java).apply {
-                                putExtra("target_tab", com.sameerasw.essentials.domain.DIYTabs.DIY.name)
+                            if (tapActionEnabled) {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                val intent = Intent(context, com.sameerasw.essentials.MainActivity::class.java).apply {
+                                    putExtra("target_tab", com.sameerasw.essentials.domain.DIYTabs.DIY.name)
+                                }
+                                context.startActivity(intent)
                             }
-                            context.startActivity(intent)
                         },
                         modifier = Modifier.fillMaxWidth(),
                         leadingContent = {
@@ -540,22 +540,23 @@ fun PixelSearchbarSettingsUI(
                                 painter = painterResource(id = R.drawable.rounded_rocket_launch_24),
                                 contentDescription = null,
                                 modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.primary
+                                tint = if (tapActionEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
                             )
                         },
                         trailingContent = {
-                            Icon(
-                                painter = painterResource(id = R.drawable.rounded_chevron_right_24),
-                                contentDescription = null,
-                                modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            Switch(
+                                checked = tapActionEnabled,
+                                onCheckedChange = { enabled ->
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    viewModel.setPixelSearchbarTapActionEnabled(enabled, context)
+                                }
                             )
                         },
                         supportingContent = {
                             Text(
-                                text = stringResource(R.string.pixel_searchbar_tap_action_desc),
+                                text = stringResource(R.string.pixel_searchbar_tap_action_enabled_desc),
                                 style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                color = if (tapActionEnabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
                             )
                         },
                         colors = ListItemDefaults.colors(
@@ -563,9 +564,9 @@ fun PixelSearchbarSettingsUI(
                         )
                     ) {
                         Text(
-                            text = stringResource(R.string.pixel_searchbar_tap_action_title),
+                            text = stringResource(R.string.pixel_searchbar_tap_action_enabled),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
+                            color = if (tapActionEnabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                         )
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -1,75 +1,73 @@
 package com.sameerasw.essentials.ui.activities
 
+import android.app.Activity
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.background
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.ToggleButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
-import androidx.compose.material3.RadioButton
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.domain.model.Feature
+import com.sameerasw.essentials.services.widgets.WidgetScraperService
 import com.sameerasw.essentials.ui.components.EssentialsFloatingToolbar
+import com.sameerasw.essentials.ui.components.cards.IconToggleItem
 import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
+import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
+import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
+import com.sameerasw.essentials.ui.modifiers.BlurDirection
+import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.viewmodels.MainViewModel
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateOf
-import com.sameerasw.essentials.domain.model.Feature
-import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
-import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
 import android.content.Context
 import android.content.Intent
-import com.sameerasw.essentials.ui.components.cards.IconToggleItem
-import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
-import androidx.compose.material3.Scaffold
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.foundation.layout.navigationBars
-import com.sameerasw.essentials.ui.modifiers.BlurDirection
-import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 
 class PixelSearchbarSettingsActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -110,7 +108,7 @@ class PixelSearchbarSettingsActivity : ComponentActivity() {
                 Scaffold(
                     contentWindowInsets = WindowInsets(0, 0, 0, 0),
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                ) { innerPadding ->
+                ) { _ ->
                     val density = LocalDensity.current
                     val statusBarHeightPx = with(density) {
                         WindowInsets.statusBars.asPaddingValues().calculateTopPadding().toPx()
@@ -190,11 +188,51 @@ fun PixelSearchbarSettingsUI(
     var showPermissionSheet by remember { mutableStateOf(false) }
     val currentType = viewModel.pixelSearchbarType.value
 
-    val options = listOf("empty", "date")
+    val options = listOf("empty", "date", "widget")
     val labels = mapOf(
         "empty" to stringResource(R.string.pixel_searchbar_style_empty),
-        "date" to stringResource(R.string.pixel_searchbar_style_date)
+        "date" to stringResource(R.string.pixel_searchbar_style_date),
+        "widget" to stringResource(R.string.pixel_searchbar_style_widget)
     )
+
+    val awm = remember { AppWidgetManager.getInstance(context) }
+    val widgetHost = remember { AppWidgetHost(context, WidgetScraperService.HOST_ID) }
+
+    // Track the allocated ID so we can deallocate on cancel
+    var pendingWidgetId by remember { mutableStateOf(AppWidgetManager.INVALID_APPWIDGET_ID) }
+
+    // Single launcher — ACTION_APPWIDGET_PICK handles bind permission internally
+    val pickerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val data = result.data ?: return@rememberLauncherForActivityResult
+            val widgetId = data.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
+            if (widgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                val info = awm.getAppWidgetInfo(widgetId)
+                val providerName = info?.provider?.flattenToString()
+                viewModel.setPixelSearchbarType("widget", context)
+                viewModel.setPixelSearchbarWidgetId(widgetId, providerName, context)
+                WidgetScraperService.start(context)
+            }
+        } else {
+            // Deallocate the ID we pre-allocated if user cancelled
+            if (pendingWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                widgetHost.deleteAppWidgetId(pendingWidgetId)
+                pendingWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+            }
+        }
+    }
+
+    fun openWidgetPicker() {
+        val allocatedId = widgetHost.allocateAppWidgetId()
+        pendingWidgetId = allocatedId
+        val pickIntent = Intent(AppWidgetManager.ACTION_APPWIDGET_PICK).apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, allocatedId)
+        }
+        pickerLauncher.launch(pickIntent)
+    }
+
 
     Column(
         modifier = modifier
@@ -238,11 +276,154 @@ fun PixelSearchbarSettingsUI(
                         items = options,
                         selectedItem = currentType,
                         onItemSelected = { type ->
-                            viewModel.setPixelSearchbarType(type, context)
+                            HapticUtil.performVirtualKeyHaptic(view)
+                            when {
+                                type == "widget" -> openWidgetPicker()
+                                currentType == "widget" -> {
+                                    WidgetScraperService.stop(context)
+                                    viewModel.setPixelSearchbarType(type, context)
+                                }
+                                else -> viewModel.setPixelSearchbarType(type, context)
+                            }
                         },
                         labelProvider = { labels[it] ?: it },
                         modifier = Modifier.fillMaxWidth()
                     )
+                }
+
+                // Widget mode controls
+                AnimatedVisibility(
+                    visible = currentType == "widget",
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val widgetProvider = viewModel.pixelSearchbarWidgetProvider.value
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        RoundedCardContainer(spacing = 2.dp) {
+                            ListItem(
+                                onClick = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    openWidgetPicker()
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.rounded_widgets_24),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp),
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                },
+                                trailingContent = {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.rounded_chevron_right_24),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                                    )
+                                },
+                                supportingContent = {
+                                    Text(
+                                        text = if (widgetProvider != null)
+                                            widgetProvider.substringAfterLast("/")
+                                        else
+                                            stringResource(R.string.pixel_searchbar_widget_none),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                },
+                                colors = ListItemDefaults.colors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceBright
+                                )
+                            ) {
+                                Text(
+                                    text = if (widgetProvider != null)
+                                        stringResource(R.string.pixel_searchbar_widget_change)
+                                    else
+                                        stringResource(R.string.pixel_searchbar_widget_picker_title),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+
+                            AnimatedVisibility(
+                                visible = widgetProvider != null,
+                                enter = expandVertically(),
+                                exit = shrinkVertically()
+                            ) {
+                                ListItem(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        viewModel.clearPixelSearchbarWidget(context)
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(id = R.drawable.rounded_delete_24),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp),
+                                            tint = MaterialTheme.colorScheme.error
+                                        )
+                                    },
+                                    colors = ListItemDefaults.colors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceBright
+                                    )
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.pixel_searchbar_widget_remove),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.error
+                                    )
+                                }
+                            }
+                        }
+
+                        // Scraped text preview
+                        val line1 = viewModel.pixelSearchbarScrapedLine1.value
+                        val line2 = viewModel.pixelSearchbarScrapedLine2.value
+                        AnimatedVisibility(
+                            visible = widgetProvider != null && (line1.isNotEmpty() || line2.isNotEmpty()),
+                            enter = expandVertically(),
+                            exit = shrinkVertically()
+                        ) {
+                            RoundedCardContainer {
+                                ListItem(
+                                    onClick = {},
+                                    modifier = Modifier.fillMaxWidth(),
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(id = R.drawable.rounded_info_24),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp),
+                                            tint = MaterialTheme.colorScheme.primary
+                                        )
+                                    },
+                                    supportingContent = if (line2.isNotEmpty()) {
+                                        {
+                                            Text(
+                                                text = line2,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    } else null,
+                                    colors = ListItemDefaults.colors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceBright
+                                    )
+                                ) {
+                                    Text(
+                                        text = line1.ifEmpty { "—" },
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
 
                 AnimatedVisibility(

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -60,8 +60,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import com.sameerasw.essentials.domain.model.Feature
 import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
+import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
 import android.content.Context
 import com.sameerasw.essentials.ui.components.cards.IconToggleItem
+import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.layout.navigationBars
@@ -183,6 +185,8 @@ fun PixelSearchbarSettingsUI(
 ) {
     val context = LocalContext.current
     val view = LocalView.current
+    val isEnabled = viewModel.isPixelSearchbarEnabled.value
+    var showPermissionSheet by remember { mutableStateOf(false) }
     val currentType = viewModel.pixelSearchbarType.value
 
     val options = listOf("empty", "date")
@@ -195,176 +199,154 @@ fun PixelSearchbarSettingsUI(
         modifier = modifier
             .fillMaxWidth()
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-
-        RoundedCardContainer(spacing = 0.dp) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceBright),
-                verticalArrangement = Arrangement.spacedBy(0.dp)
-            ) {
-                ListItem(
-                    onClick = {},
-                    modifier = Modifier.fillMaxWidth(),
-                    leadingContent = {
-                        Icon(
-                            painter = painterResource(id = R.drawable.rounded_home_24),
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    },
-                    contentPadding = PaddingValues(
-                        horizontal = 16.dp,
-                        vertical = 16.dp
-                    ),
-                    verticalAlignment = Alignment.CenterVertically,
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceBright
-                    ),
-                    content = {
-                        Text(
-                            text = stringResource(R.string.feat_pixel_searchbar_title),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+        RoundedCardContainer {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_search_24,
+                title = stringResource(R.string.feat_pixel_searchbar_title),
+                description = "Replace Pixel Launcher default searchbar",
+                isChecked = isEnabled,
+                onCheckedChange = { enabled ->
+                    if (viewModel.isWriteSecureSettingsEnabled.value || viewModel.isShizukuPermissionGranted.value || viewModel.isRootPermissionGranted.value) {
+                        viewModel.setPixelSearchbarEnabled(enabled, context)
+                    } else {
+                        showPermissionSheet = true
                     }
+                }
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isEnabled,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.label_replace_with),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
-                ) {
-                    options.forEachIndexed { index, type ->
-                        val isChecked = currentType == type
-                        val label = labels[type] ?: type
+                RoundedCardContainer {
+                    SegmentedPicker(
+                        items = options,
+                        selectedItem = currentType,
+                        onItemSelected = { type ->
+                            viewModel.setPixelSearchbarType(type, context)
+                        },
+                        labelProvider = { labels[it] ?: it },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
 
-                        ToggleButton(
-                            checked = isChecked,
-                            onCheckedChange = {
-                                HapticUtil.performVirtualKeyHaptic(view)
-                                viewModel.setPixelSearchbarType(type, context)
-                            },
-                            modifier = Modifier
-                                .weight(1f)
-                                .semantics { role = Role.RadioButton },
-                            shapes = when {
-                                index == 0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
-                                index == options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
-                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
-                            },
-                        ) {
-                            Text(
-                                text = label,
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = if (isChecked) FontWeight.Bold else FontWeight.Normal,
-                                maxLines = 1
+                AnimatedVisibility(
+                    visible = currentType == "date",
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val currentDateFormat = viewModel.pixelSearchbarDateFormat.value
+                    val dateFormats = listOf(
+                        "EEEE, MMMM d",
+                        "EEEE, MMM d",
+                        "EEE, MMM d",
+                        "EEEE, d MMMM",
+                        "d MMMM",
+                        "MMMM d",
+                        "EEE, d MMM",
+                        "yyyy-MM-dd",
+                        "dd/MM/yyyy"
+                    )
+                    val currentDate = remember { java.util.Date() }
+                    val googleSansFlexRound = remember { FontFamily(Font(R.font.google_sans_flex_round)) }
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+
+                        RoundedCardContainer {
+                            IconToggleItem(
+                                iconRes = R.drawable.rounded_rounded_corner_24,
+                                title = stringResource(R.string.pixel_searchbar_background_pill_title),
+                                description = stringResource(R.string.pixel_searchbar_background_pill_desc),
+                                isChecked = viewModel.pixelSearchbarBackgroundPill.value,
+                                onCheckedChange = { enabled ->
+                                    viewModel.setPixelSearchbarBackgroundPill(enabled, context)
+                                }
                             )
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Text(
+                            text = "Date Format",
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+
+                        RoundedCardContainer(spacing = 2.dp) {
+                            dateFormats.forEach { format ->
+                                val isSelected = currentDateFormat == format
+                                val formattedDate = remember(format, currentDate) {
+                                    try {
+                                        java.text.SimpleDateFormat(format, java.util.Locale.getDefault()).format(currentDate)
+                                    } catch (e: Exception) {
+                                        format
+                                    }
+                                }
+
+                                ListItem(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        viewModel.setPixelSearchbarDateFormat(format, context)
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    leadingContent = {
+                                        RadioButton(
+                                            selected = isSelected,
+                                            onClick = {
+                                                HapticUtil.performVirtualKeyHaptic(view)
+                                                viewModel.setPixelSearchbarDateFormat(format, context)
+                                            }
+                                        )
+                                    },
+                                    colors = ListItemDefaults.colors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceBright
+                                    )
+                                ) {
+                                    Text(
+                                        text = formattedDate,
+                                        style = MaterialTheme.typography.bodyLarge.copy(
+                                            fontFamily = googleSansFlexRound
+                                        ),
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                            }
                         }
                     }
                 }
             }
         }
+    }
 
-        AnimatedVisibility(
-            visible = currentType == "date",
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            val currentDateFormat = viewModel.pixelSearchbarDateFormat.value
-            val dateFormats = listOf(
-                "EEEE, MMMM d",
-                "EEEE, MMM d",
-                "EEE, MMM d",
-                "EEEE, d MMMM",
-                "d MMMM",
-                "MMMM d",
-                "EEE, d MMM",
-                "yyyy-MM-dd",
-                "dd/MM/yyyy"
+    if (showPermissionSheet) {
+        val permissionItem = remember(context, viewModel) {
+            com.sameerasw.essentials.utils.PermissionUIHelper.getPermissionItem("WRITE_SECURE_SETTINGS", context, viewModel)
+        }
+        if (permissionItem != null) {
+            PermissionsBottomSheet(
+                onDismissRequest = { showPermissionSheet = false },
+                featureTitle = "Pixel Searchbar",
+                permissions = listOf(permissionItem)
             )
-            val currentDate = remember { java.util.Date() }
-            val googleSansFlexRound = remember { FontFamily(Font(R.font.google_sans_flex_round)) }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Text(
-                    text = "Background Pill",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                RoundedCardContainer {
-                    IconToggleItem(
-                        iconRes = R.drawable.rounded_rounded_corner_24,
-                        title = stringResource(R.string.pixel_searchbar_background_pill_title),
-                        description = stringResource(R.string.pixel_searchbar_background_pill_desc),
-                        isChecked = viewModel.pixelSearchbarBackgroundPill.value,
-                        onCheckedChange = { enabled ->
-                            viewModel.setPixelSearchbarBackgroundPill(enabled, context)
-                        }
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Text(
-                    text = "Date Format",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                RoundedCardContainer(spacing = 2.dp) {
-                    dateFormats.forEach { format ->
-                        val isSelected = currentDateFormat == format
-                        val formattedDate = remember(format, currentDate) {
-                            try {
-                                java.text.SimpleDateFormat(format, java.util.Locale.getDefault()).format(currentDate)
-                            } catch (e: Exception) {
-                                format
-                            }
-                        }
-
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(MaterialTheme.colorScheme.surfaceBright)
-                                .clickable {
-                                    HapticUtil.performVirtualKeyHaptic(view)
-                                    viewModel.setPixelSearchbarDateFormat(format, context)
-                                }
-                                .padding(horizontal = 16.dp, vertical = 16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            RadioButton(
-                                selected = isSelected,
-                                onClick = {
-                                    HapticUtil.performVirtualKeyHaptic(view)
-                                    viewModel.setPixelSearchbarDateFormat(format, context)
-                                }
-                            )
-                            Text(
-                                text = formattedDate,
-                                style = MaterialTheme.typography.bodyLarge.copy(
-                                    fontFamily = googleSansFlexRound
-                                ),
-                                modifier = Modifier.padding(start = 16.dp),
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -62,6 +62,7 @@ import com.sameerasw.essentials.domain.model.Feature
 import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
 import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
 import android.content.Context
+import android.content.Intent
 import com.sameerasw.essentials.ui.components.cards.IconToggleItem
 import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
 import androidx.compose.material3.Scaffold
@@ -330,6 +331,51 @@ fun PixelSearchbarSettingsUI(
                                     )
                                 }
                             }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = "Tap Action",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                RoundedCardContainer {
+                    ListItem(
+                        onClick = {
+                            val intent = Intent(context, com.sameerasw.essentials.MainActivity::class.java).apply {
+                                putExtra("target_tab", com.sameerasw.essentials.domain.DIYTabs.DIY.name)
+                            }
+                            context.startActivity(intent)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_rocket_launch_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        colors = ListItemDefaults.colors(
+                            containerColor = MaterialTheme.colorScheme.surfaceBright
+                        )
+                    ) {
+                        Column {
+                            Text(
+                                text = stringResource(R.string.pixel_searchbar_tap_action_title),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(R.string.pixel_searchbar_tap_action_desc),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarSettingsActivity.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.mutableStateOf
 import com.sameerasw.essentials.domain.model.Feature
 import com.sameerasw.essentials.ui.components.sheets.FeatureHelpBottomSheet
 import android.content.Context
+import com.sameerasw.essentials.ui.components.cards.IconToggleItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.layout.navigationBars
@@ -139,7 +140,7 @@ class PixelSearchbarSettingsActivity : ComponentActivity() {
 
                             PixelSearchbarSettingsUI(
                                 viewModel = viewModel,
-                                modifier = Modifier.padding(top = 16.dp)
+                                modifier = Modifier.padding(top = 4.dp)
                             )
 
                             Spacer(
@@ -196,12 +197,6 @@ fun PixelSearchbarSettingsUI(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        Text(
-            text = stringResource(R.string.pixel_searchbar_settings_title),
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
 
         RoundedCardContainer(spacing = 0.dp) {
             Column(
@@ -301,6 +296,27 @@ fun PixelSearchbarSettingsUI(
                     .padding(top = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
+                Text(
+                    text = "Background Pill",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                RoundedCardContainer {
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_rounded_corner_24,
+                        title = stringResource(R.string.pixel_searchbar_background_pill_title),
+                        description = stringResource(R.string.pixel_searchbar_background_pill_desc),
+                        isChecked = viewModel.pixelSearchbarBackgroundPill.value,
+                        onCheckedChange = { enabled ->
+                            viewModel.setPixelSearchbarBackgroundPill(enabled, context)
+                        }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
                 Text(
                     text = "Date Format",
                     style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarTapActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/PixelSearchbarTapActivity.kt
@@ -1,0 +1,29 @@
+package com.sameerasw.essentials.ui.activities
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.sameerasw.essentials.domain.diy.Automation
+import com.sameerasw.essentials.domain.diy.DIYRepository
+import com.sameerasw.essentials.services.automation.executors.CombinedActionExecutor
+import kotlinx.coroutines.launch
+
+class PixelSearchbarTapActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        DIYRepository.init(applicationContext)
+        val automation = DIYRepository.automations.value.find { it.type == Automation.Type.PIXEL_SEARCHBAR }
+        
+        if (automation != null && automation.actions.isNotEmpty() && automation.isEnabled) {
+            lifecycleScope.launch {
+                automation.actions.forEach { action ->
+                    CombinedActionExecutor.execute(applicationContext, action)
+                }
+                finish()
+            }
+        } else {
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/QSPreferencesActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/QSPreferencesActivity.kt
@@ -60,7 +60,8 @@ class QSPreferencesActivity : ComponentActivity() {
                 return
             }
 
-            if (componentName.className == "com.sameerasw.essentials.services.tiles.DeveloperOptionsTileService") {
+            if (componentName.className == "com.sameerasw.essentials.services.tiles.DeveloperOptionsTileService" ||
+                componentName.className == "com.sameerasw.essentials.services.tiles.UsbDebuggingTileService") {
                 val devIntent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
@@ -527,14 +527,17 @@ fun YourAndroidContent(
                     .padding(32.dp)
             )
         } else if (trackedRepos.isEmpty()) {
-            androidx.compose.material3.OutlinedCard(
+            androidx.compose.material3.Card(
                 modifier = Modifier
+                    .background(
+                        MaterialTheme.colorScheme.surfaceBright
+                    )
                     .fillMaxWidth()
                     .graphicsLayer {
                         alpha = contentAlphaState.value
                         translationY = contentOffsetState.value.toPx()
                     },
-                shape = MaterialTheme.shapes.extraSmall
+                shape = MaterialTheme.shapes.large
             ) {
                 Column(
                     modifier = Modifier.padding(24.dp),

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/DeviceHeroCard.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/DeviceHeroCard.kt
@@ -167,7 +167,7 @@ fun DeviceHeroCard(
         Row(
             modifier = Modifier
                 .background(
-                    MaterialTheme.colorScheme.surfaceContainerHighest,
+                    MaterialTheme.colorScheme.surfaceBright,
                     shape = Shapes.extraSmall
                 )
                 .fillMaxWidth()
@@ -210,7 +210,7 @@ fun DeviceHeroCard(
         Column(
             modifier = Modifier
                 .background(
-                    MaterialTheme.colorScheme.surfaceContainerHighest,
+                    MaterialTheme.colorScheme.surfaceBright,
                     shape = Shapes.extraSmall
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
@@ -38,7 +38,8 @@ fun PermissionCard(
     onActionClick: () -> Unit,
     modifier: Modifier = Modifier,
     secondaryActionLabel: Any? = null, // Can be Int or String
-    onSecondaryActionClick: (() -> Unit)? = null
+    onSecondaryActionClick: (() -> Unit)? = null,
+    description: Any? = null
 ) {
     val grantedGreen = Color(0xFF4CAF50)
     val view = LocalView.current
@@ -47,6 +48,12 @@ fun PermissionCard(
         is Int -> stringResource(id = title)
         is String -> title
         else -> ""
+    }
+
+    val resolvedDescription = when (description) {
+        is Int -> stringResource(id = description)
+        is String -> description
+        else -> null
     }
 
     val resolvedActionLabel = when (actionLabel) {
@@ -86,6 +93,14 @@ fun PermissionCard(
                 },
                 supportingContent = {
                     Column {
+                        if (resolvedDescription != null) {
+                            Text(
+                                text = resolvedDescription,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
                         Text(text = "Required for:", style = MaterialTheme.typography.bodySmall)
                         Spacer(modifier = Modifier.height(4.dp))
                         dependentFeatures.forEach { f ->

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
@@ -39,6 +39,10 @@ fun PermissionCard(
     modifier: Modifier = Modifier,
     secondaryActionLabel: Any? = null, // Can be Int or String
     onSecondaryActionClick: (() -> Unit)? = null,
+    shizukuActionLabel: Any? = null,
+    shizukuActionEnabled: Boolean = false,
+    onShizukuActionClick: (() -> Unit)? = null,
+    instructions: Any? = null,
     description: Any? = null
 ) {
     val grantedGreen = Color(0xFF4CAF50)
@@ -65,6 +69,18 @@ fun PermissionCard(
     val resolvedSecondaryLabel = when (secondaryActionLabel) {
         is Int -> stringResource(id = secondaryActionLabel)
         is String -> secondaryActionLabel
+        else -> null
+    }
+
+    val resolvedShizukuLabel = when (shizukuActionLabel) {
+        is Int -> stringResource(id = shizukuActionLabel)
+        is String -> shizukuActionLabel
+        else -> null
+    }
+
+    val resolvedInstructions = when (instructions) {
+        is Int -> stringResource(id = instructions)
+        is String -> instructions
         else -> null
     }
 
@@ -164,37 +180,64 @@ fun PermissionCard(
                         }
                     }
                 } else {
-                    if (resolvedSecondaryLabel != null && onSecondaryActionClick != null) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            OutlinedButton(
-                                onClick = {
-                                    HapticUtil.performVirtualKeyHaptic(view)
-                                    onActionClick()
-                                },
-                                modifier = Modifier.weight(1f)
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (resolvedInstructions != null) {
+                            Text(
+                                text = resolvedInstructions,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(bottom = 4.dp)
+                            )
+                        }
+
+                        if (resolvedSecondaryLabel != null && onSecondaryActionClick != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
+                                OutlinedButton(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        onActionClick()
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Text(resolvedActionLabel)
+                                }
+
+                                Button(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        onSecondaryActionClick()
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Text(resolvedSecondaryLabel)
+                                }
+                            }
+                        } else {
+                            Button(onClick = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                onActionClick()
+                            }, modifier = Modifier.fillMaxWidth()) {
                                 Text(resolvedActionLabel)
                             }
+                        }
 
+                        if (resolvedShizukuLabel != null && onShizukuActionClick != null) {
                             Button(
                                 onClick = {
                                     HapticUtil.performVirtualKeyHaptic(view)
-                                    onSecondaryActionClick()
+                                    onShizukuActionClick()
                                 },
-                                modifier = Modifier.weight(1f)
+                                enabled = shizukuActionEnabled,
+                                modifier = Modifier.fillMaxWidth()
                             ) {
-                                Text(resolvedSecondaryLabel)
+                                Text(resolvedShizukuLabel)
                             }
-                        }
-                    } else {
-                        Button(onClick = {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            onActionClick()
-                        }, modifier = Modifier.fillMaxWidth()) {
-                            Text(resolvedActionLabel)
                         }
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/diy/AutomationItem.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/diy/AutomationItem.kt
@@ -152,6 +152,7 @@ fun AutomationItem(
                     val icon = when (automation.type) {
                         Automation.Type.TRIGGER -> automation.trigger?.icon
                         Automation.Type.ACTION_SHORTCUT -> R.drawable.rounded_rocket_launch_24
+                        Automation.Type.PIXEL_SEARCHBAR -> R.drawable.rounded_search_24
                         Automation.Type.STATE -> automation.state?.icon
                         Automation.Type.APP -> R.drawable.rounded_apps_24
                     }
@@ -163,6 +164,7 @@ fun AutomationItem(
                             )
                         }
                         Automation.Type.ACTION_SHORTCUT -> stringResource(R.string.diy_create_action_shortcut_title)
+                        Automation.Type.PIXEL_SEARCHBAR -> stringResource(R.string.diy_create_pixel_searchbar_title)
                         Automation.Type.STATE -> automation.state?.title?.let { stringResource(it) }
                         Automation.Type.APP -> stringResource(R.string.diy_create_app_title) + " (${automation.selectedApps.size})"
                     }
@@ -209,7 +211,7 @@ fun AutomationItem(
                 }
 
 
-                if (automation.type == Automation.Type.TRIGGER || automation.type == Automation.Type.ACTION_SHORTCUT) {
+                if (automation.type == Automation.Type.TRIGGER || automation.type == Automation.Type.ACTION_SHORTCUT || automation.type == Automation.Type.PIXEL_SEARCHBAR) {
                     // Separator Icon
                     Box(
                         modifier = Modifier
@@ -273,7 +275,7 @@ fun AutomationItem(
                     modifier = Modifier
                         .weight(1f),
                 ) {
-                    if (automation.type == Automation.Type.TRIGGER || automation.type == Automation.Type.ACTION_SHORTCUT) {
+                    if (automation.type == Automation.Type.TRIGGER || automation.type == Automation.Type.ACTION_SHORTCUT || automation.type == Automation.Type.PIXEL_SEARCHBAR) {
                         automation.actions.forEach { action ->
                             ActionItem(action = action)
                         }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/NewAutomationSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/NewAutomationSheet.kt
@@ -32,6 +32,8 @@ import com.sameerasw.essentials.domain.diy.Automation
 import com.sameerasw.essentials.domain.diy.DIYRepository
 import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.utils.HapticUtil
+import androidx.compose.ui.platform.LocalContext
+import com.sameerasw.essentials.data.repository.SettingsRepository
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,9 +41,20 @@ fun NewAutomationSheet(
     onDismiss: () -> Unit,
     onOptionSelected: (Automation.Type) -> Unit
 ) {
+    val context = LocalContext.current
+    val isPixelSearchbarEnabled = remember(context) {
+        SettingsRepository(context).getBoolean(SettingsRepository.KEY_PIXEL_SEARCHBAR, false)
+    }
+
     val hasActionShortcut = remember {
         DIYRepository.automations.value.any {
             it.type == Automation.Type.ACTION_SHORTCUT
+        }
+    }
+
+    val hasPixelSearchbar = remember {
+        DIYRepository.automations.value.any {
+            it.type == Automation.Type.PIXEL_SEARCHBAR
         }
     }
 
@@ -114,6 +127,17 @@ fun NewAutomationSheet(
                     enabled = !hasActionShortcut,
                     onClick = { onOptionSelected(Automation.Type.ACTION_SHORTCUT) }
                 )
+
+                // Pixel Searchbar Tap Option
+                if (isPixelSearchbarEnabled) {
+                    AutomationTypeOption(
+                        title = stringResource(R.string.diy_create_pixel_searchbar_title),
+                        description = stringResource(R.string.diy_create_pixel_searchbar_desc),
+                        iconRes = R.drawable.rounded_search_24,
+                        enabled = !hasPixelSearchbar,
+                        onClick = { onOptionSelected(Automation.Type.PIXEL_SEARCHBAR) }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/PermissionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/PermissionsBottomSheet.kt
@@ -78,7 +78,8 @@ fun PermissionsBottomSheet(
                         isGranted = perm.isGranted,
                         onActionClick = { perm.action?.invoke() },
                         secondaryActionLabel = perm.secondaryActionLabel,
-                        onSecondaryActionClick = { perm.secondaryAction?.invoke() }
+                        onSecondaryActionClick = { perm.secondaryAction?.invoke() },
+                        description = perm.description
                     )
                 }
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/PermissionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/PermissionsBottomSheet.kt
@@ -27,7 +27,11 @@ data class PermissionItem(
     val action: (() -> Unit)? = null,
     val secondaryActionLabel: Any? = null, // Can be Int or String
     val secondaryAction: (() -> Unit)? = null,
-    val isGranted: Boolean = false
+    val isGranted: Boolean = false,
+    val shizukuActionLabel: Any? = null,
+    val shizukuActionEnabled: Boolean = false,
+    val shizukuAction: (() -> Unit)? = null,
+    val instructions: Any? = null
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -79,6 +83,10 @@ fun PermissionsBottomSheet(
                         onActionClick = { perm.action?.invoke() },
                         secondaryActionLabel = perm.secondaryActionLabel,
                         onSecondaryActionClick = { perm.secondaryAction?.invoke() },
+                        shizukuActionLabel = perm.shizukuActionLabel,
+                        shizukuActionEnabled = perm.shizukuActionEnabled,
+                        onShizukuActionClick = { perm.shizukuAction?.invoke() },
+                        instructions = perm.instructions,
                         description = perm.description
                     )
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WatchInstallHelpBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WatchInstallHelpBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.sameerasw.essentials.ui.components.sheets
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -52,7 +54,8 @@ fun WatchInstallHelpBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 32.dp),
+                .padding(bottom = 32.dp)
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -100,34 +103,6 @@ fun WatchInstallHelpBottomSheet(
                 }
             }
 
-            /*
-            // Action Button
-            Button(
-                onClick = {
-                    viewModel.openPlayStoreOnWatch(context)
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.rounded_watch_24),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(R.string.watch_help_open_play_store),
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-            */
-
             // GitHub Download Button
             Button(
                 onClick = {
@@ -153,6 +128,95 @@ fun WatchInstallHelpBottomSheet(
                     text = stringResource(R.string.action_download_from_github),
                     style = MaterialTheme.typography.labelLarge
                 )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Watch ADB Permissions",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.align(Alignment.Start).padding(start = 8.dp)
+            )
+
+            val context = LocalContext.current
+
+            // Secure Settings Command Card
+            AdbCommandCard(
+                title = "Write Secure Settings",
+                description = "Required on the watch to toggle Wireless Debugging remotely.",
+                command = "adb shell pm grant com.sameerasw.essentials android.permission.WRITE_SECURE_SETTINGS",
+                context = context,
+                view = view
+            )
+
+            // DND Access Command Card
+            AdbCommandCard(
+                title = "Do Not Disturb (DND) Access",
+                description = "Required on the watch for DND / Silent sync modes.",
+                command = "adb shell cmd notification allow_dnd com.sameerasw.essentials",
+                context = context,
+                view = view
+            )
+        }
+    }
+}
+
+@Composable
+private fun AdbCommandCard(
+    title: String,
+    description: String,
+    command: String,
+    context: android.content.Context,
+    view: android.view.View
+) {
+    RoundedCardContainer(
+        containerColor = MaterialTheme.colorScheme.surfaceBright
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = MaterialTheme.shapes.small
+                    )
+                    .padding(start = 12.dp, top = 4.dp, bottom = 4.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = command,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f)
+                )
+
+                androidx.compose.material3.IconButton(
+                    onClick = {
+                        HapticUtil.performUIHaptic(view)
+                        val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                        val clip = android.content.ClipData.newPlainText("adb_command", command)
+                        clipboard.setPrimaryClip(clip)
+                        android.widget.Toast.makeText(context, "Command copied", android.widget.Toast.LENGTH_SHORT).show()
+                    }
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.rounded_content_copy_24),
+                        contentDescription = "Copy command",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/watermark/WatermarkPreview.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/watermark/WatermarkPreview.kt
@@ -40,28 +40,31 @@ fun WatermarkPreview(
 
             is WatermarkUiState.Success -> {
                 val targetFile = uiState.file
-                var visibleFile by androidx.compose.runtime.remember {
+                val targetBitmap = uiState.bitmap
+                val targetModel: Any = targetBitmap ?: targetFile
+
+                var visibleModel by androidx.compose.runtime.remember {
                     androidx.compose.runtime.mutableStateOf(
-                        targetFile
+                        targetModel
                     )
                 }
 
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     AsyncImage(
-                        model = visibleFile,
+                        model = visibleModel,
                         contentDescription = null,
                         modifier = Modifier.fillMaxSize(),
                         contentScale = ContentScale.Fit
                     )
 
-                    if (targetFile != visibleFile) {
+                    if (targetModel != visibleModel) {
                         AsyncImage(
-                            model = targetFile,
+                            model = targetModel,
                             contentDescription = "Preview",
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Fit,
                             onSuccess = {
-                                visibleFile = targetFile
+                                visibleModel = targetModel
                             }
                         )
                     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/SetupFeatures.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/SetupFeatures.kt
@@ -1333,6 +1333,8 @@ private fun RecentSearchesSection(
                         viewModel.addRecentSearch(result)
                         val feature = allFeatures.find { it.id == result.featureKey }
                         if (feature != null) {
+                            val targetFeatureKey = feature.parentFeatureId ?: feature.id
+                            val highlightKey = result.targetSettingHighlightKey ?: (if (feature.parentFeatureId != null) feature.id else null)
                             BiometricSecurityHelper.runWithAuth(
                                 activity = context as FragmentActivity,
                                 feature = feature,
@@ -1342,8 +1344,8 @@ private fun RecentSearchesSection(
                                             context,
                                             FeatureSettingsActivity::class.java
                                         ).apply {
-                                            putExtra("feature", result.featureKey)
-                                            result.targetSettingHighlightKey?.let {
+                                            putExtra("feature", targetFeatureKey)
+                                            highlightKey?.let {
                                                 putExtra("highlight_setting", it)
                                             }
                                         }
@@ -1395,6 +1397,8 @@ private fun SearchResultsSection(
                         viewModel.addRecentSearch(result)
                         val feature = allFeatures.find { it.id == result.featureKey }
                         if (feature != null) {
+                            val targetFeatureKey = feature.parentFeatureId ?: feature.id
+                            val highlightKey = result.targetSettingHighlightKey ?: (if (feature.parentFeatureId != null) feature.id else null)
                             BiometricSecurityHelper.runWithAuth(
                                 activity = context as FragmentActivity,
                                 feature = feature,
@@ -1404,8 +1408,8 @@ private fun SearchResultsSection(
                                             context,
                                             FeatureSettingsActivity::class.java
                                         ).apply {
-                                            putExtra("feature", result.featureKey)
-                                            result.targetSettingHighlightKey?.let {
+                                            putExtra("feature", targetFeatureKey)
+                                            highlightKey?.let {
                                                 putExtra("highlight_setting", it)
                                             }
                                         }

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/SetupFeatures.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/SetupFeatures.kt
@@ -1,5 +1,6 @@
 package com.sameerasw.essentials.ui.composables
 
+import androidx.activity.compose.BackHandler
 import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -849,6 +850,14 @@ fun SetupFeatures(
     val focusRequester = remember { FocusRequester() }
     var isFocused by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
+    val searchQuery = viewModel.searchQuery.value
+
+    BackHandler(enabled = isFocused || searchQuery.isNotEmpty()) {
+        focusManager.clearFocus()
+        viewModel.onSearchQueryChanged("", context)
+        isFocused = false
+    }
+
     LocalSoftwareKeyboardController.current
     WindowInsets.isImeVisible
 
@@ -1333,8 +1342,16 @@ private fun RecentSearchesSection(
                         viewModel.addRecentSearch(result)
                         val feature = allFeatures.find { it.id == result.featureKey }
                         if (feature != null) {
-                            val targetFeatureKey = feature.parentFeatureId ?: feature.id
-                            val highlightKey = result.targetSettingHighlightKey ?: (if (feature.parentFeatureId != null) feature.id else null)
+                            val targetFeatureKey = if (!feature.hasMoreSettings && feature.parentFeatureId != null) {
+                                feature.parentFeatureId
+                            } else {
+                                feature.id
+                            }
+                            val highlightKey = if (!feature.hasMoreSettings && feature.parentFeatureId != null) {
+                                feature.id
+                            } else {
+                                result.targetSettingHighlightKey
+                            }
                             BiometricSecurityHelper.runWithAuth(
                                 activity = context as FragmentActivity,
                                 feature = feature,
@@ -1397,8 +1414,16 @@ private fun SearchResultsSection(
                         viewModel.addRecentSearch(result)
                         val feature = allFeatures.find { it.id == result.featureKey }
                         if (feature != null) {
-                            val targetFeatureKey = feature.parentFeatureId ?: feature.id
-                            val highlightKey = result.targetSettingHighlightKey ?: (if (feature.parentFeatureId != null) feature.id else null)
+                            val targetFeatureKey = if (!feature.hasMoreSettings && feature.parentFeatureId != null) {
+                                feature.parentFeatureId
+                            } else {
+                                feature.id
+                            }
+                            val highlightKey = if (!feature.hasMoreSettings && feature.parentFeatureId != null) {
+                                feature.id
+                            } else {
+                                result.targetSettingHighlightKey
+                            }
                             BiometricSecurityHelper.runWithAuth(
                                 activity = context as FragmentActivity,
                                 feature = feature,

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/OtherCustomizationsSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/OtherCustomizationsSettingsUI.kt
@@ -30,12 +30,14 @@ import com.sameerasw.essentials.ui.components.sheets.PermissionsBottomSheet
 import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.viewmodels.MainViewModel
+import com.sameerasw.essentials.ui.activities.PixelSearchbarSettingsActivity
 
 enum class PermissionModule {
     HIDE_GESTURE_BAR,
     SHOW_ON_LAUNCHER,
     CIRCLE_TO_SEARCH,
     DISABLE_ROTATION_SUGGESTION,
+    PIXEL_SEARCHBAR,
     NONE
 }
 
@@ -121,6 +123,7 @@ fun OtherCustomizationsSettingsUI(
 
             PermissionModule.CIRCLE_TO_SEARCH -> listOf(shizukuPermission, accessibilityPermission)
             PermissionModule.DISABLE_ROTATION_SUGGESTION -> listOf(shizukuPermission)
+            PermissionModule.PIXEL_SEARCHBAR -> listOf(shizukuPermission)
             else -> emptyList()
         }
 
@@ -251,6 +254,31 @@ fun OtherCustomizationsSettingsUI(
                 },
                 iconRes = R.drawable.rounded_mobile_rotate_24,
                 modifier = Modifier.highlight(highlightSetting == "disable_rotation_suggestion_toggle")
+            )
+
+            IconToggleItem(
+                title = stringResource(R.string.feat_pixel_searchbar_title),
+                description = stringResource(R.string.feat_pixel_searchbar_desc),
+                isChecked = viewModel.isPixelSearchbarEnabled.value,
+                onCheckedChange = { enabled ->
+                    if (viewModel.isWriteSecureSettingsEnabled.value || viewModel.isShizukuPermissionGranted.value || viewModel.isRootPermissionGranted.value) {
+                        viewModel.setPixelSearchbarEnabled(enabled, context)
+                    } else {
+                        requestingPermissionFor = PermissionModule.PIXEL_SEARCHBAR
+                    }
+                },
+                onClick = {
+                    val intent = Intent(context, PixelSearchbarSettingsActivity::class.java)
+                    context.startActivity(intent)
+                },
+                enabled = true,
+                onDisabledClick = {
+                    if (!viewModel.isWriteSecureSettingsEnabled.value && !viewModel.isShizukuPermissionGranted.value && !viewModel.isRootPermissionGranted.value) {
+                        requestingPermissionFor = PermissionModule.PIXEL_SEARCHBAR
+                    }
+                },
+                iconRes = R.drawable.rounded_search_24,
+                modifier = Modifier.highlight(highlightSetting == "pixel_searchbar_toggle")
             )
 
             AnimatedVisibility(

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/OtherCustomizationsSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/OtherCustomizationsSettingsUI.kt
@@ -256,30 +256,7 @@ fun OtherCustomizationsSettingsUI(
                 modifier = Modifier.highlight(highlightSetting == "disable_rotation_suggestion_toggle")
             )
 
-            IconToggleItem(
-                title = stringResource(R.string.feat_pixel_searchbar_title),
-                description = stringResource(R.string.feat_pixel_searchbar_desc),
-                isChecked = viewModel.isPixelSearchbarEnabled.value,
-                onCheckedChange = { enabled ->
-                    if (viewModel.isWriteSecureSettingsEnabled.value || viewModel.isShizukuPermissionGranted.value || viewModel.isRootPermissionGranted.value) {
-                        viewModel.setPixelSearchbarEnabled(enabled, context)
-                    } else {
-                        requestingPermissionFor = PermissionModule.PIXEL_SEARCHBAR
-                    }
-                },
-                onClick = {
-                    val intent = Intent(context, PixelSearchbarSettingsActivity::class.java)
-                    context.startActivity(intent)
-                },
-                enabled = true,
-                onDisabledClick = {
-                    if (!viewModel.isWriteSecureSettingsEnabled.value && !viewModel.isShizukuPermissionGranted.value && !viewModel.isRootPermissionGranted.value) {
-                        requestingPermissionFor = PermissionModule.PIXEL_SEARCHBAR
-                    }
-                },
-                iconRes = R.drawable.rounded_search_24,
-                modifier = Modifier.highlight(highlightSetting == "pixel_searchbar_toggle")
-            )
+
 
             AnimatedVisibility(
                 visible = viewModel.isCircleToSearchGestureEnabled.value,

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchControlsSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchControlsSettingsUI.kt
@@ -1,0 +1,270 @@
+package com.sameerasw.essentials.ui.composables.configs
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.services.DeviceInfoSyncManager
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+import kotlin.math.min
+
+@Composable
+fun WatchControlsSettingsUI(
+    modifier: Modifier = Modifier,
+    highlightSetting: String? = null
+) {
+    val context = LocalContext.current
+    val prefs = remember {
+        context.getSharedPreferences("essentials_prefs", android.content.Context.MODE_PRIVATE)
+    }
+
+    val defaultLayout = "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD"
+    val savedLayout = prefs.getString("watch_controls_layout", defaultLayout) ?: defaultLayout
+    var activeControls by remember { mutableStateOf(savedLayout.split(",").filter { it.isNotBlank() }) }
+
+    val allPossible = listOf("LOCK", "SOUND", "FLASHLIGHT", "FLASHLIGHT_PULSE", "AOD")
+    var disabledControls by remember {
+        mutableStateOf(allPossible.filter { it !in activeControls })
+    }
+
+    val controlIcons = mapOf(
+        "LOCK" to R.drawable.rounded_lock_24,
+        "SOUND" to R.drawable.rounded_volume_up_24,
+        "FLASHLIGHT" to R.drawable.rounded_flashlight_on_24,
+        "FLASHLIGHT_PULSE" to R.drawable.outline_backlight_high_24,
+        "AOD" to R.drawable.rounded_mobile_text_2_24
+    )
+
+    val controlNames = mapOf(
+        "LOCK" to R.string.feat_lock_from_watch_title,
+        "SOUND" to R.string.tile_sound_mode,
+        "FLASHLIGHT" to R.string.tile_flashlight,
+        "FLASHLIGHT_PULSE" to R.string.tile_flashlight_pulse,
+        "AOD" to R.string.feat_always_on_display_title
+    )
+
+    fun save() {
+        prefs.edit {
+            putString("watch_controls_layout", activeControls.joinToString(","))
+        }
+        DeviceInfoSyncManager.forceSync(context)
+    }
+
+    val hapticFeedback = LocalHapticFeedback.current
+    val lazyListState = rememberLazyListState()
+    val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val originalActiveSize = activeControls.size
+        val fromKey: String = when {
+            from.index < originalActiveSize -> activeControls.getOrNull(from.index)
+                ?: return@rememberReorderableLazyListState
+            from.index == originalActiveSize -> "separator"
+            else -> disabledControls.getOrNull(from.index - originalActiveSize - 1)
+                ?: return@rememberReorderableLazyListState
+        }
+        if (fromKey == "separator") return@rememberReorderableLazyListState
+
+        if (from.index < originalActiveSize) {
+            activeControls = activeControls.toMutableList().apply { removeAt(from.index) }
+        } else {
+            disabledControls = disabledControls.toMutableList()
+                .apply { removeAt(from.index - originalActiveSize - 1) }
+        }
+
+        val newActiveSize = activeControls.size
+        val newDisabledSize = disabledControls.size
+        if (to.index < newActiveSize) {
+            activeControls = activeControls.toMutableList().apply { add(to.index, fromKey) }
+        } else if (to.index == newActiveSize) {
+            activeControls = activeControls.toMutableList().apply { add(newActiveSize, fromKey) }
+        } else {
+            val pos = min(to.index - newActiveSize - 1, newDisabledSize)
+            disabledControls = disabledControls.toMutableList().apply { add(pos, fromKey) }
+        }
+
+        // Enforce at least 1 active
+        if (from.index < originalActiveSize && activeControls.isEmpty() && disabledControls.isNotEmpty()) {
+            val restore = disabledControls[0]
+            activeControls = listOf(restore)
+            disabledControls = disabledControls.drop(1)
+        }
+
+        save()
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+    }
+
+    Text(
+        text = stringResource(R.string.watch_controls_reorder_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(start = 24.dp, top = 16.dp, end = 24.dp),
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        state = lazyListState,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        items(activeControls.size, key = { activeControls[it] }) { index ->
+            val key = activeControls[index]
+            ReorderableItem(reorderableLazyListState, key = key) { _ ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .pointerInput(Unit) {
+                            detectTapGestures(onLongPress = {
+                                if (activeControls.size > 1) {
+                                    val toDisable = activeControls[index]
+                                    activeControls = activeControls.toMutableList().apply { removeAt(index) }
+                                    disabledControls = disabledControls + toDisable
+                                }
+                                save()
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            })
+                        }
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(id = controlIcons[key] ?: R.drawable.rounded_watch_24),
+                            contentDescription = key,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            stringResource(controlNames[key] ?: R.string.feat_watch_controls_title),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        IconButton(
+                            modifier = Modifier.draggableHandle(
+                                onDragStarted = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+                                },
+                                onDragStopped = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
+                                }
+                            ),
+                            onClick = {}
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_drag_handle_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            ReorderableItem(reorderableLazyListState, key = "separator") { _ ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = stringResource(R.string.watch_controls_long_press_hint),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        items(disabledControls.size, key = { disabledControls[it] }) { index ->
+            val key = disabledControls[index]
+            ReorderableItem(reorderableLazyListState, key = key) { _ ->
+                OutlinedCard(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .pointerInput(Unit) {
+                            detectTapGestures(onLongPress = {
+                                val toEnable = disabledControls[index]
+                                disabledControls = disabledControls.toMutableList().apply { removeAt(index) }
+                                activeControls = activeControls + toEnable
+                                save()
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            })
+                        }
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(id = controlIcons[key] ?: R.drawable.rounded_watch_24),
+                            contentDescription = key,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            stringResource(controlNames[key] ?: R.string.feat_watch_controls_title),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        IconButton(
+                            modifier = Modifier.draggableHandle(
+                                onDragStarted = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+                                },
+                                onDragStopped = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
+                                }
+                            ),
+                            onClick = {}
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_drag_handle_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchControlsSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchControlsSettingsUI.kt
@@ -50,11 +50,11 @@ fun WatchControlsSettingsUI(
         context.getSharedPreferences("essentials_prefs", android.content.Context.MODE_PRIVATE)
     }
 
-    val defaultLayout = "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD"
+    val defaultLayout = "LOCK,SOUND,FLASHLIGHT,FLASHLIGHT_PULSE,AOD,TAP_TO_WAKE"
     val savedLayout = prefs.getString("watch_controls_layout", defaultLayout) ?: defaultLayout
     var activeControls by remember { mutableStateOf(savedLayout.split(",").filter { it.isNotBlank() }) }
 
-    val allPossible = listOf("LOCK", "SOUND", "FLASHLIGHT", "FLASHLIGHT_PULSE", "AOD")
+    val allPossible = listOf("LOCK", "SOUND", "FLASHLIGHT", "FLASHLIGHT_PULSE", "AOD", "TAP_TO_WAKE")
     var disabledControls by remember {
         mutableStateOf(allPossible.filter { it !in activeControls })
     }
@@ -64,7 +64,8 @@ fun WatchControlsSettingsUI(
         "SOUND" to R.drawable.rounded_volume_up_24,
         "FLASHLIGHT" to R.drawable.rounded_flashlight_on_24,
         "FLASHLIGHT_PULSE" to R.drawable.outline_backlight_high_24,
-        "AOD" to R.drawable.rounded_mobile_text_2_24
+        "AOD" to R.drawable.rounded_mobile_text_2_24,
+        "TAP_TO_WAKE" to R.drawable.rounded_touch_app_24
     )
 
     val controlNames = mapOf(
@@ -72,7 +73,8 @@ fun WatchControlsSettingsUI(
         "SOUND" to R.string.tile_sound_mode,
         "FLASHLIGHT" to R.string.tile_flashlight,
         "FLASHLIGHT_PULSE" to R.string.tile_flashlight_pulse,
-        "AOD" to R.string.feat_always_on_display_title
+        "AOD" to R.string.feat_always_on_display_title,
+        "TAP_TO_WAKE" to R.string.tile_tap_to_wake
     )
 
     fun save() {

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/WatchSettingsUI.kt
@@ -1,6 +1,7 @@
 package com.sameerasw.essentials.ui.composables.configs
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,7 @@ fun WatchSettingsUI(
 ) {
     val uriHandler = LocalUriHandler.current
     val view = LocalView.current
+    val context = LocalContext.current
     val isWatchDetected = viewModel.isWatchDetected.value
     val connectedWatchName = viewModel.connectedWatchName.value
 
@@ -58,6 +60,12 @@ fun WatchSettingsUI(
                         .fillMaxWidth()
                         .height(280.dp)
                         .background(MaterialTheme.colorScheme.surfaceBright)
+                        .clickable {
+                            HapticUtil.performUIHaptic(view)
+                            android.widget.Toast.makeText(context, "Syncing...", android.widget.Toast.LENGTH_SHORT).show()
+                            com.sameerasw.essentials.services.DeviceInfoSyncManager.forceSync(context)
+                            com.sameerasw.essentials.services.CalendarSyncManager.forceSync(context)
+                        }
                         .padding(24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/watermark/WatermarkScreen.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/watermark/WatermarkScreen.kt
@@ -1,5 +1,7 @@
 package com.sameerasw.essentials.ui.composables.watermark
 
+import android.app.Activity
+import android.content.pm.ActivityInfo
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
@@ -19,6 +21,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -58,6 +61,34 @@ fun WatermarkScreen(
 
     val options by viewModel.options.collectAsState()
     val previewState by viewModel.previewUiState.collectAsState()
+
+    val isShowingHdrContent = remember(previewState) {
+        val successState = previewState as? WatermarkUiState.Success
+        val bitmap = successState?.bitmap
+        android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE && bitmap?.hasGainmap() == true
+    }
+
+    DisposableEffect(isShowingHdrContent) {
+        val activity = context as? Activity
+        if (activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            activity.window.colorMode = if (isShowingHdrContent) {
+                ActivityInfo.COLOR_MODE_HDR
+            } else {
+                ActivityInfo.COLOR_MODE_DEFAULT
+            }
+            if (android.os.Build.VERSION.SDK_INT >= 35) {
+                activity.window.desiredHdrHeadroom = if (isShowingHdrContent) 5.0f else 1.0f
+            }
+        }
+        onDispose {
+            if (activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                activity.window.colorMode = ActivityInfo.COLOR_MODE_DEFAULT
+                if (android.os.Build.VERSION.SDK_INT >= 35) {
+                    activity.window.desiredHdrHeadroom = 1.0f
+                }
+            }
+        }
+    }
     val saveState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(initialUri) {

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
@@ -54,7 +54,15 @@ object PermissionUIHelper {
                 secondaryAction = {
                     viewModel.check(context)
                 },
-                isGranted = viewModel.isWriteSecureSettingsEnabled.value
+                isGranted = viewModel.isWriteSecureSettingsEnabled.value,
+                shizukuActionLabel = R.string.perm_action_grant_shizuku,
+                shizukuActionEnabled = ShizukuUtils.hasPermission(),
+                shizukuAction = {
+                    if (ShizukuUtils.grantWriteSecureSettingsPermission()) {
+                        viewModel.check(context)
+                    }
+                },
+                instructions = R.string.perm_write_secure_instructions
             )
 
             "NOTIFICATION_LISTENER" -> PermissionItem(

--- a/app/src/main/java/com/sameerasw/essentials/utils/ShellUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/ShellUtils.kt
@@ -4,6 +4,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.sameerasw.essentials.R
@@ -109,6 +110,16 @@ object ShellUtils {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        val restartIntent = Intent(context, com.sameerasw.essentials.services.receivers.ShizukuActionReceiver::class.java).apply {
+            action = "com.sameerasw.essentials.ACTION_RESTART_SHIZUKU"
+        }
+        val restartPendingIntent = PendingIntent.getBroadcast(
+            context,
+            9001,
+            restartIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.app_logo)
             .setContentTitle(title)
@@ -116,6 +127,11 @@ object ShellUtils {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
+            .addAction(
+                R.drawable.rounded_power_settings_new_24,
+                context.getString(R.string.action_restart_shizuku),
+                restartPendingIntent
+            )
 
         notificationManager.notify(9001, builder.build())
     }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -58,6 +58,9 @@ import com.sameerasw.essentials.utils.DeviceUtils
 import com.sameerasw.essentials.utils.PermissionUtils
 import com.sameerasw.essentials.utils.RefreshRateUtils
 import com.sameerasw.essentials.utils.RootUtils
+import java.io.File
+import java.io.FileOutputStream
+import android.graphics.Bitmap
 import com.sameerasw.essentials.utils.ShellUtils
 import com.sameerasw.essentials.utils.ShizukuUtils
 import com.sameerasw.essentials.utils.UpdateNotificationHelper
@@ -153,6 +156,9 @@ class MainViewModel : ViewModel() {
     val pixelSearchbarWidgetPaddingH = mutableIntStateOf(0)
     val pixelSearchbarWidgetPaddingV = mutableIntStateOf(0)
     val pixelSearchbarTapActionEnabled = mutableStateOf(true)
+    val pixelSearchbarMusicTitle = mutableStateOf("")
+    val pixelSearchbarMusicArtist = mutableStateOf("")
+    val pixelSearchbarMusicPackage = mutableStateOf("")
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -872,6 +878,12 @@ class MainViewModel : ViewModel() {
             settingsRepository.getPixelSearchbarWidgetPaddingV()
         pixelSearchbarTapActionEnabled.value =
             settingsRepository.getPixelSearchbarTapActionEnabled()
+        pixelSearchbarMusicTitle.value =
+            settingsRepository.getPixelSearchbarMusicTitle()
+        pixelSearchbarMusicArtist.value =
+            settingsRepository.getPixelSearchbarMusicArtist()
+        pixelSearchbarMusicPackage.value =
+            settingsRepository.getPixelSearchbarMusicPackage()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1866,6 +1878,9 @@ class MainViewModel : ViewModel() {
     fun setPixelSearchbarType(type: String, context: Context) {
         pixelSearchbarType.value = type
         settingsRepository.setPixelSearchbarType(type)
+        if (type == "music") {
+            updateMediaFromActiveSession(context)
+        }
         updatePixelSearchbarWidget(context)
 
         // Force stop nexus launcher to apply setting
@@ -1946,6 +1961,64 @@ class MainViewModel : ViewModel() {
         pixelSearchbarTapActionEnabled.value = enabled
         settingsRepository.setPixelSearchbarTapActionEnabled(enabled)
         updatePixelSearchbarWidget(context)
+    }
+
+    fun updatePixelSearchbarMusic(title: String, artist: String, packageName: String, context: Context) {
+        pixelSearchbarMusicTitle.value = title
+        pixelSearchbarMusicArtist.value = artist
+        pixelSearchbarMusicPackage.value = packageName
+        settingsRepository.setPixelSearchbarMusicTitle(title)
+        settingsRepository.setPixelSearchbarMusicArtist(artist)
+        settingsRepository.setPixelSearchbarMusicPackage(packageName)
+        settingsRepository.incrementPixelSearchbarWidgetRevision()
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun updateMediaFromActiveSession(context: Context) {
+        try {
+            val manager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? android.media.session.MediaSessionManager ?: return
+            val componentName = android.content.ComponentName(context, com.sameerasw.essentials.services.NotificationListener::class.java)
+            val sessions = manager.getActiveSessions(componentName)
+            val activeSession = sessions?.sortedWith(
+                compareByDescending<android.media.session.MediaController> { 
+                    val state = it.playbackState?.state
+                    state == android.media.session.PlaybackState.STATE_PLAYING || state == android.media.session.PlaybackState.STATE_BUFFERING
+                }.thenByDescending {
+                    val state = it.playbackState?.state
+                    state == android.media.session.PlaybackState.STATE_PAUSED
+                }
+            )?.firstOrNull()
+
+            if (activeSession != null) {
+                val metadata = activeSession.metadata
+                val title = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE) ?: ""
+                val artist = metadata?.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST) ?: ""
+                val packageName = activeSession.packageName
+
+                val artwork = metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_ALBUM_ART)
+                    ?: metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_ART)
+                    ?: metadata?.getBitmap(android.media.MediaMetadata.METADATA_KEY_DISPLAY_ICON)
+
+                val filesDirFile = File(context.filesDir, "music_artwork.png")
+                if (artwork != null) {
+                    try {
+                        FileOutputStream(filesDirFile).use { out ->
+                            artwork.compress(Bitmap.CompressFormat.PNG, 100, out)
+                        }
+                    } catch (_: Exception) {}
+                } else {
+                    if (filesDirFile.exists()) filesDirFile.delete()
+                }
+
+                pixelSearchbarMusicTitle.value = title
+                pixelSearchbarMusicArtist.value = artist
+                pixelSearchbarMusicPackage.value = packageName
+                settingsRepository.setPixelSearchbarMusicTitle(title)
+                settingsRepository.setPixelSearchbarMusicArtist(artist)
+                settingsRepository.setPixelSearchbarMusicPackage(packageName)
+                settingsRepository.incrementPixelSearchbarWidgetRevision()
+            }
+        } catch (_: Exception) {}
     }
 
     fun updatePixelSearchbarWidget(context: Context) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -144,6 +144,7 @@ class MainViewModel : ViewModel() {
     val isDisableRotationSuggestionEnabled = mutableStateOf(false)
     val isPixelSearchbarEnabled = mutableStateOf(false)
     val pixelSearchbarType = mutableStateOf("empty")
+    val pixelSearchbarDateFormat = mutableStateOf("EEEE, MMMM d")
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -845,6 +846,8 @@ class MainViewModel : ViewModel() {
             settingsRepository.getBoolean(SettingsRepository.KEY_PIXEL_SEARCHBAR, false)
         pixelSearchbarType.value =
             settingsRepository.getPixelSearchbarType()
+        pixelSearchbarDateFormat.value =
+            settingsRepository.getPixelSearchbarDateFormat()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1839,6 +1842,20 @@ class MainViewModel : ViewModel() {
     fun setPixelSearchbarType(type: String, context: Context) {
         pixelSearchbarType.value = type
         settingsRepository.setPixelSearchbarType(type)
+        updatePixelSearchbarWidget(context)
+
+        // Force stop nexus launcher to apply setting
+        val forceStopCommand = "am force-stop com.google.android.apps.nexuslauncher"
+        if (ShizukuUtils.hasPermission()) {
+            ShizukuUtils.runCommand(forceStopCommand)
+        } else if (RootUtils.isRootPermissionGranted()) {
+            RootUtils.runCommand(forceStopCommand)
+        }
+    }
+
+    fun setPixelSearchbarDateFormat(format: String, context: Context) {
+        pixelSearchbarDateFormat.value = format
+        settingsRepository.setPixelSearchbarDateFormat(format)
         updatePixelSearchbarWidget(context)
 
         // Force stop nexus launcher to apply setting

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -142,6 +142,8 @@ class MainViewModel : ViewModel() {
     val circleToSearchGestureHeight = mutableFloatStateOf(48f)
     val isCircleToSearchPreviewEnabled = mutableStateOf(false)
     val isDisableRotationSuggestionEnabled = mutableStateOf(false)
+    val isPixelSearchbarEnabled = mutableStateOf(false)
+    val pixelSearchbarType = mutableStateOf("empty")
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -668,6 +670,17 @@ class MainViewModel : ViewModel() {
                             )
                         }
                     }
+
+                    SettingsRepository.KEY_PIXEL_SEARCHBAR -> {
+                        isPixelSearchbarEnabled.value =
+                            settingsRepository.getBoolean(key)
+                        appContext?.let {
+                            applyPixelSearchbarSetting(
+                                it,
+                                isPixelSearchbarEnabled.value
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -828,6 +841,10 @@ class MainViewModel : ViewModel() {
             settingsRepository.getEdgeLightingSweepSelectedShapes()
         isDisableRotationSuggestionEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_DISABLE_ROTATION_SUGGESTION, false)
+        isPixelSearchbarEnabled.value =
+            settingsRepository.getBoolean(SettingsRepository.KEY_PIXEL_SEARCHBAR, false)
+        pixelSearchbarType.value =
+            settingsRepository.getPixelSearchbarType()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1774,6 +1791,76 @@ class MainViewModel : ViewModel() {
                 ShizukuUtils.runCommand(command)
             } else if (RootUtils.isRootPermissionGranted()) {
                 RootUtils.runCommand(command)
+            }
+        }
+    }
+
+    fun setPixelSearchbarEnabled(enabled: Boolean, context: Context) {
+        isPixelSearchbarEnabled.value = enabled
+        settingsRepository.putBoolean(SettingsRepository.KEY_PIXEL_SEARCHBAR, enabled)
+        applyPixelSearchbarSetting(context, enabled)
+    }
+
+    private fun applyPixelSearchbarSetting(context: Context, enabled: Boolean) {
+        val value = if (enabled) "com.sameerasw.essentials" else null
+        val key = "selected_search_engine"
+
+        var success = false
+        if (PermissionUtils.canWriteSecureSettings(context)) {
+            try {
+                success = Settings.Secure.putString(context.contentResolver, key, value)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+
+        if (!success) {
+            val command = if (enabled) {
+                "settings put secure $key com.sameerasw.essentials"
+            } else {
+                "settings delete secure $key"
+            }
+            if (ShizukuUtils.hasPermission()) {
+                ShizukuUtils.runCommand(command)
+            } else if (RootUtils.isRootPermissionGranted()) {
+                RootUtils.runCommand(command)
+            }
+        }
+
+        // Force stop nexus launcher to apply setting
+        val forceStopCommand = "am force-stop com.google.android.apps.nexuslauncher"
+        if (ShizukuUtils.hasPermission()) {
+            ShizukuUtils.runCommand(forceStopCommand)
+        } else if (RootUtils.isRootPermissionGranted()) {
+            RootUtils.runCommand(forceStopCommand)
+        }
+    }
+
+    fun setPixelSearchbarType(type: String, context: Context) {
+        pixelSearchbarType.value = type
+        settingsRepository.setPixelSearchbarType(type)
+        updatePixelSearchbarWidget(context)
+
+        // Force stop nexus launcher to apply setting
+        val forceStopCommand = "am force-stop com.google.android.apps.nexuslauncher"
+        if (ShizukuUtils.hasPermission()) {
+            ShizukuUtils.runCommand(forceStopCommand)
+        } else if (RootUtils.isRootPermissionGranted()) {
+            RootUtils.runCommand(forceStopCommand)
+        }
+    }
+
+    fun updatePixelSearchbarWidget(context: Context) {
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            try {
+                val manager = androidx.glance.appwidget.GlanceAppWidgetManager(context)
+                val widget = com.sameerasw.essentials.services.widgets.PixelSearchbarWidget()
+                val glanceIds = manager.getGlanceIds(com.sameerasw.essentials.services.widgets.PixelSearchbarWidget::class.java)
+                for (glanceId in glanceIds) {
+                    widget.update(context, glanceId)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
         }
     }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -249,6 +249,7 @@ class MainViewModel : ViewModel() {
     val isPitchBlackThemeEnabled = mutableStateOf(false)
     val isBlurEnabled = mutableStateOf(true)
     val isBlurSettingEnabled = mutableStateOf(true)
+    val isSwipeTabsEnabled = mutableStateOf(true)
     val sentryReportMode = mutableStateOf("auto")
     val isPowerSaveModeEnabled = mutableStateOf(false)
     private var powerSaveReceiver: BroadcastReceiver? = null
@@ -1150,6 +1151,7 @@ class MainViewModel : ViewModel() {
         MapsState.isEnabled = isMapsPowerSavingEnabled.value
         hapticFeedbackType.value = settingsRepository.getHapticFeedbackType()
         defaultTab.value = settingsRepository.getDIYTab()
+        isSwipeTabsEnabled.value = settingsRepository.getBoolean(SettingsRepository.KEY_SWIPE_TABS, true)
         sentryReportMode.value =
             settingsRepository.getString(SettingsRepository.KEY_SENTRY_REPORT_MODE, "auto")
                 ?: "auto"
@@ -1618,6 +1620,11 @@ class MainViewModel : ViewModel() {
     fun setBlurEnabled(enabled: Boolean, context: Context) {
         settingsRepository.putBoolean(SettingsRepository.KEY_USE_BLUR, enabled)
         updateBlurState(context)
+    }
+
+    fun setSwipeTabsEnabled(enabled: Boolean) {
+        settingsRepository.putBoolean(SettingsRepository.KEY_SWIPE_TABS, enabled)
+        isSwipeTabsEnabled.value = enabled
     }
 
     private fun updateBlurState(context: Context) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -150,6 +150,9 @@ class MainViewModel : ViewModel() {
     val pixelSearchbarWidgetProvider = mutableStateOf<String?>(null)
     val pixelSearchbarScrapedLine1 = mutableStateOf("")
     val pixelSearchbarScrapedLine2 = mutableStateOf("")
+    val pixelSearchbarWidgetPaddingH = mutableIntStateOf(0)
+    val pixelSearchbarWidgetPaddingV = mutableIntStateOf(0)
+    val pixelSearchbarTapActionEnabled = mutableStateOf(true)
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -863,6 +866,12 @@ class MainViewModel : ViewModel() {
             settingsRepository.getPixelSearchbarScrapedLine1()
         pixelSearchbarScrapedLine2.value =
             settingsRepository.getPixelSearchbarScrapedLine2()
+        pixelSearchbarWidgetPaddingH.intValue =
+            settingsRepository.getPixelSearchbarWidgetPaddingH()
+        pixelSearchbarWidgetPaddingV.intValue =
+            settingsRepository.getPixelSearchbarWidgetPaddingV()
+        pixelSearchbarTapActionEnabled.value =
+            settingsRepository.getPixelSearchbarTapActionEnabled()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1918,6 +1927,24 @@ class MainViewModel : ViewModel() {
         pixelSearchbarScrapedLine2.value = line2
         settingsRepository.setPixelSearchbarScrapedLine1(line1)
         settingsRepository.setPixelSearchbarScrapedLine2(line2)
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun setPixelSearchbarWidgetPaddingH(value: Int, context: Context) {
+        pixelSearchbarWidgetPaddingH.intValue = value
+        settingsRepository.setPixelSearchbarWidgetPaddingH(value)
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun setPixelSearchbarWidgetPaddingV(value: Int, context: Context) {
+        pixelSearchbarWidgetPaddingV.intValue = value
+        settingsRepository.setPixelSearchbarWidgetPaddingV(value)
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun setPixelSearchbarTapActionEnabled(enabled: Boolean, context: Context) {
+        pixelSearchbarTapActionEnabled.value = enabled
+        settingsRepository.setPixelSearchbarTapActionEnabled(enabled)
         updatePixelSearchbarWidget(context)
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -145,6 +145,7 @@ class MainViewModel : ViewModel() {
     val isPixelSearchbarEnabled = mutableStateOf(false)
     val pixelSearchbarType = mutableStateOf("empty")
     val pixelSearchbarDateFormat = mutableStateOf("EEEE, MMMM d")
+    val pixelSearchbarBackgroundPill = mutableStateOf(false)
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -848,6 +849,8 @@ class MainViewModel : ViewModel() {
             settingsRepository.getPixelSearchbarType()
         pixelSearchbarDateFormat.value =
             settingsRepository.getPixelSearchbarDateFormat()
+        pixelSearchbarBackgroundPill.value =
+            settingsRepository.getPixelSearchbarBackgroundPill()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1856,6 +1859,20 @@ class MainViewModel : ViewModel() {
     fun setPixelSearchbarDateFormat(format: String, context: Context) {
         pixelSearchbarDateFormat.value = format
         settingsRepository.setPixelSearchbarDateFormat(format)
+        updatePixelSearchbarWidget(context)
+
+        // Force stop nexus launcher to apply setting
+        val forceStopCommand = "am force-stop com.google.android.apps.nexuslauncher"
+        if (ShizukuUtils.hasPermission()) {
+            ShizukuUtils.runCommand(forceStopCommand)
+        } else if (RootUtils.isRootPermissionGranted()) {
+            RootUtils.runCommand(forceStopCommand)
+        }
+    }
+
+    fun setPixelSearchbarBackgroundPill(enabled: Boolean, context: Context) {
+        pixelSearchbarBackgroundPill.value = enabled
+        settingsRepository.setPixelSearchbarBackgroundPill(enabled)
         updatePixelSearchbarWidget(context)
 
         // Force stop nexus launcher to apply setting

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -146,6 +146,10 @@ class MainViewModel : ViewModel() {
     val pixelSearchbarType = mutableStateOf("empty")
     val pixelSearchbarDateFormat = mutableStateOf("EEEE, MMMM d")
     val pixelSearchbarBackgroundPill = mutableStateOf(false)
+    val pixelSearchbarWidgetId = mutableIntStateOf(android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID)
+    val pixelSearchbarWidgetProvider = mutableStateOf<String?>(null)
+    val pixelSearchbarScrapedLine1 = mutableStateOf("")
+    val pixelSearchbarScrapedLine2 = mutableStateOf("")
     val lockScreenClockId = mutableStateOf<String?>(null)
     val lockScreenClockWeight = mutableIntStateOf(300)
     val lockScreenClockWidth = mutableIntStateOf(116)
@@ -851,6 +855,14 @@ class MainViewModel : ViewModel() {
             settingsRepository.getPixelSearchbarDateFormat()
         pixelSearchbarBackgroundPill.value =
             settingsRepository.getPixelSearchbarBackgroundPill()
+        pixelSearchbarWidgetId.intValue =
+            settingsRepository.getPixelSearchbarWidgetId()
+        pixelSearchbarWidgetProvider.value =
+            settingsRepository.getPixelSearchbarWidgetProvider()
+        pixelSearchbarScrapedLine1.value =
+            settingsRepository.getPixelSearchbarScrapedLine1()
+        pixelSearchbarScrapedLine2.value =
+            settingsRepository.getPixelSearchbarScrapedLine2()
         lockScreenClockId.value = readCurrentLockScreenClockId(context)
         lockScreenClockWeight.intValue = settingsRepository.getLockScreenClockWeight()
         lockScreenClockWidth.intValue = settingsRepository.getLockScreenClockWidth()
@@ -1882,6 +1894,31 @@ class MainViewModel : ViewModel() {
         } else if (RootUtils.isRootPermissionGranted()) {
             RootUtils.runCommand(forceStopCommand)
         }
+    }
+
+    fun setPixelSearchbarWidgetId(id: Int, provider: String?, context: Context) {
+        pixelSearchbarWidgetId.intValue = id
+        pixelSearchbarWidgetProvider.value = provider
+        settingsRepository.setPixelSearchbarWidgetId(id)
+        settingsRepository.setPixelSearchbarWidgetProvider(provider)
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun clearPixelSearchbarWidget(context: Context) {
+        pixelSearchbarWidgetId.intValue = android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID
+        pixelSearchbarWidgetProvider.value = null
+        settingsRepository.setPixelSearchbarWidgetId(android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID)
+        settingsRepository.setPixelSearchbarWidgetProvider(null)
+        context.stopService(android.content.Intent(context, com.sameerasw.essentials.services.widgets.WidgetScraperService::class.java))
+        updatePixelSearchbarWidget(context)
+    }
+
+    fun updatePixelSearchbarScrapedText(line1: String, line2: String, context: Context) {
+        pixelSearchbarScrapedLine1.value = line1
+        pixelSearchbarScrapedLine2.value = line2
+        settingsRepository.setPixelSearchbarScrapedLine1(line1)
+        settingsRepository.setPixelSearchbarScrapedLine2(line2)
+        updatePixelSearchbarWidget(context)
     }
 
     fun updatePixelSearchbarWidget(context: Context) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/WatermarkViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/WatermarkViewModel.kt
@@ -24,7 +24,7 @@ import java.io.File
 sealed class WatermarkUiState {
     data object Idle : WatermarkUiState()
     data object Processing : WatermarkUiState()
-    data class Success(val file: File) : WatermarkUiState()
+    data class Success(val file: File, val bitmap: android.graphics.Bitmap? = null) : WatermarkUiState()
     data class Error(val message: String) : WatermarkUiState()
 }
 
@@ -248,6 +248,12 @@ class WatermarkViewModel(
                 val workingBitmap =
                     bitmap.copy(bitmap.config ?: android.graphics.Bitmap.Config.ARGB_8888, true)
 
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    if (bitmap.hasGainmap()) {
+                        workingBitmap.gainmap = bitmap.gainmap
+                    }
+                }
+
                 // Merge transient logo settings with base options
                 val currentOptions = _options.value.copy(
                     logoResId = _logoResId.value,
@@ -272,7 +278,7 @@ class WatermarkViewModel(
                     }
                 }
 
-                _previewUiState.value = WatermarkUiState.Success(file)
+                _previewUiState.value = WatermarkUiState.Success(file, result)
             } catch (e: Exception) {
                 e.printStackTrace()
                 _previewUiState.value = WatermarkUiState.Error(e.message ?: "Unknown error")

--- a/app/src/main/res/font/google_sans_flex_round.xml
+++ b/app/src/main/res/font/google_sans_flex_round.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<font-family xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <font
+        android:font="@font/google_sans_flex"
+        android:fontStyle="normal"
+        android:fontWeight="400"
+        app:fontVariationSettings="&apos;ROND&apos; 100"
+        android:fontVariationSettings="&apos;ROND&apos; 100" />
+    <font
+        android:font="@font/google_sans_flex"
+        android:fontStyle="normal"
+        android:fontWeight="500"
+        app:fontVariationSettings="&apos;ROND&apos; 100"
+        android:fontVariationSettings="&apos;ROND&apos; 100" />
+    <font
+        android:font="@font/google_sans_flex"
+        android:fontStyle="normal"
+        android:fontWeight="700"
+        app:fontVariationSettings="&apos;ROND&apos; 100"
+        android:fontVariationSettings="&apos;ROND&apos; 100" />
+</font-family>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="label_customization">Customization</string>
-    <string name="label_beta"></string>
+    <string name="label_beta">BETA</string>
     <string name="shut_up_attempt_shizuku_restart">Attempt Shizuku restart</string>
     <string name="shut_up_shizuku_restart_warning_title">Shizuku Restart Warning</string>
     <string name="shut_up_shizuku_restart_warning_message">Since wireless debugging was toggled, Shizuku services might not have started automatically causing freezing to not function. Consider turning on attempt shizuku restart as well</string>
@@ -1454,4 +1454,6 @@
     <string name="whats_new_specs_desc">Inaccurate GSMArena-powered specifications have been removed to keep device insights clean, fast, and completely reliable.</string>
     <string name="whats_new_apps_title">App Updates Migrated</string>
     <string name="whats_new_apps_desc">The Apps tab is now fully integrated into the Your Android feature, making it easier to manage all your app updates in one cohesive hub.</string>
+    <string name="action_restart_shizuku">Restart Shizuku</string>
+    <string name="toast_enter_shizuku_token">Please enter Shizuku auth token in settings first</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1606,4 +1606,6 @@
     <string name="pixel_searchbar_tap_action_enabled">Custom tap action</string>
     <string name="pixel_searchbar_tap_action_enabled_desc">Use DIY tap action instead of widget\'s own</string>
     <string name="pixel_searchbar_style_music">Music</string>
+    <string name="action_restart_shizuku">Restart Shizuku</string>
+    <string name="toast_enter_shizuku_token">Please enter Shizuku auth token in settings first</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,6 +445,8 @@
     <string name="diy_create_state_desc">Schedule an action to execute based on the state of a condition in and out</string>
     <string name="diy_create_action_shortcut_title">Action Shortcut</string>
     <string name="diy_create_action_shortcut_desc">Launch shortcut to trigger action</string>
+    <string name="diy_create_pixel_searchbar_title">Pixel searchbar</string>
+    <string name="diy_create_pixel_searchbar_desc">Tap action for Pixel searchbar replacement</string>
     <string name="diy_editor_new_title">New Automation</string>
     <string name="diy_editor_edit_title">Edit Automation</string>
     <string name="feat_link_actions_title">Link actions</string>
@@ -1586,4 +1588,6 @@
     <string name="pixel_searchbar_background_pill_desc">Show the date inside a container</string>
     <string name="about_desc_pixel_searchbar">Replace the default Pixel Launcher search bar on your home screen. You can customize the content to show either nothing (Empty) or the current date. \n\nPlease note that enabling this may break Pixel Launcher At a Glance widgets (such as sports and finance widgets). \n\nAnd the setting may need to be applied multiple times to take effect.</string>
     <string name="label_replace_with">Replace with</string>
+    <string name="pixel_searchbar_tap_action_title">Configure tap action</string>
+    <string name="pixel_searchbar_tap_action_desc">Set up actions to trigger in DIY automations when tapped</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1352,6 +1352,10 @@
     <string name="watch_help_title">Install on Watch</string>
     <string name="watch_help_description">To use Watch features, you need to install the Essentials companion app on your Wear OS watch. Click the button below to open the Play Store directly on your watch.</string>
     <string name="watch_help_open_play_store">Open on Watch</string>
+    <string name="feat_watch_controls_title">Customize</string>
+    <string name="feat_watch_controls_desc">Customize WearOS app controls</string>
+    <string name="watch_controls_long_press_hint">Long press to enable or disable buttons</string>
+    <string name="watch_controls_reorder_title">Reorder watch controls</string>
 
 
     <string name="cat_interaction">Interaction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1522,6 +1522,8 @@
     <string name="shut_up_shortcut_created">Shortcut created for %s</string>
     <string name="feat_disable_rotation_suggestion_title">Disable rotation suggestion</string>
     <string name="feat_disable_rotation_suggestion_desc">Do not show the rotation button when auto-rotate is off</string>
+    <string name="feat_pixel_searchbar_title">Pixel searchbar</string>
+    <string name="feat_pixel_searchbar_desc">Set Essentials as the default search provider for the home screen search bar in Pixel Launcher.</string>
     <string name="shut_up_toast_active">App got shut up</string>
     <string name="shut_up_toast_restored">Shut up features returned</string>
     <string name="shut_up_auto_archive_notif_title">Auto Freeze</string>
@@ -1577,4 +1579,7 @@
     <!-- External Control Permission -->
     <string name="perm_external_control_label">control Essentials features</string>
     <string name="perm_external_control_desc">read, update and control Essentials features and settings</string>
+    <string name="pixel_searchbar_settings_title">Pixel Searchbar Customization</string>
+    <string name="pixel_searchbar_style_empty">Empty (Default)</string>
+    <string name="pixel_searchbar_style_date">Date</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1356,6 +1356,10 @@
     <string name="feat_watch_controls_desc">Customize WearOS app controls</string>
     <string name="watch_controls_long_press_hint">Long press to enable or disable buttons</string>
     <string name="watch_controls_reorder_title">Reorder watch controls</string>
+    <string name="feat_watch_wireless_debugging_title">Wireless Debugging</string>
+    <string name="feat_watch_wireless_debugging_desc">Enable remotely</string>
+    <string name="perm_watch_write_secure_title">Watch Secure Settings</string>
+    <string name="perm_watch_write_secure_desc">Requires secure settings write permission on your Watch. Grant it using the ADB command below.</string>
 
 
     <string name="cat_interaction">Interaction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,4 +1605,5 @@
     <string name="pixel_searchbar_widget_padding_v">Vertical padding</string>
     <string name="pixel_searchbar_tap_action_enabled">Custom tap action</string>
     <string name="pixel_searchbar_tap_action_enabled_desc">Use DIY tap action instead of widget\'s own</string>
+    <string name="pixel_searchbar_style_music">Music</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1474,6 +1474,8 @@
     <string name="label_use_blur">Use blur</string>
     <string name="desc_use_blur">Enable progressive blur elements across the UI</string>
     <string name="msg_blur_compatibility_error">Blur is disabled on this device to prevent a known display bug on Samsung devices with Android 15 or below.</string>
+    <string name="setting_swipe_tabs_title">Swipe between tabs</string>
+    <string name="setting_swipe_tabs_desc">In home screen</string>
 
     <!-- Empty State Actions -->
     <string name="msg_no_apps_frozen">No apps selected to freeze.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1522,8 +1522,8 @@
     <string name="shut_up_shortcut_created">Shortcut created for %s</string>
     <string name="feat_disable_rotation_suggestion_title">Disable rotation suggestion</string>
     <string name="feat_disable_rotation_suggestion_desc">Do not show the rotation button when auto-rotate is off</string>
-    <string name="feat_pixel_searchbar_title">Pixel searchbar</string>
-    <string name="feat_pixel_searchbar_desc">Set Essentials as the default search provider for the home screen search bar in Pixel Launcher.</string>
+    <string name="feat_pixel_searchbar_title">Replace with</string>
+    <string name="feat_pixel_searchbar_desc">Replace Pixel Launcher default searchbar.</string>
     <string name="shut_up_toast_active">App got shut up</string>
     <string name="shut_up_toast_restored">Shut up features returned</string>
     <string name="shut_up_auto_archive_notif_title">Auto Freeze</string>
@@ -1580,6 +1580,7 @@
     <string name="perm_external_control_label">control Essentials features</string>
     <string name="perm_external_control_desc">read, update and control Essentials features and settings</string>
     <string name="pixel_searchbar_settings_title">Pixel Searchbar Customization</string>
-    <string name="pixel_searchbar_style_empty">Empty (Default)</string>
+    <string name="pixel_searchbar_style_empty">Empty</string>
     <string name="pixel_searchbar_style_date">Date</string>
+    <string name="about_desc_pixel_searchbar">Replace the default Pixel Launcher search bar on your home screen. You can customize the content to show either nothing (Empty) or the current date. Please note that enabling this may break Pixel Launcher At a Glance widgets (such as sports and finance widgets), and the setting may need to be applied multiple times to take effect.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -649,6 +649,8 @@
     <string name="perm_action_enable">Enable in Settings</string>
     <string name="perm_action_how_to">How to grant</string>
     <string name="perm_action_granted">Granted</string>
+    <string name="perm_action_grant_shizuku">Grant using Shizuku</string>
+    <string name="perm_write_secure_instructions">This permission can be granted either via a PC using ADB. Copy the ADB command and run on the shell.\n\nOr you can easily grant it using Shizuku from the below button.\n\nThis permission only needs to be granted once.</string>
     <string name="perm_battery_optimization_title">Battery Optimization</string>
     <string name="perm_battery_optimization_desc">Ensure the service is not killed by the system to save power.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1358,6 +1358,8 @@
     <string name="watch_controls_reorder_title">Reorder watch controls</string>
     <string name="feat_watch_wireless_debugging_title">Wireless Debugging</string>
     <string name="feat_watch_wireless_debugging_desc">Enable remotely</string>
+    <string name="feat_sync_sound_mode_title">Sync sound mode</string>
+    <string name="feat_sync_sound_mode_desc">Automatically sync with watch</string>
     <string name="perm_watch_write_secure_title">Watch Secure Settings</string>
     <string name="perm_watch_write_secure_desc">Requires secure settings write permission on your Watch. Grant it using the ADB command below.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1601,4 +1601,8 @@
     <string name="pixel_searchbar_bind_permission_desc">Essentials needs permission to host widgets. Tap to grant.</string>
     <string name="pixel_searchbar_scraped_line1">Scraped title</string>
     <string name="pixel_searchbar_scraped_line2">Scraped subtitle</string>
+    <string name="pixel_searchbar_widget_padding_h">Horizontal padding</string>
+    <string name="pixel_searchbar_widget_padding_v">Vertical padding</string>
+    <string name="pixel_searchbar_tap_action_enabled">Custom tap action</string>
+    <string name="pixel_searchbar_tap_action_enabled_desc">Use DIY tap action instead of widget\'s own</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1590,4 +1590,15 @@
     <string name="label_replace_with">Replace with</string>
     <string name="pixel_searchbar_tap_action_title">Configure tap action</string>
     <string name="pixel_searchbar_tap_action_desc">Set up actions to trigger in DIY automations when tapped</string>
+    <string name="pixel_searchbar_style_widget">Widget</string>
+    <string name="pixel_searchbar_widget_picker_title">Pick a widget</string>
+    <string name="pixel_searchbar_widget_picker_desc">Select a widget to display its content in the searchbar</string>
+    <string name="pixel_searchbar_widget_selected">Widget selected</string>
+    <string name="pixel_searchbar_widget_none">No widget selected</string>
+    <string name="pixel_searchbar_widget_change">Change widget</string>
+    <string name="pixel_searchbar_widget_remove">Remove widget</string>
+    <string name="pixel_searchbar_bind_permission_title">Widget host permission required</string>
+    <string name="pixel_searchbar_bind_permission_desc">Essentials needs permission to host widgets. Tap to grant.</string>
+    <string name="pixel_searchbar_scraped_line1">Scraped title</string>
+    <string name="pixel_searchbar_scraped_line2">Scraped subtitle</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1522,7 +1522,7 @@
     <string name="shut_up_shortcut_created">Shortcut created for %s</string>
     <string name="feat_disable_rotation_suggestion_title">Disable rotation suggestion</string>
     <string name="feat_disable_rotation_suggestion_desc">Do not show the rotation button when auto-rotate is off</string>
-    <string name="feat_pixel_searchbar_title">Replace with</string>
+    <string name="feat_pixel_searchbar_title">Replace searchbar</string>
     <string name="feat_pixel_searchbar_desc">Replace Pixel Launcher default searchbar.</string>
     <string name="shut_up_toast_active">App got shut up</string>
     <string name="shut_up_toast_restored">Shut up features returned</string>
@@ -1585,4 +1585,5 @@
     <string name="pixel_searchbar_background_pill_title">Background pill</string>
     <string name="pixel_searchbar_background_pill_desc">Show the date inside a container</string>
     <string name="about_desc_pixel_searchbar">Replace the default Pixel Launcher search bar on your home screen. You can customize the content to show either nothing (Empty) or the current date. \n\nPlease note that enabling this may break Pixel Launcher At a Glance widgets (such as sports and finance widgets). \n\nAnd the setting may need to be applied multiple times to take effect.</string>
+    <string name="label_replace_with">Replace with</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1582,5 +1582,7 @@
     <string name="pixel_searchbar_settings_title">Pixel Searchbar Customization</string>
     <string name="pixel_searchbar_style_empty">Empty</string>
     <string name="pixel_searchbar_style_date">Date</string>
-    <string name="about_desc_pixel_searchbar">Replace the default Pixel Launcher search bar on your home screen. You can customize the content to show either nothing (Empty) or the current date. Please note that enabling this may break Pixel Launcher At a Glance widgets (such as sports and finance widgets), and the setting may need to be applied multiple times to take effect.</string>
+    <string name="pixel_searchbar_background_pill_title">Background pill</string>
+    <string name="pixel_searchbar_background_pill_desc">Show the date inside a container</string>
+    <string name="about_desc_pixel_searchbar">Replace the default Pixel Launcher search bar on your home screen. You can customize the content to show either nothing (Empty) or the current date. \n\nPlease note that enabling this may break Pixel Launcher At a Glance widgets (such as sports and finance widgets). \n\nAnd the setting may need to be applied multiple times to take effect.</string>
 </resources>

--- a/app/src/main/res/xml/pixel_searchbar_widget_info.xml
+++ b/app/src/main/res/xml/pixel_searchbar_widget_info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/feat_pixel_searchbar_desc"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:resizeMode="horizontal|vertical"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen|searchbox" />


### PR DESCRIPTION
This pull request introduces several new features and improvements, most notably the addition of a Pixel Searchbar widget, enhancements to the Watch feature settings, and a major refactor of the main tab navigation to support swipe gestures and haptic feedback. The manifest is updated to register new activities, services, and permissions, and the settings UI is extended for better Watch integration.

**Key changes include:**

### Pixel Searchbar Widget & Related Features

* Added new activities (`PixelSearchActivity`, `PixelSearchbarSettingsActivity`, `PixelSearchbarTapActivity`) and a widget receiver (`PixelSearchbarWidgetReceiver`) to support the Pixel Searchbar widget, including necessary permissions and metadata in `AndroidManifest.xml`. [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR36) [[2]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR104-R124) [[3]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR219-R228) [[4]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR405-R427)
* Introduced a new foreground service (`WidgetScraperService`) for widget-related functionality.
* Added the `android.permission.BIND_APPWIDGET` permission for widget binding.

### Main Tab Navigation Refactor & Haptics

* Refactored main tab navigation in `MainActivity` to use `HorizontalPager` for swipeable tabs, including predictive back support and animated transitions. [[1]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effR27-R28) [[2]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effR47) [[3]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effR216) [[4]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effL264-R328) [[5]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effL297-R348) [[6]](diffhunk://#diff-ad4ba0c464c3da383256c4282daceee29c13d8de8e60416fef688e3a78f49effL448-R516)
* Added haptic feedback when swiping between tabs and on tab selection, with bucketed haptics for smooth user experience.
* Enabled intent-based tab switching via `target_tab` extra.

### Watch Feature Settings Enhancements

* Added `WatchControlsSettingsUI` and improved state management for Watch-related toggles in `FeatureSettingsActivity`, including real-time preference updates and status requests to connected Wear devices. [[1]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R86-R89) [[2]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R222-R241) [[3]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R250-R258) [[4]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60L414-R445) [[5]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R552-R560) [[6]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60R750-R756)

### Permissions and Receivers

* Registered a new receiver for Shizuku actions and updated permissions for widget and notification features in `AndroidManifest.xml`. [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR36) [[2]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR933-R940)
* Added new intent actions to the Quick Settings Tile service for preferences support.

### Versioning

* Bumped `versionCode` to 49 and `versionName` to "15.5" in `build.gradle.kts`.