### PR TITLE
Develop - fix permission card

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.sameerasw.essentials"
         minSdk = 26
         targetSdk = 37
-        versionCode = 53
-        versionName = "16.1"
+        versionCode = 54
+        versionName = "16.2"
 
         val whatsNewCounter = 2
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())
@@ -42,16 +42,16 @@ android {
 
 //        optimized dev build
 
-//          debug {
-//             isMinifyEnabled = true
-//             isShrinkResources = true
-//             isDebuggable = false
-//
-//             proguardFiles(
-//                 getDefaultProguardFile("proguard-android-optimize.txt"),
-//                 "proguard-rules.pro"
-//             )
-//          }
+        //   debug {
+        //      isMinifyEnabled = true
+        //      isShrinkResources = true
+        //      isDebuggable = false
+
+        //      proguardFiles(
+        //          getDefaultProguardFile("proguard-android-optimize.txt"),
+        //          "proguard-rules.pro"
+        //      )
+        //   }
 
         // end
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/cards/PermissionCard.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -22,8 +24,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -36,7 +40,7 @@ import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenu
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
 import com.sameerasw.essentials.utils.HapticUtil
 
-@OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PermissionCard(
     iconRes: Int,
@@ -117,7 +121,10 @@ fun PermissionCard(
                         }
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                    verticalAlignment = Alignment.CenterVertically,
+                    colors = ListItemDefaults.colors(
+                        containerColor = Color.Transparent
+                    ),
                     leadingContent = {
                         Icon(
                             painter = painterResource(id = iconRes),
@@ -165,7 +172,7 @@ fun PermissionCard(
                         expanded = showMenu,
                         onDismissRequest = { showMenu = false }
                     ) {
-                        val context = androidx.compose.ui.platform.LocalContext.current
+                        val context = LocalContext.current
                         val keyTitle = remember(title) { TranslationManager.resolveKey(context, title) }
                         val keyDesc = remember(description) { TranslationManager.resolveKey(context, description) }
                         val keyInst = remember(instructions) { TranslationManager.resolveKey(context, instructions) }
@@ -249,24 +256,78 @@ fun PermissionCard(
                             }
                         }
                     } else {
-                        Button(onClick = {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            onActionClick()
-                        }, modifier = Modifier.fillMaxWidth()) {
+                        OutlinedButton(
+                            onClick = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                onActionClick()
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
                             Text(resolvedActionLabel)
                         }
                     }
+                } else {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (resolvedInstructions != null) {
+                            Text(
+                                text = resolvedInstructions,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(bottom = 4.dp)
+                            )
+                        }
 
-                    if (resolvedShizukuLabel != null && onShizukuActionClick != null) {
-                        Button(
-                            onClick = {
-                                HapticUtil.performVirtualKeyHaptic(view)
-                                onShizukuActionClick()
-                            },
-                            enabled = shizukuActionEnabled,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(resolvedShizukuLabel)
+                        if (resolvedSecondaryLabel != null && onSecondaryActionClick != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                OutlinedButton(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        onActionClick()
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Text(resolvedActionLabel)
+                                }
+
+                                Button(
+                                    onClick = {
+                                        HapticUtil.performVirtualKeyHaptic(view)
+                                        onSecondaryActionClick()
+                                    },
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Text(resolvedSecondaryLabel)
+                                }
+                            }
+                        } else {
+                            Button(
+                                onClick = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    onActionClick()
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(resolvedActionLabel)
+                            }
+                        }
+
+                        if (resolvedShizukuLabel != null && onShizukuActionClick != null) {
+                            Button(
+                                onClick = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    onShizukuActionClick()
+                                },
+                                enabled = shizukuActionEnabled,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(resolvedShizukuLabel)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -904,6 +904,7 @@ class MainViewModel : ViewModel() {
         isAccessibilityEnabled.value = PermissionUtils.isAccessibilityServiceEnabled(context)
         isWriteSecureSettingsEnabled.value = PermissionUtils.canWriteSecureSettings(context)
         isShizukuAvailable.value = ShizukuUtils.isShizukuAvailable()
+        isShizukuPermissionGranted.value = ShizukuUtils.hasPermission()
         if (cachedIsUpdateAvailable) {
             isUpdateAvailable.value = true
             updateInfo.value = cachedUpdateInfo
@@ -3602,6 +3603,7 @@ class MainViewModel : ViewModel() {
 
     fun requestShizukuPermission() {
         ShizukuUtils.requestPermission()
+        isShizukuPermissionGranted.value = ShizukuUtils.hasPermission()
     }
 
     fun grantWriteSecureSettingsWithShizuku(context: Context): Boolean {
@@ -3609,6 +3611,7 @@ class MainViewModel : ViewModel() {
         if (success) {
             // Refresh the write secure settings check
             isWriteSecureSettingsEnabled.value = canWriteSecureSettings(context)
+            isShizukuPermissionGranted.value = ShizukuUtils.hasPermission()
         }
         return success
     }


### PR DESCRIPTION
This pull request updates the `PermissionCard` UI component to improve its flexibility and visual consistency, while also updating the app version and making minor code cleanups. The main changes include switching to `OutlinedButton` for primary actions, supporting both primary and secondary actions, and updating the layout to better handle instructions and action buttons. Additionally, the app's version code and name are incremented.

**UI Improvements to `PermissionCard`:**

* Changed the primary action button from `Button` to `OutlinedButton` for a more consistent appearance and added support for displaying both primary and secondary actions with improved layout using `Column` and `Row` composables. Instructions and secondary actions are now displayed more flexibly, and haptic feedback is triggered for both actions.
* Updated the `ListItem` to use `ListItemDefaults.colors` with a transparent background and refactored alignment and context usage for clarity and consistency. [[1]](diffhunk://#diff-e826d47830692deab9d5e5a27aad9b56e634fd1474ce0195d7ce0dfd2fd3ec51L120-R127) [[2]](diffhunk://#diff-e826d47830692deab9d5e5a27aad9b56e634fd1474ce0195d7ce0dfd2fd3ec51L168-R175)
* Cleaned up imports and annotations, replacing fully-qualified names with direct imports and simplifying `@OptIn` usage. [[1]](diffhunk://#diff-e826d47830692deab9d5e5a27aad9b56e634fd1474ce0195d7ce0dfd2fd3ec51R15-R18) [[2]](diffhunk://#diff-e826d47830692deab9d5e5a27aad9b56e634fd1474ce0195d7ce0dfd2fd3ec51R27-R30) [[3]](diffhunk://#diff-e826d47830692deab9d5e5a27aad9b56e634fd1474ce0195d7ce0dfd2fd3ec51L39-R43)

**Versioning:**

* Bumped `versionCode` to 54 and `versionName` to "16.2" in `app/build.gradle.kts` to reflect the new release.

**Minor Build Script Cleanup:**

* Removed an unnecessary commented line in the build script for improved readability.