### PR TITLE
Develop - In-app translation enhancements

### DIFF
--- a/.github/workflows/apply-translations.yml
+++ b/.github/workflows/apply-translations.yml
@@ -15,6 +15,10 @@ on:
         description: 'Display name of contributor'
         required: false
         type: string
+      contributor_email:
+        description: 'Email address of contributor'
+        required: false
+        type: string
       user_token:
         description: 'User OAuth token'
         required: false
@@ -89,11 +93,16 @@ jobs:
                       sf.write(new_content)
           EOF
 
-          git config user.email "actions@github.com"
+          AUTHOR_EMAIL="${{ inputs.contributor_email }}"
+          if [ -z "$AUTHOR_EMAIL" ]; then
+            AUTHOR_EMAIL="${{ inputs.contributor }}@users.noreply.github.com"
+          fi
+
+          git config user.email "$AUTHOR_EMAIL"
           git config user.name "${{ inputs.contributor_name || inputs.contributor }}"
 
           git add app/src/main/res/
-          git commit -m "Community translations by @${{ inputs.contributor }}" || echo "No changes to commit"
+          git commit --author="${{ inputs.contributor_name || inputs.contributor }} <$AUTHOR_EMAIL>" -m "Community translations by @${{ inputs.contributor }}" || echo "No changes to commit"
           git push origin "$BRANCH"
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
 

--- a/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/SettingsActivity.kt
@@ -286,7 +286,9 @@ fun SettingsContent(
 
 
     val isTranslationModeActive by TranslationManager.isTranslationModeEnabled
-    val sessionEditsCount = remember(TranslationManager.session.edits.size) { TranslationManager.session.edits.size }
+    val sessionEditsCount = TranslationManager.session.edits.size
+
+
 
     var openTranslationPRs by remember { mutableStateOf<List<com.sameerasw.essentials.domain.model.github.GitHubPullRequest>>(emptyList()) }
     val gitHubRepo = remember { com.sameerasw.essentials.data.repository.GitHubRepository() }

--- a/app/src/main/java/com/sameerasw/essentials/translation/model/TranslationModels.kt
+++ b/app/src/main/java/com/sameerasw/essentials/translation/model/TranslationModels.kt
@@ -1,5 +1,7 @@
 package com.sameerasw.essentials.translation.model
 
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.google.gson.Gson
 
 data class StringEntry(
@@ -16,7 +18,7 @@ data class TranslationEdit(
 )
 
 data class TranslationSession(
-    val edits: MutableList<TranslationEdit> = mutableListOf()
+    val edits: SnapshotStateList<TranslationEdit> = mutableStateListOf()
 ) {
     fun addOrUpdate(edit: TranslationEdit) {
         val existingIndex = edits.indexOfFirst { it.key == edit.key && it.locale == edit.locale }

--- a/app/src/main/java/com/sameerasw/essentials/translation/ui/TranslationSessionSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/translation/ui/TranslationSessionSheet.kt
@@ -143,6 +143,8 @@ fun TranslationSessionSheet(
                                         "translations_json" to jsonPayload,
                                         "contributor" to currentUser.login,
                                         "contributor_name" to (currentUser.name ?: currentUser.login),
+                                        "contributor_email" to "${currentUser.id}+${currentUser.login}@users.noreply.github.com",
+
                                         "user_token" to token
                                     )
                                 )


### PR DESCRIPTION
This pull request introduces improvements to the translation contribution workflow by enhancing contributor metadata handling and improving state management for translation edits. The main changes include adding support for contributor email addresses in the GitHub Actions workflow, updating how translation edits are stored for better Compose compatibility, and ensuring contributor email is passed when submitting translations.

**Translation workflow improvements:**

* [`.github/workflows/apply-translations.yml`](diffhunk://#diff-a3f7722207a73e6405f04440bc640173b93a9015cd581bab14d7a743ebe3b6efR18-R21): Added an optional `contributor_email` input, updated the workflow to use this value (or generate a fallback if not provided), and set the Git commit author accordingly for more accurate attribution. [[1]](diffhunk://#diff-a3f7722207a73e6405f04440bc640173b93a9015cd581bab14d7a743ebe3b6efR18-R21) [[2]](diffhunk://#diff-a3f7722207a73e6405f04440bc640173b93a9015cd581bab14d7a743ebe3b6efL92-R105)
* [`TranslationSessionSheet.kt`](diffhunk://#diff-e3c7cbf58600260f2180391b62547763d1533e5414dbcbd90ecab48b564df75eR146-R147): Now includes `contributor_email` when submitting translation PRs, using a unique, noreply-style email for each contributor.

**State management updates:**

* [`TranslationModels.kt`](diffhunk://#diff-de6fd37185e8cf1d47d9476b7a21ec8cdbdb13451c646a7a429185b599021e14R3-R4): Changed the `TranslationSession.edits` property from a `MutableList` to a `SnapshotStateList` using `mutableStateListOf`, improving compatibility with Jetpack Compose's state system. [[1]](diffhunk://#diff-de6fd37185e8cf1d47d9476b7a21ec8cdbdb13451c646a7a429185b599021e14R3-R4) [[2]](diffhunk://#diff-de6fd37185e8cf1d47d9476b7a21ec8cdbdb13451c646a7a429185b599021e14L19-R21)
* [`SettingsActivity.kt`](diffhunk://#diff-576ba73ddab3e3ff415e6dc1c0b3b670b182d923408666f9be5a506cd6f9f5a1L289-R291): Simplified the way `sessionEditsCount` is tracked to reflect the new state management approach.