### PR TITLE
Develop - translation fixes and new translations

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -54,3 +54,10 @@
 # SLF4J logging rules (prevent R8 missing class warnings)
 -dontwarn org.slf4j.**
 -keep class org.slf4j.** { *; }
+
+# Keep R.string class and fields for runtime translation key reflection lookup
+-keep class com.sameerasw.essentials.R$string { *; }
+-keepclassmembers class com.sameerasw.essentials.R$string {
+    public static <fields>;
+}
+

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1392,8 +1392,8 @@
     <string name="custom_video">Custom video</string>
     <string name="about_desc_live_wallpaper">Set your favorite video as your home screen wallpaper. Choose between triggering the animation upon unlocking or simply whenever the screen turns on for a dynamic experience.</string>
     <!-- Shut-Up! Feature -->
-    <string name="feat_shut_up_title">Shut-Up!</string>
-    <string name="feat_shut_up_desc">I know what I\'m doing</string>
+    <string name="feat_shut_up_title">اخرس</string>
+    <string name="feat_shut_up_desc">انا اعرف ماذا افعل</string>
     <string name="shut_up_description">Shut-Up! bypasses app restrictions and checks for developer options, accessibility and debugging by dynamically hiding them when you launch sensitive apps. \n\nUse the custom shortcuts to ensure settings are hidden before the app launches.</string>
     <string name="shut_up_select_apps_title">Select Apps</string>
     <string name="shut_up_select_apps_desc">Choose apps to apply Shut-Up! logic</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1456,4 +1456,5 @@ Cuando llegue un mensaje o alerta de una aplicación seleccionada, la Pantalla s
     <string name="whats_new_specs_desc">Se han eliminado las especificaciones inexactas basadas en GSMArena para mantener la información del dispositivo limpia, rápida y completamente fiable.</string>
     <string name="whats_new_apps_title">Actualizaciones de la aplicación migradas</string>
     <string name="whats_new_apps_desc">La pestaña Aplicaciones ahora está completamente integrada en la función Tu Android, lo que facilita gestionar todas tus actualizaciones de aplicaciones desde un único y coherente centro unificado.</string>
+    <string name="feat_safe_volume_title">Deshabilitar advertencia de volumen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1454,4 +1454,6 @@
     <string name="whats_new_specs_desc">Inaccurate GSMArena-powered specifications have been removed to keep device insights clean, fast, and completely reliable.</string>
     <string name="whats_new_apps_title">App Updates Migrated</string>
     <string name="whats_new_apps_desc">The Apps tab is now fully integrated into the Your Android feature, making it easier to manage all your app updates in one cohesive hub.</string>
+    <string name="feat_daily_wallpaper_title">Fond d'écran</string>
+    <string name="feat_daily_wallpaper_desc">Fonds d'écran sélectionnés avec soin chaque jour</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1456,4 +1456,10 @@
     <string name="whats_new_apps_desc">The Apps tab is now fully integrated into the Your Android feature, making it easier to manage all your app updates in one cohesive hub.</string>
     <string name="feat_daily_wallpaper_title">Fond d'écran</string>
     <string name="feat_daily_wallpaper_desc">Fonds d'écran sélectionnés avec soin chaque jour</string>
+    <string name="feat_power_battery_title">Alimentation et batterie</string>
+    <string name="feat_power_battery_desc">Configurer les règles d'économie d'énergie</string>
+    <string name="feat_flashlight_title">Lampe de poche</string>
+    <string name="feat_flashlight_desc">Améliorer le fonctionnement de la lampe de poche</string>
+    <string name="feat_notification_snoozing_title">Mise en veille des notifications</string>
+    <string name="feat_notification_snoozing_desc">Reprogrammer les notifications</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_display_visuals_title">Tampilan</string>
+    <string name="feat_display_visuals_desc">Visual untuk meningkatkan pengalaman Anda</string>
+</resources>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -706,8 +706,8 @@
     <string name="unit_seconds">%d seconds</string>
     <string name="unit_minute">1 minute</string>
     <string name="unit_minutes">%d minutes</string>
