### PR TITLE
Develop - fixed inconsistent repository tracking card ui, wallpaper update last time, dev settings for backup

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -952,6 +952,14 @@ fun SettingsContent(
             )
 
             RoundedCardContainer {
+                IconToggleItem(
+                    iconRes = R.drawable.rounded_front_hand_24,
+                    title = "Keep new settings",
+                    description = "Don't reset existing settings after import",
+                    isChecked = viewModel.isKeepPrefs.value,
+                    onCheckedChange = { viewModel.toggleKeepPrefs(it) }
+                )
+
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -96,6 +96,7 @@ import com.sameerasw.essentials.ui.components.sheets.UpdateBottomSheet
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
+import com.sameerasw.essentials.ui.theme.Shapes
 import com.sameerasw.essentials.utils.DeviceUtils
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUtils
@@ -964,7 +965,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -995,7 +997,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -1034,7 +1037,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -288,6 +288,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_POCKET_MODE_EXCLUDED_APPS = "pocket_mode_excluded_apps"
         const val KEY_POCKET_MODE_TRIGGER_DELAY = "pocket_mode_trigger_delay"
         const val KEY_POCKET_MODE_LOCK_SCREEN_ONLY = "pocket_mode_lock_screen_only"
+        const val KEY_KEEP_PREFS = "keep_prefs"
     }
 
     // Observe changes
