### PR TITLE
Develop - A lot of bug fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.sameerasw.essentials"
         minSdk = 26
         targetSdk = 37
-        versionCode = 50
-        versionName = "15.6"
+        versionCode = 51
+        versionName = "15.7"
 
         val whatsNewCounter = 2
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())

--- a/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/FeatureSettingsActivity.kt
@@ -304,7 +304,9 @@ class FeatureSettingsActivity : AppCompatActivity() {
 
                             "Location reached" -> !viewModel.isLocationPermissionGranted.value || !viewModel.isBackgroundLocationPermissionGranted.value
                             "Quick settings tiles" -> !viewModel.isWriteSettingsEnabled.value
-                            "Screen refresh rate" -> !viewModel.isShizukuPermissionGranted.value
+                            "Screen refresh rate" -> !com.sameerasw.essentials.utils.ShellUtils.hasPermission(
+                                context
+                            )
                             // Top level checks for other features (rarely hit if they are children, but safe to add)
                             "Essentials On Display" -> !isAccessibilityEnabled || !isNotificationListenerEnabled
                             "Call vibrations" -> !isReadPhoneStateEnabled || !isNotificationListenerEnabled
@@ -539,7 +541,9 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                                 "Battery notification" -> !viewModel.isPostNotificationsEnabled.value || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !viewModel.isBluetoothPermissionGranted.value)
                                                 "Text and animations" -> !viewModel.isWriteSettingsEnabled.value || !isWriteSecureSettingsEnabled
                                                 "Lock screen clock" -> !isWriteSecureSettingsEnabled
-                                                "Screen refresh rate" -> !viewModel.isShizukuPermissionGranted.value
+                                                "Screen refresh rate" -> !com.sameerasw.essentials.utils.ShellUtils.hasPermission(
+                                                    context
+                                                )
                                                 "Shut-Up!" -> !isWriteSecureSettingsEnabled || !viewModel.isUsageStatsPermissionGranted.value
                                                 else -> false
                                             }

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -952,6 +952,14 @@ fun SettingsContent(
             )
 
             RoundedCardContainer {
+                IconToggleItem(
+                    iconRes = R.drawable.rounded_front_hand_24,
+                    title = "Keep new settings",
+                    description = "Don't reset existing settings after import",
+                    isChecked = viewModel.isKeepPrefs.value,
+                    onCheckedChange = { viewModel.toggleKeepPrefs(it) }
+                )
+
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -955,8 +955,8 @@ fun SettingsContent(
             RoundedCardContainer {
                 IconToggleItem(
                     iconRes = R.drawable.rounded_front_hand_24,
-                    title = "Keep new settings",
-                    description = "Don't reset existing settings after import",
+                    title = stringResource(R.string.label_keep_new_settings),
+                    description = stringResource(R.string.desc_keep_new_settings),
                     isChecked = viewModel.isKeepPrefs.value,
                     onCheckedChange = { viewModel.toggleKeepPrefs(it) }
                 )

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -96,6 +96,7 @@ import com.sameerasw.essentials.ui.components.sheets.UpdateBottomSheet
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
+import com.sameerasw.essentials.ui.theme.Shapes
 import com.sameerasw.essentials.utils.DeviceUtils
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUtils
@@ -964,7 +965,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -995,7 +997,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -1034,7 +1037,8 @@ fun SettingsContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = MaterialTheme.colorScheme.surfaceBright
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
                         )
                         .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -92,6 +92,7 @@ import com.sameerasw.essentials.ui.components.pickers.DefaultTabPicker
 import com.sameerasw.essentials.ui.components.pickers.LanguagePicker
 import com.sameerasw.essentials.ui.components.sheets.InstructionsBottomSheet
 import com.sameerasw.essentials.ui.components.sheets.UnsupportedFeaturesConfirmationSheet
+import com.sameerasw.essentials.ui.components.sheets.ImportConfigConfirmationSheet
 import com.sameerasw.essentials.ui.components.sheets.UpdateBottomSheet
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
@@ -262,6 +263,30 @@ fun SettingsContent(
     var showInstructionsSheet by remember { mutableStateOf(false) }
     var showShizukuHelpBottomSheet by remember { mutableStateOf(false) }
     var showUnsupportedFeaturesSheet by remember { mutableStateOf(false) }
+    var showImportConfirmSheet by remember { mutableStateOf(false) }
+    var selectedImportUri by remember { mutableStateOf<Uri?>(null) }
+
+    val onImportConfig: (Boolean) -> Unit = { keepPrefs ->
+        selectedImportUri?.let { uri ->
+            try {
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    if (viewModel.importConfigs(context, inputStream, keepPrefs)) {
+                        Toast.makeText(context, "Config imported successfully", Toast.LENGTH_SHORT)
+                            .show()
+                    } else {
+                        Toast.makeText(context, "Failed to import config", Toast.LENGTH_SHORT)
+                            .show()
+                    }
+                }
+            } catch (e: Exception) {
+                Toast.makeText(context, "Failed to import config", Toast.LENGTH_SHORT).show()
+                e.printStackTrace()
+            } finally {
+                selectedImportUri = null
+                showImportConfirmSheet = false
+            }
+        }
+    }
 
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/json")
@@ -284,20 +309,8 @@ fun SettingsContent(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         uri?.let {
-            try {
-                context.contentResolver.openInputStream(it)?.use { inputStream ->
-                    if (viewModel.importConfigs(context, inputStream)) {
-                        Toast.makeText(context, "Config imported successfully", Toast.LENGTH_SHORT)
-                            .show()
-                    } else {
-                        Toast.makeText(context, "Failed to import config", Toast.LENGTH_SHORT)
-                            .show()
-                    }
-                }
-            } catch (e: Exception) {
-                Toast.makeText(context, "Failed to import config", Toast.LENGTH_SHORT).show()
-                e.printStackTrace()
-            }
+            selectedImportUri = it
+            showImportConfirmSheet = true
         }
     }
 
@@ -323,6 +336,21 @@ fun SettingsContent(
                 viewModel.setEnableUnsupportedFeatures(true, context)
             },
             featureTitleResIds = FeatureRegistry.getUnsupportedFeatures(context).map { it.title }
+        )
+    }
+
+    if (showImportConfirmSheet) {
+        ImportConfigConfirmationSheet(
+            onDismissRequest = {
+                showImportConfirmSheet = false
+                selectedImportUri = null
+            },
+            onConfirmOverride = {
+                onImportConfig(false)
+            },
+            onConfirmMerge = {
+                onImportConfig(true)
+            }
         )
     }
 