-    <string name="action_restart_systemui">Restart SystemUI</string>
-    <string name="desc_restart_systemui">Kills and restarts SystemUI process to apply some changes immediately</string>
+    <string name="action_restart_systemui">SystemUI නැවත ආරම්භ කරන්න</string>
+    <string name="desc_restart_systemui">සමහර වෙනස්කම් වහාම ක්‍රියාත්මක කිරීම සඳහා SystemUI ක්‍රියාවලිය (process) නවතා නැවත ආරම්භ කරයි.</string>
     <string name="msg_error_load_release_notes">Couldn\'t load the release note</string>
     <string name="action_view_on_web">View on web</string>
     <string name="action_done">කළා</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -1454,4 +1454,5 @@
     <string name="whats_new_specs_desc">Inaccurate GSMArena-powered specifications have been removed to keep device insights clean, fast, and completely reliable.</string>
     <string name="whats_new_apps_title">App Updates Migrated</string>
     <string name="whats_new_apps_desc">The Apps tab is now fully integrated into the Your Android feature, making it easier to manage all your app updates in one cohesive hub.</string>
+    <string name="feat_power_battery_title">බැටරි සුරැකුම්</string>
 </resources>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -664,9 +664,9 @@
     <string name="label_settings">සැකසීම්</string>
     <string name="action_report_bug">දෝෂයක් වාර්තා කරන්න</string>
     <!-- Sentry Crash Reporting -->
-    <string name="sentry_report_mode_title">Crash reporting</string>
-    <string name="sentry_mode_off">Off</string>
-    <string name="sentry_mode_auto">Auto</string>
+    <string name="sentry_report_mode_title">බිඳ වැටීම් වාර්තාකරණය</string>
+    <string name="sentry_mode_off">අක්‍රියයි</string>
+    <string name="sentry_mode_auto">ස්වයංක්‍රීය</string>
     <string name="sentry_crash_toast">Essentials crashed, Report sent</string>
     <string name="simulate_crash">Simulate crash</string>
     <string name="welcome_title">Welcome to Essentials</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -1455,4 +1455,5 @@
     <string name="whats_new_apps_title">App Updates Migrated</string>
     <string name="whats_new_apps_desc">The Apps tab is now fully integrated into the Your Android feature, making it easier to manage all your app updates in one cohesive hub.</string>
     <string name="feat_power_battery_title">බැටරි සුරැකුම්</string>
+    <string name="feat_notification_snoozing_title">දැන්වීම් කල්දැමීම </string>
 </resources>


### PR DESCRIPTION
This pull request primarily adds and updates translation strings across several languages to improve localization, and updates ProGuard rules to support runtime translation key lookups. The most important changes are grouped below:

**Localization Improvements:**

* Added new and updated translation strings for features in various languages, including French (`feat_daily_wallpaper`, `feat_power_battery`, `feat_flashlight`, `feat_notification_snoozing`), Spanish (`feat_safe_volume_title`), Indonesian (new file with `feat_display_visuals` strings), and Sinhala (`feat_power_battery_title`, `feat_notification_snoozing_title`). [[1]](diffhunk://#diff-a2529e239a99387f33127b7e3027bc8447c2392f428129f616ca7f319dd187fbR1457-R1464) [[2]](diffhunk://#diff-8c6b298e44d13c3fb1a2b68937365e5e0746ab568b88bb6dc7a44936f8c653acR1459) [[3]](diffhunk://#diff-4e3b35193984abea0d79601eea2eea30655a11f01d733877e6f8d6759df0e93bR1-R5) [[4]](diffhunk://#diff-395bf68e2bca4c59ffd41d3155aa64cee26c0c46ba77900f531e2dd73fa6ce38R1457-R1458)
* Improved existing translations for the "Shut-Up!" feature in Arabic, and for crash reporting and system UI restart actions in Sinhala. [[1]](diffhunk://#diff-275e22e5424874865d61be0a790c48168da5998ec6dd530c83fb33005bfa4449L1395-R1396) [[2]](diffhunk://#diff-395bf68e2bca4c59ffd41d3155aa64cee26c0c46ba77900f531e2dd73fa6ce38L667-R669) [[3]](diffhunk://#diff-395bf68e2bca4c59ffd41d3155aa64cee26c0c46ba77900f531e2dd73fa6ce38L709-R710)

**Build Configuration:**

* Updated `proguard-rules.pro` to keep the `R$string` class and its fields, ensuring that runtime translation key reflection lookups work correctly and translations are not stripped during minification.