@@ -769,7 +770,7 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    fun importConfigs(inputStream: java.io.InputStream): Boolean {
+    fun importConfigs(inputStream: java.io.InputStream, keepPrefs: Boolean): Boolean {
         return try {
             val json = inputStream.bufferedReader().use { it.readText() }
             val allConfigs: Map<String, Map<String, Map<String, Any>>> =
@@ -797,7 +798,7 @@ class SettingsRepository(private val context: Context) {
                 }
 
                 p.edit().apply {
-                    clear()
+                    if(!keepPrefs) clear()
                     
                     // Restore preserved values
                     preservedValues.forEach { (key, value) ->

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -52,6 +52,8 @@ class SettingsRepository(private val context: Context) {
         const val KEY_DAILY_WALLPAPER_PHOTO_LINK = "daily_wallpaper_photo_link"
         const val KEY_DAILY_WALLPAPER_UPDATED_AT = "daily_wallpaper_updated_at"
         const val KEY_DAILY_WALLPAPER_AUTO_UPDATE = "daily_wallpaper_auto_update"
+        const val KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME = "daily_wallpaper_auto_update_time"
+        const val KEY_DAILY_WALLPAPER_SHOW_LAST_TIME = "daily_wallpaper_show_last_time"
         const val KEY_DAILY_WALLPAPER_APPLY_HOME = "daily_wallpaper_apply_home"
         const val KEY_DAILY_WALLPAPER_APPLY_LOCK = "daily_wallpaper_apply_lock"
 

--- a/app/src/main/java/com/sameerasw/essentials/services/DailyWallpaperWorker.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DailyWallpaperWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.data.repository.WallpaperRepository
+import java.time.LocalDateTime
 
 class DailyWallpaperWorker(
     appContext: Context,
@@ -77,6 +78,13 @@ class DailyWallpaperWorker(
                                 SettingsRepository.KEY_DAILY_WALLPAPER_UPDATED_AT,
                                 todayWallpaper.updatedAt
                             )
+
+                            val currentTime = LocalDateTime.now().toString()
+                            settingsRepository.putString(
+                                SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME,
+                                currentTime
+                            )
+
                             Log.d(
                                 "DailyWallpaperWorker",
                                 "Successfully auto-applied wallpaper (force=$force, flags=$flags): ${todayWallpaper.id}"

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
@@ -16,15 +16,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
@@ -527,20 +527,17 @@ fun YourAndroidContent(
                     .padding(32.dp)
             )
         } else if (trackedRepos.isEmpty()) {
-            androidx.compose.material3.Card(
-                modifier = Modifier
-                    .background(
-                        MaterialTheme.colorScheme.surfaceBright
-                    )
-                    .fillMaxWidth()
-                    .graphicsLayer {
-                        alpha = contentAlphaState.value
-                        translationY = contentOffsetState.value.toPx()
-                    },
-                shape = MaterialTheme.shapes.large
+            RoundedCardContainer(
+                modifier = Modifier.graphicsLayer {
+                    alpha = contentAlphaState.value
+                    translationY = contentOffsetState.value.toPx()
+                }
             ) {
                 Column(
-                    modifier = Modifier.padding(24.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .padding(32.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
@@ -549,17 +546,26 @@ fun YourAndroidContent(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(onClick = onAddRepoClick) {
-                        Text(stringResource(R.string.action_add_repository))
-                    }
-                    Spacer(modifier = Modifier.height(24.dp))
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
                     ImportExportButtons(
+                        modifier = Modifier.wrapContentWidth().weight(1f),
                         view = view,
                         exportLauncher = exportLauncher,
                         importLauncher = importLauncher,
                         showExport = false
                     )
+                    Button(onClick = onAddRepoClick, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.action_add_repository))
+                    }
                 }
             }
         } else {

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
@@ -74,6 +74,7 @@ import com.sameerasw.essentials.ui.components.sheets.UpdateBottomSheet
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
+import com.sameerasw.essentials.ui.theme.Shapes
 import com.sameerasw.essentials.utils.DeviceInfo
 import com.sameerasw.essentials.utils.DeviceUtils
 import com.sameerasw.essentials.utils.HapticUtil
@@ -536,7 +537,10 @@ fun YourAndroidContent(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
+                        )
                         .padding(32.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
@@ -551,7 +555,10 @@ fun YourAndroidContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
+                        )
                         .padding(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -107,6 +108,9 @@ import com.sameerasw.essentials.viewmodels.MainViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -124,6 +128,8 @@ fun WallpaperScreen(
     val isLoading by viewModel.isWallpaperLoading
     val isBlurEnabled by viewModel.isBlurEnabled
     val isAutoUpdateEnabled by viewModel.isDailyWallpaperAutoUpdateEnabled
+    val dailyWallpaperAutoUpdateTime by viewModel.dailyWallpaperAutoUpdateTime
+    val isDailyWallpaperShowLastTime by viewModel.isDailyWallpaperShowLastTime
 
     // Live Wallpaper Settings State
     var availableVideos by remember { mutableStateOf(repository.getLiveWallpaperAvailableVideos()) }
@@ -210,6 +216,19 @@ fun WallpaperScreen(
                     HapticUtil.performHeavyHaptic(view)
                 }
             }
+    }
+
+    var dailyWallpaperNextAutoUpdateTime by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(dailyWallpaperAutoUpdateTime) {
+        if (!dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
+            val prevTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
+            val passedTime = Duration.between(
+                prevTime,
+                LocalDateTime.now()
+            ).toHours()
+            val hoursLeft = (12L - passedTime).coerceAtLeast(0)
+            dailyWallpaperNextAutoUpdateTime = hoursLeft
+        }
     }
 
     Box(
@@ -473,24 +492,47 @@ fun WallpaperScreen(
                                     .padding(16.dp),
                                 verticalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.SpaceBetween
-                                ) {
-                                    Text(
-                                        text = stringResource(R.string.label_wallpaper_auto_update),
-                                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                        color = MaterialTheme.colorScheme.onSurface
-                                    )
-                                    Switch(
-                                        checked = isAutoUpdateEnabled,
-                                        onCheckedChange = { checked ->
-                                            HapticUtil.performUIHaptic(view)
-                                            viewModel.setDailyWallpaperAutoUpdate(checked, context)
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.SpaceBetween
+                                    ) {
+                                        Column(
+                                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.label_wallpaper_auto_update),
+                                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                                color = MaterialTheme.colorScheme.onSurface
+                                            )
+                                            if (isAutoUpdateEnabled && !dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
+                                                val timeText = if(isDailyWallpaperShowLastTime) {
+                                                    val showTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
+                                                        .format(DateTimeFormatter.ofPattern("hh:mm a"))
+                                                    "Last checked at $showTime"
+                                                } else{
+                                                    val showTime = if(dailyWallpaperNextAutoUpdateTime > 0L) "$dailyWallpaperNextAutoUpdateTime hours" else "a few minutes"
+                                                    "Next check in $showTime"
+                                                }
+                                                Text(
+                                                    text = timeText,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    modifier = Modifier.clickable(enabled = true, onClick = {
+                                                        HapticUtil.performUIHaptic(view)
+                                                        viewModel.setDailyWallpaperShowLastTime()
+                                                    })
+                                                )
+                                            }
                                         }
-                                    )
-                                }
+                                        Switch(
+                                            checked = isAutoUpdateEnabled,
+                                            onCheckedChange = { checked ->
+                                                HapticUtil.performUIHaptic(view)
+                                                viewModel.setDailyWallpaperAutoUpdate(checked, context)
+                                            }
+                                        )
+                                    }
 
                                 Row(
                                     modifier = Modifier

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -332,6 +332,8 @@ class MainViewModel : ViewModel() {
     private var workflowPollingJob: kotlinx.coroutines.Job? = null
     val gitHubUser = mutableStateOf<com.sameerasw.essentials.domain.model.github.GitHubUser?>(null)
 
+    val isKeepPrefs = mutableStateOf(false)
+
     private val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean, uri: Uri?) {
             uri?.let {
@@ -1498,6 +1500,8 @@ class MainViewModel : ViewModel() {
         if (isBatteryNotificationEnabled.value) {
             startBatteryNotificationService(context)
         }
+
+        isKeepPrefs.value = settingsRepository.getBoolean(SettingsRepository.KEY_KEEP_PREFS)
     }
 
     private fun startBatteryNotificationService(context: Context) {
@@ -3935,7 +3939,7 @@ class MainViewModel : ViewModel() {
     }
 
     fun importConfigs(context: Context, inputStream: java.io.InputStream): Boolean {
-        val success = settingsRepository.importConfigs(inputStream)
+        val success = settingsRepository.importConfigs(inputStream, isKeepPrefs.value)
         if (success) {
             settingsRepository.syncSystemSettingsWithSaved()
             com.sameerasw.essentials.domain.diy.DIYRepository.reloadAutomations()
@@ -4301,5 +4305,10 @@ class MainViewModel : ViewModel() {
             dailyWallpaperAutoUpdateTime.value = null
             settingsRepository.remove(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
         }
+    }
+
+    fun toggleKeepPrefs(enabled: Boolean) {
+        isKeepPrefs.value = enabled
+        settingsRepository.putBoolean(SettingsRepository.KEY_KEEP_PREFS, enabled)
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import java.time.LocalDateTime
 
 class MainViewModel : ViewModel() {
     val isAccessibilityEnabled = mutableStateOf(false)
@@ -937,6 +938,8 @@ class MainViewModel : ViewModel() {
         if (isDailyWallpaperAutoUpdateEnabled.value) {
             schedulePeriodicWallpaperCheck(context)
         }
+        dailyWallpaperAutoUpdateTime.value = settingsRepository.getString(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
+        isDailyWallpaperShowLastTime.value = settingsRepository.getBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_SHOW_LAST_TIME)
 
         if (isHideGestureBarEnabled.value) {
             applyHideGestureBar(context, true)
@@ -4239,10 +4242,19 @@ class MainViewModel : ViewModel() {
     }
 
     val isDailyWallpaperAutoUpdateEnabled = mutableStateOf(false)
+    val dailyWallpaperAutoUpdateTime = mutableStateOf<String?>(null)
+    val isDailyWallpaperShowLastTime = mutableStateOf(false)
+
+    fun setDailyWallpaperShowLastTime() {
+        val status = !isDailyWallpaperShowLastTime.value
+        isDailyWallpaperShowLastTime.value = status
+        settingsRepository.putBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_SHOW_LAST_TIME, status)
+    }
 
     fun setDailyWallpaperAutoUpdate(enabled: Boolean, context: Context) {
         isDailyWallpaperAutoUpdateEnabled.value = enabled
         settingsRepository.putBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE, enabled)
+        updateDailyWallpaperAutoUpdateTime(enabled)
         if (enabled) {
             schedulePeriodicWallpaperCheck(context)
             triggerInstantWallpaperUpdate(context)
@@ -4278,5 +4290,16 @@ class MainViewModel : ViewModel() {
     private fun cancelPeriodicWallpaperCheck(context: Context) {
         androidx.work.WorkManager.getInstance(context)
             .cancelUniqueWork("daily_wallpaper_check_work")
+    }
+
+    private fun updateDailyWallpaperAutoUpdateTime(enabled: Boolean) {
+        if (enabled){
+            val currentTime = LocalDateTime.now().toString()
+            dailyWallpaperAutoUpdateTime.value = currentTime
+            settingsRepository.putString(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME, currentTime)
+        } else {
+            dailyWallpaperAutoUpdateTime.value = null
+            settingsRepository.remove(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a issue where the repo tracking card looks different from other composables.

### Changes

- replaced Card composable with custom RoundedCardContainer.
- changed structure of action buttons
- showing wallpaper last update time
- option for keep new settings
- added ignore or include option for sensitive data (Github tokens) with export config
- and some refactors

### Fixes

- importing config resets some settings, which is new and doesn't exists in config
- previously github token's are exposed in config by default, it's okay for personal use but if sharing with other's, it can cause privacy issue, anyone can login with your github account
- but all these issues fixed and now you can choose to include or not before exporting