@@ -953,14 +981,6 @@ fun SettingsContent(
             )
 
             RoundedCardContainer {
-                IconToggleItem(
-                    iconRes = R.drawable.rounded_front_hand_24,
-                    title = stringResource(R.string.label_keep_new_settings),
-                    description = stringResource(R.string.desc_keep_new_settings),
-                    isChecked = viewModel.isKeepPrefs.value,
-                    onCheckedChange = { viewModel.toggleKeepPrefs(it) }
-                )
-
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -288,6 +288,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_POCKET_MODE_EXCLUDED_APPS = "pocket_mode_excluded_apps"
         const val KEY_POCKET_MODE_TRIGGER_DELAY = "pocket_mode_trigger_delay"
         const val KEY_POCKET_MODE_LOCK_SCREEN_ONLY = "pocket_mode_lock_screen_only"
+        const val KEY_KEEP_PREFS = "keep_prefs"
     }
 
     // Observe changes
@@ -769,7 +770,7 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    fun importConfigs(inputStream: java.io.InputStream): Boolean {
+    fun importConfigs(inputStream: java.io.InputStream, keepPrefs: Boolean): Boolean {
         return try {
             val json = inputStream.bufferedReader().use { it.readText() }
             val allConfigs: Map<String, Map<String, Map<String, Any>>> =
@@ -797,7 +798,7 @@ class SettingsRepository(private val context: Context) {
                 }
 
                 p.edit().apply {
-                    clear()
+                    if(!keepPrefs) clear()
                     
                     // Restore preserved values
                     preservedValues.forEach { (key, value) ->

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -52,6 +52,8 @@ class SettingsRepository(private val context: Context) {
         const val KEY_DAILY_WALLPAPER_PHOTO_LINK = "daily_wallpaper_photo_link"
         const val KEY_DAILY_WALLPAPER_UPDATED_AT = "daily_wallpaper_updated_at"
         const val KEY_DAILY_WALLPAPER_AUTO_UPDATE = "daily_wallpaper_auto_update"
+        const val KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME = "daily_wallpaper_auto_update_time"
+        const val KEY_DAILY_WALLPAPER_SHOW_LAST_TIME = "daily_wallpaper_show_last_time"
         const val KEY_DAILY_WALLPAPER_APPLY_HOME = "daily_wallpaper_apply_home"
         const val KEY_DAILY_WALLPAPER_APPLY_LOCK = "daily_wallpaper_apply_lock"
 

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -123,6 +123,7 @@ class SettingsRepository(private val context: Context) {
         const val KEY_FLASHLIGHT_PULSE_MAX_INTENSITY = "flashlight_pulse_max_intensity"
         const val KEY_FLASHLIGHT_PULSE_DISABLE_ON_DND = "flashlight_pulse_disable_on_dnd"
         const val KEY_FLASHLIGHT_POCKET_TURN_OFF_ENABLED = "flashlight_pocket_turn_off_enabled"
+        const val KEY_FLASHLIGHT_OVERHEAT_PREVENTION_ENABLED = "flashlight_overheat_prevention_enabled"
 
         const val KEY_SCREEN_LOCKED_SECURITY_ENABLED = "screen_locked_security_enabled"
         const val KEY_HIDE_SYSTEM_ICONS = "hide_system_icons"

--- a/app/src/main/java/com/sameerasw/essentials/services/DailyWallpaperWorker.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/DailyWallpaperWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.data.repository.WallpaperRepository
+import java.time.LocalDateTime
 
 class DailyWallpaperWorker(
     appContext: Context,
@@ -77,6 +78,13 @@ class DailyWallpaperWorker(
                                 SettingsRepository.KEY_DAILY_WALLPAPER_UPDATED_AT,
                                 todayWallpaper.updatedAt
                             )
+
+                            val currentTime = LocalDateTime.now().toString()
+                            settingsRepository.putString(
+                                SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME,
+                                currentTime
+                            )
+
                             Log.d(
                                 "DailyWallpaperWorker",
                                 "Successfully auto-applied wallpaper (force=$force, flags=$flags): ${todayWallpaper.id}"

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/FlashlightHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/FlashlightHandler.kt
@@ -51,6 +51,7 @@ class FlashlightHandler(
     private var primaryCameraId: String? = null
     private var currentIntensityLevel: Int = 1
     private var flashlightJob: Job? = null
+    private var overheatPreventionJob: Job? = null
     private var isInternalToggle = false
 
     private val NOTIFICATION_ID_FLASHLIGHT = 1010
@@ -105,11 +106,13 @@ class FlashlightHandler(
                     currentIntensityLevel = FlashlightUtil.getDefaultLevel(service, cameraId)
                     updateFlashlightNotification(currentIntensityLevel)
                 }
+                startOverheatPrevention(cameraId)
             } else {
                 // Flashlight turned OFF
                 flashlightJob?.cancel() // Stop any ongoing fade-in or fade-out
                 isInternalToggle = false // Reset
                 cancelFlashlightNotification()
+                stopOverheatPrevention()
             }
         }
     }
@@ -121,6 +124,7 @@ class FlashlightHandler(
     fun unregister() {
         torchCallback.let { cameraManager.unregisterTorchCallback(it) }
         primaryCameraId = null
+        stopOverheatPrevention()
     }
 
     fun handleIntent(intent: Intent) {
@@ -656,5 +660,38 @@ class FlashlightHandler(
         } catch (_: Exception) {
             false
         }
+    }
+
+    private fun startOverheatPrevention(cameraId: String) {
+        overheatPreventionJob?.cancel()
+        overheatPreventionJob = scope.launch {
+            while (isTorchOn) {
+                kotlinx.coroutines.delay(120000L)
+                val prefs = service.getSharedPreferences("essentials_prefs", Context.MODE_PRIVATE)
+                val isOverheatEnabled = prefs.getBoolean("flashlight_overheat_prevention_enabled", true)
+                if (isOverheatEnabled && FlashlightUtil.isIntensitySupported(service, cameraId)) {
+                    val currentLevel = FlashlightUtil.getCurrentLevel(service, cameraId)
+                    val maxLevel = FlashlightUtil.getMaxLevel(service, cameraId)
+                    val limitLevel = (maxLevel * 0.75f).toInt().coerceAtLeast(1)
+                    if (currentLevel > limitLevel) {
+                        FlashlightUtil.fadeFlashlight(
+                            service,
+                            cameraId,
+                            fromLevel = currentLevel,
+                            toLevel = limitLevel,
+                            durationMs = 1000L,
+                            steps = 15
+                        )
+                        currentIntensityLevel = limitLevel
+                        updateFlashlightNotification(limitLevel)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun stopOverheatPrevention() {
+        overheatPreventionJob?.cancel()
+        overheatPreventionJob = null
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
@@ -16,15 +16,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
@@ -527,20 +527,17 @@ fun YourAndroidContent(
                     .padding(32.dp)
             )
         } else if (trackedRepos.isEmpty()) {
-            androidx.compose.material3.Card(
-                modifier = Modifier
-                    .background(
-                        MaterialTheme.colorScheme.surfaceBright
-                    )
-                    .fillMaxWidth()
-                    .graphicsLayer {
-                        alpha = contentAlphaState.value
-                        translationY = contentOffsetState.value.toPx()
-                    },
-                shape = MaterialTheme.shapes.large
+            RoundedCardContainer(
+                modifier = Modifier.graphicsLayer {
+                    alpha = contentAlphaState.value
+                    translationY = contentOffsetState.value.toPx()
+                }
             ) {
                 Column(
-                    modifier = Modifier.padding(24.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .padding(32.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
@@ -549,17 +546,26 @@ fun YourAndroidContent(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(onClick = onAddRepoClick) {
-                        Text(stringResource(R.string.action_add_repository))
-                    }
-                    Spacer(modifier = Modifier.height(24.dp))
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
                     ImportExportButtons(
+                        modifier = Modifier.wrapContentWidth().weight(1f),
                         view = view,
                         exportLauncher = exportLauncher,
                         importLauncher = importLauncher,
                         showExport = false
                     )
+                    Button(onClick = onAddRepoClick, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.action_add_repository))
+                    }
                 }
             }
         } else {

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/YourAndroidActivity.kt
@@ -74,6 +74,7 @@ import com.sameerasw.essentials.ui.components.sheets.UpdateBottomSheet
 import com.sameerasw.essentials.ui.modifiers.BlurDirection
 import com.sameerasw.essentials.ui.modifiers.progressiveBlur
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
+import com.sameerasw.essentials.ui.theme.Shapes
 import com.sameerasw.essentials.utils.DeviceInfo
 import com.sameerasw.essentials.utils.DeviceUtils
 import com.sameerasw.essentials.utils.HapticUtil
@@ -536,7 +537,10 @@ fun YourAndroidContent(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
+                        )
                         .padding(32.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
@@ -551,7 +555,10 @@ fun YourAndroidContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceBright)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceBright,
+                            shape = Shapes.extraSmall
+                        )
                         .padding(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/ImportConfigConfirmationSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/ImportConfigConfirmationSheet.kt
@@ -1,0 +1,119 @@
+package com.sameerasw.essentials.ui.components.sheets
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
+import com.sameerasw.essentials.utils.HapticUtil
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportConfigConfirmationSheet(
+    onDismissRequest: () -> Unit,
+    onConfirmOverride: () -> Unit,
+    onConfirmMerge: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val view = LocalView.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.import_config_sheet_title),
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center
+            )
+
+            Text(
+                text = stringResource(R.string.import_config_sheet_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            RoundedCardContainer(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = stringResource(R.string.import_config_merge_warning),
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = {
+                        HapticUtil.performUIHaptic(view)
+                        onConfirmOverride()
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(R.string.action_override))
+                }
+
+                OutlinedButton(
+                    onClick = {
+                        HapticUtil.performUIHaptic(view)
+                        onConfirmMerge()
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(R.string.action_merge))
+                }
+            }
+
+            OutlinedButton(
+                onClick = {
+                    HapticUtil.performUIHaptic(view)
+                    onDismissRequest()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.action_abort))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightPulseSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightPulseSettingsUI.kt
@@ -85,9 +85,9 @@ fun FlashlightPulseSettingsUI(
                     title = stringResource(R.string.flashlight_pulse_max_brightness),
                     value = viewModel.flashlightPulseMaxIntensity.floatValue,
                     onValueChange = { viewModel.setFlashlightPulseMaxIntensity(it) },
-                    valueRange = 0.05f..1f,
-                    valueFormatter = { "${(it * 100).toInt()}%" },
-                    increment = 0.05f,
+                    valueRange = 0.01f..1f,
+                    valueFormatter = { "${Math.round(it * 100)}%" },
+                    increment = 0.01f,
                     modifier = Modifier.highlight(highlightSetting == "flashlight_pulse_max_intensity")
                 )
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightSettingsUI.kt
@@ -72,7 +72,7 @@ fun FlashlightSettingsUI(
                 onCheckedChange = { viewModel.setFlashlightPocketTurnOffEnabled(it, context) }
             )
             IconToggleItem(
-                iconRes = R.drawable.rounded_snowflake_24,
+                iconRes = R.drawable.rounded_thermometer_alert_24,
                 title = stringResource(R.string.flashlight_overheat_title),
                 description = stringResource(R.string.flashlight_overheat_desc),
                 isChecked = viewModel.isFlashlightOverheatEnabled.value,

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/FlashlightSettingsUI.kt
@@ -71,6 +71,13 @@ fun FlashlightSettingsUI(
                 isChecked = viewModel.isFlashlightPocketTurnOffEnabled.value,
                 onCheckedChange = { viewModel.setFlashlightPocketTurnOffEnabled(it, context) }
             )
+            IconToggleItem(
+                iconRes = R.drawable.rounded_snowflake_24,
+                title = stringResource(R.string.flashlight_overheat_title),
+                description = stringResource(R.string.flashlight_overheat_desc),
+                isChecked = viewModel.isFlashlightOverheatEnabled.value,
+                onCheckedChange = { viewModel.setFlashlightOverheatEnabled(it, context) }
+            )
 
         }
     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/RefreshRateSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/configs/RefreshRateSettingsUI.kt
@@ -38,7 +38,7 @@ fun RefreshRateSettingsUI(
 ) {
     val context = LocalContext.current
     val view = LocalView.current
-    val isEnabled = viewModel.isShizukuPermissionGranted.value
+    val isEnabled = if (viewModel.isRootEnabled.value) viewModel.isRootPermissionGranted.value else viewModel.isShizukuPermissionGranted.value
     val isFixedMode = viewModel.refreshRateMode.value == RefreshRateUtils.MODE_FIXED
     val systemLabel = stringResource(R.string.refresh_rate_system_default)
 
@@ -172,7 +172,10 @@ fun RefreshRateSettingsUI(
                     }
                 } else {
                     Text(
-                        text = stringResource(R.string.msg_refresh_rate_permission_required),
+                        text = stringResource(
+                            if (viewModel.isRootEnabled.value) R.string.msg_refresh_rate_root_permission_required
+                            else R.string.msg_refresh_rate_permission_required
+                        ),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.error,
                         modifier = Modifier
@@ -181,7 +184,11 @@ fun RefreshRateSettingsUI(
                     )
                     Button(
                         onClick = {
-                            viewModel.requestShizukuPermission()
+                            if (viewModel.isRootEnabled.value) {
+                                viewModel.check(context)
+                            } else {
+                                viewModel.requestShizukuPermission()
+                            }
                             HapticUtil.performSliderHaptic(view)
                         },
                         colors = ButtonDefaults.filledTonalButtonColors(),

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -107,6 +108,9 @@ import com.sameerasw.essentials.viewmodels.MainViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -124,6 +128,8 @@ fun WallpaperScreen(
     val isLoading by viewModel.isWallpaperLoading
     val isBlurEnabled by viewModel.isBlurEnabled
     val isAutoUpdateEnabled by viewModel.isDailyWallpaperAutoUpdateEnabled
+    val dailyWallpaperAutoUpdateTime by viewModel.dailyWallpaperAutoUpdateTime
+    val isDailyWallpaperShowLastTime by viewModel.isDailyWallpaperShowLastTime
 
     // Live Wallpaper Settings State
     var availableVideos by remember { mutableStateOf(repository.getLiveWallpaperAvailableVideos()) }
@@ -210,6 +216,19 @@ fun WallpaperScreen(
                     HapticUtil.performHeavyHaptic(view)
                 }
             }
+    }
+
+    var dailyWallpaperNextAutoUpdateTime by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(dailyWallpaperAutoUpdateTime) {
+        if (!dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
+            val prevTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
+            val passedTime = Duration.between(
+                prevTime,
+                LocalDateTime.now()
+            ).toHours()
+            val hoursLeft = (12L - passedTime).coerceAtLeast(0)
+            dailyWallpaperNextAutoUpdateTime = hoursLeft
+        }
     }
 
     Box(
@@ -473,24 +492,47 @@ fun WallpaperScreen(
                                     .padding(16.dp),
                                 verticalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.SpaceBetween
-                                ) {
-                                    Text(
-                                        text = stringResource(R.string.label_wallpaper_auto_update),
-                                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                        color = MaterialTheme.colorScheme.onSurface
-                                    )
-                                    Switch(
-                                        checked = isAutoUpdateEnabled,
-                                        onCheckedChange = { checked ->
-                                            HapticUtil.performUIHaptic(view)
-                                            viewModel.setDailyWallpaperAutoUpdate(checked, context)
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.SpaceBetween
+                                    ) {
+                                        Column(
+                                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.label_wallpaper_auto_update),
+                                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                                color = MaterialTheme.colorScheme.onSurface
+                                            )
+                                            if (isAutoUpdateEnabled && !dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
+                                                val timeText = if(isDailyWallpaperShowLastTime) {
+                                                    val showTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
+                                                        .format(DateTimeFormatter.ofPattern("hh:mm a"))
+                                                    "Last checked at $showTime"
+                                                } else{
+                                                    val showTime = if(dailyWallpaperNextAutoUpdateTime > 0L) "$dailyWallpaperNextAutoUpdateTime hours" else "a few minutes"
+                                                    "Next check in $showTime"
+                                                }
+                                                Text(
+                                                    text = timeText,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    modifier = Modifier.clickable(enabled = true, onClick = {
+                                                        HapticUtil.performUIHaptic(view)
+                                                        viewModel.setDailyWallpaperShowLastTime()
+                                                    })
+                                                )
+                                            }
                                         }
-                                    )
-                                }
+                                        Switch(
+                                            checked = isAutoUpdateEnabled,
+                                            onCheckedChange = { checked ->
+                                                HapticUtil.performUIHaptic(view)
+                                                viewModel.setDailyWallpaperAutoUpdate(checked, context)
+                                            }
+                                        )
+                                    }
 
                                 Row(
                                     modifier = Modifier

--- a/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/composables/wallpaper/WallpaperScreen.kt
@@ -219,15 +219,20 @@ fun WallpaperScreen(
     }
 
     var dailyWallpaperNextAutoUpdateTime by remember { mutableLongStateOf(0L) }
+    var dailyWallpaperLastCheckedFormatted by remember { mutableStateOf("") }
     LaunchedEffect(dailyWallpaperAutoUpdateTime) {
         if (!dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
-            val prevTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
-            val passedTime = Duration.between(
-                prevTime,
-                LocalDateTime.now()
-            ).toHours()
-            val hoursLeft = (12L - passedTime).coerceAtLeast(0)
-            dailyWallpaperNextAutoUpdateTime = hoursLeft
+            val prevTime = runCatching { LocalDateTime.parse(dailyWallpaperAutoUpdateTime) }.getOrNull()
+            if (prevTime != null) {
+                val passedTime = Duration.between(
+                    prevTime,
+                    LocalDateTime.now()
+                ).toHours()
+                dailyWallpaperNextAutoUpdateTime = (12L - passedTime).coerceAtLeast(0)
+                dailyWallpaperLastCheckedFormatted = runCatching {
+                    prevTime.format(DateTimeFormatter.ofPattern("hh:mm a"))
+                }.getOrDefault("")
+            }
         }
     }
 
@@ -507,12 +512,14 @@ fun WallpaperScreen(
                                             )
                                             if (isAutoUpdateEnabled && !dailyWallpaperAutoUpdateTime.isNullOrEmpty()){
                                                 val timeText = if(isDailyWallpaperShowLastTime) {
-                                                    val showTime = LocalDateTime.parse(dailyWallpaperAutoUpdateTime)
-                                                        .format(DateTimeFormatter.ofPattern("hh:mm a"))
-                                                    "Last checked at $showTime"
+                                                    stringResource(R.string.label_wallpaper_last_checked, dailyWallpaperLastCheckedFormatted)
                                                 } else{
-                                                    val showTime = if(dailyWallpaperNextAutoUpdateTime > 0L) "$dailyWallpaperNextAutoUpdateTime hours" else "a few minutes"
-                                                    "Next check in $showTime"
+                                                    val showTime = if(dailyWallpaperNextAutoUpdateTime > 0L) {
+                                                        stringResource(R.string.label_wallpaper_hours, dailyWallpaperNextAutoUpdateTime.toInt())
+                                                    } else {
+                                                        stringResource(R.string.label_wallpaper_a_few_minutes)
+                                                    }
+                                                    stringResource(R.string.label_wallpaper_next_check, showTime)
                                                 }
                                                 Text(
                                                     text = timeText,

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
@@ -209,13 +209,23 @@ object PermissionUIHelper {
             )
 
             "SHIZUKU" -> PermissionItem(
-                iconRes = R.drawable.rounded_mode_cool_24,
-                title = R.string.perm_shizuku_title,
-                description = R.string.perm_shizuku_desc,
+                iconRes = if (viewModel.isRootEnabled.value) R.drawable.rounded_numbers_24 else R.drawable.rounded_mode_cool_24,
+                title = if (viewModel.isRootEnabled.value) R.string.perm_root_title else R.string.perm_shizuku_title,
+                description = if (viewModel.isRootEnabled.value) R.string.perm_root_desc else R.string.perm_shizuku_desc,
                 dependentFeatures = PermissionRegistry.getFeatures("SHIZUKU"),
-                actionLabel = if (viewModel.isShizukuPermissionGranted.value) R.string.perm_action_granted else R.string.perm_action_grant,
-                action = { viewModel.requestShizukuPermission() },
-                isGranted = viewModel.isShizukuPermissionGranted.value
+                actionLabel = if (viewModel.isRootEnabled.value) {
+                    if (viewModel.isRootPermissionGranted.value) R.string.perm_action_granted else R.string.perm_action_grant
+                } else {
+                    if (viewModel.isShizukuPermissionGranted.value) R.string.perm_action_granted else R.string.perm_action_grant
+                },
+                action = {
+                    if (viewModel.isRootEnabled.value) {
+                        viewModel.check(context)
+                    } else {
+                        viewModel.requestShizukuPermission()
+                    }
+                },
+                isGranted = if (viewModel.isRootEnabled.value) viewModel.isRootPermissionGranted.value else viewModel.isShizukuPermissionGranted.value
             )
 
             "READ_CALENDAR" -> PermissionItem(

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUIHelper.kt
@@ -55,11 +55,17 @@ object PermissionUIHelper {
                     viewModel.check(context)
                 },
                 isGranted = viewModel.isWriteSecureSettingsEnabled.value,
-                shizukuActionLabel = R.string.perm_action_grant_shizuku,
-                shizukuActionEnabled = ShizukuUtils.hasPermission(),
+                shizukuActionLabel = if (viewModel.isRootEnabled.value) R.string.perm_action_grant_root else R.string.perm_action_grant_shizuku,
+                shizukuActionEnabled = if (viewModel.isRootEnabled.value) viewModel.isRootAvailable.value else ShizukuUtils.hasPermission(),
                 shizukuAction = {
-                    if (ShizukuUtils.grantWriteSecureSettingsPermission()) {
-                        viewModel.check(context)
+                    if (viewModel.isRootEnabled.value) {
+                        if (RootUtils.runCommand("pm grant ${context.packageName} android.permission.WRITE_SECURE_SETTINGS")) {
+                            viewModel.check(context)
+                        }
+                    } else {
+                        if (ShizukuUtils.grantWriteSecureSettingsPermission()) {
+                            viewModel.check(context)
+                        }
                     }
                 },
                 instructions = R.string.perm_write_secure_instructions

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -332,6 +332,8 @@ class MainViewModel : ViewModel() {
     private var workflowPollingJob: kotlinx.coroutines.Job? = null
     val gitHubUser = mutableStateOf<com.sameerasw.essentials.domain.model.github.GitHubUser?>(null)
 
+    val isKeepPrefs = mutableStateOf(false)
+
     private val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean, uri: Uri?) {
             uri?.let {
@@ -1498,6 +1500,8 @@ class MainViewModel : ViewModel() {
         if (isBatteryNotificationEnabled.value) {
             startBatteryNotificationService(context)
         }
+
+        isKeepPrefs.value = settingsRepository.getBoolean(SettingsRepository.KEY_KEEP_PREFS)
     }
 
     private fun startBatteryNotificationService(context: Context) {
@@ -3935,7 +3939,7 @@ class MainViewModel : ViewModel() {
     }
 
     fun importConfigs(context: Context, inputStream: java.io.InputStream): Boolean {
-        val success = settingsRepository.importConfigs(inputStream)
+        val success = settingsRepository.importConfigs(inputStream, isKeepPrefs.value)
         if (success) {
             settingsRepository.syncSystemSettingsWithSaved()
             com.sameerasw.essentials.domain.diy.DIYRepository.reloadAutomations()
@@ -4301,5 +4305,10 @@ class MainViewModel : ViewModel() {
             dailyWallpaperAutoUpdateTime.value = null
             settingsRepository.remove(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
         }
+    }
+
+    fun toggleKeepPrefs(enabled: Boolean) {
+        isKeepPrefs.value = enabled
+        settingsRepository.putBoolean(SettingsRepository.KEY_KEEP_PREFS, enabled)
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import java.time.LocalDateTime
 
 class MainViewModel : ViewModel() {
     val isAccessibilityEnabled = mutableStateOf(false)
@@ -937,6 +938,8 @@ class MainViewModel : ViewModel() {
         if (isDailyWallpaperAutoUpdateEnabled.value) {
             schedulePeriodicWallpaperCheck(context)
         }
+        dailyWallpaperAutoUpdateTime.value = settingsRepository.getString(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
+        isDailyWallpaperShowLastTime.value = settingsRepository.getBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_SHOW_LAST_TIME)
 
         if (isHideGestureBarEnabled.value) {
             applyHideGestureBar(context, true)
@@ -4239,10 +4242,19 @@ class MainViewModel : ViewModel() {
     }
 
     val isDailyWallpaperAutoUpdateEnabled = mutableStateOf(false)
+    val dailyWallpaperAutoUpdateTime = mutableStateOf<String?>(null)
+    val isDailyWallpaperShowLastTime = mutableStateOf(false)
+
+    fun setDailyWallpaperShowLastTime() {
+        val status = !isDailyWallpaperShowLastTime.value
+        isDailyWallpaperShowLastTime.value = status
+        settingsRepository.putBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_SHOW_LAST_TIME, status)
+    }
 
     fun setDailyWallpaperAutoUpdate(enabled: Boolean, context: Context) {
         isDailyWallpaperAutoUpdateEnabled.value = enabled
         settingsRepository.putBoolean(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE, enabled)
+        updateDailyWallpaperAutoUpdateTime(enabled)
         if (enabled) {
             schedulePeriodicWallpaperCheck(context)
             triggerInstantWallpaperUpdate(context)
@@ -4278,5 +4290,16 @@ class MainViewModel : ViewModel() {
     private fun cancelPeriodicWallpaperCheck(context: Context) {
         androidx.work.WorkManager.getInstance(context)
             .cancelUniqueWork("daily_wallpaper_check_work")
+    }
+
+    private fun updateDailyWallpaperAutoUpdateTime(enabled: Boolean) {
+        if (enabled){
+            val currentTime = LocalDateTime.now().toString()
+            dailyWallpaperAutoUpdateTime.value = currentTime
+            settingsRepository.putString(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME, currentTime)
+        } else {
+            dailyWallpaperAutoUpdateTime.value = null
+            settingsRepository.remove(SettingsRepository.KEY_DAILY_WALLPAPER_AUTO_UPDATE_TIME)
+        }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -332,7 +332,6 @@ class MainViewModel : ViewModel() {
     private var workflowPollingJob: kotlinx.coroutines.Job? = null
     val gitHubUser = mutableStateOf<com.sameerasw.essentials.domain.model.github.GitHubUser?>(null)
 
-    val isKeepPrefs = mutableStateOf(false)
 
     private val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean, uri: Uri?) {
@@ -1501,7 +1500,6 @@ class MainViewModel : ViewModel() {
             startBatteryNotificationService(context)
         }
 
-        isKeepPrefs.value = settingsRepository.getBoolean(SettingsRepository.KEY_KEEP_PREFS)
     }
 
     private fun startBatteryNotificationService(context: Context) {
@@ -3938,8 +3936,8 @@ class MainViewModel : ViewModel() {
         settingsRepository.exportConfigs(outputStream)
     }
 
-    fun importConfigs(context: Context, inputStream: java.io.InputStream): Boolean {
-        val success = settingsRepository.importConfigs(inputStream, isKeepPrefs.value)
+    fun importConfigs(context: Context, inputStream: java.io.InputStream, keepPrefs: Boolean): Boolean {
+        val success = settingsRepository.importConfigs(inputStream, keepPrefs)
         if (success) {
             settingsRepository.syncSystemSettingsWithSaved()
             com.sameerasw.essentials.domain.diy.DIYRepository.reloadAutomations()
@@ -4307,8 +4305,4 @@ class MainViewModel : ViewModel() {
         }
     }
 
-    fun toggleKeepPrefs(enabled: Boolean) {
-        isKeepPrefs.value = enabled
-        settingsRepository.putBoolean(SettingsRepository.KEY_KEEP_PREFS, enabled)
-    }
 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -119,6 +119,7 @@ class MainViewModel : ViewModel() {
     val flashlightPulseMaxIntensity = mutableFloatStateOf(0.5f)
     val isFlashlightPulseDisableOnDnd = mutableStateOf(true)
     val isFlashlightPocketTurnOffEnabled = mutableStateOf(false)
+    val isFlashlightOverheatEnabled = mutableStateOf(true)
     val isLocationPermissionGranted = mutableStateOf(false)
     val isBackgroundLocationPermissionGranted = mutableStateOf(false)
     val isFullScreenIntentPermissionGranted = mutableStateOf(false)
@@ -652,6 +653,10 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_FLASHLIGHT_POCKET_TURN_OFF_ENABLED -> {
                         isFlashlightPocketTurnOffEnabled.value = settingsRepository.getBoolean(key)
+                    }
+
+                    SettingsRepository.KEY_FLASHLIGHT_OVERHEAT_PREVENTION_ENABLED -> {
+                        isFlashlightOverheatEnabled.value = settingsRepository.getBoolean(key, true)
                     }
 
                     SettingsRepository.KEY_CIRCLE_TO_SEARCH_GESTURE_ENABLED -> {
@@ -1316,6 +1321,8 @@ class MainViewModel : ViewModel() {
         )
         isFlashlightPocketTurnOffEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_FLASHLIGHT_POCKET_TURN_OFF_ENABLED)
+        isFlashlightOverheatEnabled.value =
+            settingsRepository.getBoolean(SettingsRepository.KEY_FLASHLIGHT_OVERHEAT_PREVENTION_ENABLED, true)
         isPitchBlackThemeEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_PITCH_BLACK_THEME_ENABLED)
         isEnableUnsupportedFeatures.value = settingsRepository.isEnableUnsupportedFeatures()
@@ -3835,6 +3842,14 @@ class MainViewModel : ViewModel() {
         isFlashlightPocketTurnOffEnabled.value = enabled
         settingsRepository.putBoolean(
             SettingsRepository.KEY_FLASHLIGHT_POCKET_TURN_OFF_ENABLED,
+            enabled
+        )
+    }
+
+    fun setFlashlightOverheatEnabled(enabled: Boolean, context: Context) {
+        isFlashlightOverheatEnabled.value = enabled
+        settingsRepository.putBoolean(
+            SettingsRepository.KEY_FLASHLIGHT_OVERHEAT_PREVENTION_ENABLED,
             enabled
         )
     }

--- a/app/src/main/res/drawable/rounded_thermometer_alert_24.xml
+++ b/app/src/main/res/drawable/rounded_thermometer_alert_24.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M320,840Q237,840 178.5,781.5Q120,723 120,640Q120,592 141,550.5Q162,509 200,480L200,240Q200,190 235,155Q270,120 320,120Q370,120 405,155Q440,190 440,240L440,480Q478,509 499,550.5Q520,592 520,640Q520,723 461.5,781.5Q403,840 320,840ZM320,760Q370,760 405,725Q440,690 440,640Q440,611 427.5,586Q415,561 392,544L360,520L360,240Q360,223 348.5,211.5Q337,200 320,200Q303,200 291.5,211.5Q280,223 280,240L280,520L248,544Q225,561 212.5,586Q200,611 200,640Q200,690 235,725Q270,760 320,760ZM320,640Q320,640 320,640Q320,640 320,640Q320,640 320,640Q320,640 320,640L320,640L320,640L320,640L320,640L320,640Q320,640 320,640Q320,640 320,640Q320,640 320,640Q320,640 320,640ZM691.5,428.5Q680,417 680,400Q680,383 691.5,371.5Q703,360 720,360Q737,360 748.5,371.5Q760,383 760,400Q760,417 748.5,428.5Q737,440 720,440Q703,440 691.5,428.5ZM691.5,308.5Q680,297 680,280L680,160Q680,143 691.5,131.5Q703,120 720,120Q737,120 748.5,131.5Q760,143 760,160L760,280Q760,297 748.5,308.5Q737,320 720,320Q703,320 691.5,308.5Z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -671,6 +671,7 @@
     <string name="perm_action_how_to">How to grant</string>
     <string name="perm_action_granted">Granted</string>
     <string name="perm_action_grant_shizuku">Grant using Shizuku</string>
+    <string name="perm_action_grant_root">Grant using Root</string>
     <string name="perm_write_secure_instructions">This permission can be granted either via a PC using ADB. Copy the ADB command and run on the shell.\n\nOr you can easily grant it using Shizuku from the below button.\n\nThis permission only needs to be granted once.</string>
     <string name="perm_battery_optimization_title">Battery Optimization</string>
     <string name="perm_battery_optimization_desc">Ensure the service is not killed by the system to save power.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1485,6 +1485,7 @@
     <string name="refresh_rate_system_default">System</string>
     <string name="refresh_rate_reset_desc">Remove the custom override and return to the system default refresh behavior</string>
     <string name="msg_refresh_rate_permission_required">Shizuku permission required to adjust refresh rate</string>
+    <string name="msg_refresh_rate_root_permission_required">Root permission required to adjust refresh rate</string>
     <string name="search_refresh_rate_mode_title">Refresh Rate Mode</string>
     <string name="search_refresh_rate_mode_desc">Switch between fixed and ranged refresh rate control</string>
     <string name="search_refresh_rate_fixed_title">Fixed Refresh Rate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1665,4 +1665,12 @@
     <string name="pocket_mode_trigger_delay_title">Trigger delay</string>
     <string name="pocket_mode_lock_screen_only_title">Lock screen only</string>
     <string name="pocket_mode_lock_screen_only_desc">Only trigger pocket mode when the device is locked</string>
+
+    <!-- Developer Settings & Wallpaper Check -->
+    <string name="label_keep_new_settings">Keep new settings</string>
+    <string name="desc_keep_new_settings">Don\'t reset existing settings after import</string>
+    <string name="label_wallpaper_last_checked">Last checked at %1$s</string>
+    <string name="label_wallpaper_next_check">Next check in %1$s</string>
+    <string name="label_wallpaper_hours">%1$d hours</string>
+    <string name="label_wallpaper_a_few_minutes">a few minutes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="flashlight_always_off_desc">Even while display is on</string>
     <string name="flashlight_pocket_title">Pocket detection</string>
     <string name="flashlight_pocket_desc">Turn off flashlight when phone is in your pocket</string>
+    <string name="flashlight_overheat_title">Overheating prevention</string>
+    <string name="flashlight_overheat_desc">Lower brightness on longer period of use</string>
     <string name="content_desc_settings">Settings</string>
 
     <!-- Caffeinate / Permissions -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1667,8 +1667,11 @@
     <string name="pocket_mode_lock_screen_only_desc">Only trigger pocket mode when the device is locked</string>
 
     <!-- Developer Settings & Wallpaper Check -->
-    <string name="label_keep_new_settings">Keep new settings</string>
-    <string name="desc_keep_new_settings">Don\'t reset existing settings after import</string>
+    <string name="import_config_sheet_title">Restore Configuration</string>
+    <string name="import_config_sheet_desc">Choose how you want to restore the configuration.</string>
+    <string name="import_config_merge_warning">Merging might cause data corruption. Please proceed with caution!</string>
+    <string name="action_override">Override</string>
+    <string name="action_merge">Merge</string>
     <string name="label_wallpaper_last_checked">Last checked at %1$s</string>
     <string name="label_wallpaper_next_check">Next check in %1$s</string>
     <string name="label_wallpaper_hours">%1$d hours</string>


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the app, focusing on improving the configuration import workflow, adding flashlight overheat prevention, updating UI components for consistency, and updating versioning. Below are the most significant changes grouped by theme:

**Configuration Import and Settings**

- Added an import confirmation dialog for configuration imports in `SettingsActivity`, allowing users to choose between overriding or merging with existing preferences. The import logic in `SettingsRepository` was updated to support this, preserving preferences when requested. (`SettingsActivity.kt`, `SettingsRepository.kt`) [[1]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1R266-R289) [[2]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1L286-R313) [[3]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1R342-R356) [[4]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7L770-R774) [[5]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7L798-R802)
- Introduced new keys to `SettingsRepository` for tracking wallpaper update times, last shown times, flashlight overheat prevention, and import preferences. (`SettingsRepository.kt`) [[1]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R55-R56) [[2]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R126) [[3]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R292)

**Flashlight Overheat Prevention**

- Implemented a new overheat prevention feature for the flashlight, which automatically reduces intensity if it remains on at high levels for extended periods. This includes a coroutine-based job that checks and adjusts the flashlight intensity as needed. (`FlashlightHandler.kt`) [[1]](diffhunk://#diff-cd16c5ba64f5cbad352e6e9df27333a9b4bebc23840ceedba73d6bb509f45490R54) [[2]](diffhunk://#diff-cd16c5ba64f5cbad352e6e9df27333a9b4bebc23840ceedba73d6bb509f45490R109-R115) [[3]](diffhunk://#diff-cd16c5ba64f5cbad352e6e9df27333a9b4bebc23840ceedba73d6bb509f45490R127) [[4]](diffhunk://#diff-cd16c5ba64f5cbad352e6e9df27333a9b4bebc23840ceedba73d6bb509f45490R664-R696)

**Daily Wallpaper Updates**

- Tracked the last auto-update time for daily wallpapers by saving the current time whenever a new wallpaper is applied. (`DailyWallpaperWorker.kt`, `SettingsRepository.kt`) [[1]](diffhunk://#diff-9c4feacdab30fdb1516426157084953213935e3958928b296bcd0d0588deee3aR9) [[2]](diffhunk://#diff-9c4feacdab30fdb1516426157084953213935e3958928b296bcd0d0588deee3aR81-R87) [[3]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R55-R56)

**UI/UX Improvements**

- Applied consistent rounded corners to cards and containers in `SettingsActivity` and `YourAndroidActivity` by using the `Shapes.extraSmall` shape, improving visual consistency across the app. (`SettingsActivity.kt`, `YourAndroidActivity.kt`) [[1]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1L959-R989) [[2]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1L990-R1021) [[3]](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1L1029-R1061) [[4]](diffhunk://#diff-f54a52cfb3305491fb1aec48f384bde9ee59f7bf2f161f2b18e2f7f5e9642c04R77) [[5]](diffhunk://#diff-f54a52cfb3305491fb1aec48f384bde9ee59f7bf2f161f2b18e2f7f5e9642c04L530-R544)
- Refactored imports and layout components for better code organization and maintainability. (`YourAndroidActivity.kt`)

**Versioning**

- Bumped the app version to `15.7` and `versionCode` to `51` in `build.gradle.kts`.

**Permissions Handling**

- Updated the logic for checking the "Screen refresh rate" feature's permission to use a new shell utility method instead of relying solely on Shizuku permission. (`FeatureSettingsActivity.kt`) [[1]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60L307-R309) [[2]](diffhunk://#diff-dd3d9f46d2b3a6d22fe1e3d6c01d0731ea48d3f11f5890898dde2d0e7f40ce60L542-R546)