### PR TITLE
Develop - samsung battery info support, DIY wifi and bt

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/com/sameerasw/essentials/domain/diy/Trigger.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/diy/Trigger.kt
@@ -53,4 +53,58 @@ sealed interface Trigger {
         override val icon: Int get() = R.drawable.rounded_nest_clock_farsight_analog_24
         override val isConfigurable: Boolean get() = true
     }
+
+    @Keep
+    data class BluetoothConnected(
+        @SerializedName("deviceAddress") val deviceAddress: String = "",
+        @SerializedName("deviceName") val deviceName: String = ""
+    ) : Trigger {
+        override val title: Int get() = R.string.diy_trigger_bluetooth_connected
+        override val icon: Int get() = R.drawable.rounded_bluetooth_24
+        override val isConfigurable: Boolean get() = true
+        override val permissions: List<String>
+            get() = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                listOf(android.Manifest.permission.BLUETOOTH_CONNECT)
+            } else {
+                emptyList()
+            }
+    }
+
+    @Keep
+    data class BluetoothDisconnected(
+        @SerializedName("deviceAddress") val deviceAddress: String = "",
+        @SerializedName("deviceName") val deviceName: String = ""
+    ) : Trigger {
+        override val title: Int get() = R.string.diy_trigger_bluetooth_disconnected
+        override val icon: Int get() = R.drawable.rounded_bluetooth_24
+        override val isConfigurable: Boolean get() = true
+        override val permissions: List<String>
+            get() = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                listOf(android.Manifest.permission.BLUETOOTH_CONNECT)
+            } else {
+                emptyList()
+            }
+    }
+
+    @Keep
+    data class WifiConnected(
+        @SerializedName("ssid") val ssid: String = ""
+    ) : Trigger {
+        override val title: Int get() = R.string.diy_trigger_wifi_connected
+        override val icon: Int get() = R.drawable.rounded_android_wifi_4_bar_plus_24
+        override val isConfigurable: Boolean get() = true
+        override val permissions: List<String>
+            get() = listOf(android.Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    @Keep
+    data class WifiDisconnected(
+        @SerializedName("ssid") val ssid: String = ""
+    ) : Trigger {
+        override val title: Int get() = R.string.diy_trigger_wifi_disconnected
+        override val icon: Int get() = R.drawable.rounded_android_wifi_3_bar_24
+        override val isConfigurable: Boolean get() = true
+        override val permissions: List<String>
+            get() = listOf(android.Manifest.permission.ACCESS_FINE_LOCATION)
+    }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/AutomationManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/AutomationManager.kt
@@ -6,9 +6,11 @@ import com.sameerasw.essentials.domain.diy.Automation
 import com.sameerasw.essentials.domain.diy.DIYRepository
 import com.sameerasw.essentials.domain.diy.Trigger
 import com.sameerasw.essentials.services.automation.modules.AutomationModule
+import com.sameerasw.essentials.services.automation.modules.BluetoothModule
 import com.sameerasw.essentials.services.automation.modules.DisplayModule
 import com.sameerasw.essentials.services.automation.modules.PowerModule
 import com.sameerasw.essentials.services.automation.modules.TimeModule
+import com.sameerasw.essentials.services.automation.modules.WifiModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -63,6 +65,8 @@ object AutomationManager {
         val powerAutomations = mutableListOf<Automation>()
         val displayAutomations = mutableListOf<Automation>()
         val timeAutomations = mutableListOf<Automation>()
+        val bluetoothAutomations = mutableListOf<Automation>()
+        val wifiAutomations = mutableListOf<Automation>()
 
         enabledAutomations.forEach { automation ->
             when (automation.type) {
@@ -81,6 +85,16 @@ object AutomationManager {
                         is Trigger.Schedule -> {
                             requiredModuleIds.add(TimeModule.ID)
                             timeAutomations.add(automation)
+                        }
+
+                        is Trigger.BluetoothConnected, is Trigger.BluetoothDisconnected -> {
+                            requiredModuleIds.add(BluetoothModule.ID)
+                            bluetoothAutomations.add(automation)
+                        }
+
+                        is Trigger.WifiConnected, is Trigger.WifiDisconnected -> {
+                            requiredModuleIds.add(WifiModule.ID)
+                            wifiAutomations.add(automation)
                         }
 
                         else -> {}
@@ -157,6 +171,26 @@ object AutomationManager {
             module.updateAutomations(timeAutomations)
         } else {
             activeModules.remove(TimeModule.ID)?.stop(context)
+        }
+
+        // Bluetooth Module
+        if (requiredModuleIds.contains(BluetoothModule.ID)) {
+            val module = activeModules.getOrPut(BluetoothModule.ID) {
+                BluetoothModule().also { it.start(context) }
+            }
+            module.updateAutomations(bluetoothAutomations)
+        } else {
+            activeModules.remove(BluetoothModule.ID)?.stop(context)
+        }
+
+        // Wifi Module
+        if (requiredModuleIds.contains(WifiModule.ID)) {
+            val module = activeModules.getOrPut(WifiModule.ID) {
+                WifiModule().also { it.start(context) }
+            }
+            module.updateAutomations(wifiAutomations)
+        } else {
+            activeModules.remove(WifiModule.ID)?.stop(context)
         }
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/modules/BluetoothModule.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/modules/BluetoothModule.kt
@@ -1,0 +1,79 @@
+package com.sameerasw.essentials.services.automation.modules
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.sameerasw.essentials.domain.diy.Automation
+import com.sameerasw.essentials.domain.diy.Trigger
+import com.sameerasw.essentials.services.automation.executors.CombinedActionExecutor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class BluetoothModule : AutomationModule {
+    companion object {
+        const val ID = "bluetooth_module"
+    }
+
+    override val id: String = ID
+    private var automations: List<Automation> = emptyList()
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    @SuppressLint("MissingPermission")
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val device = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+            } ?: return
+
+            val address = device.address ?: return
+
+            when (intent.action) {
+                BluetoothDevice.ACTION_ACL_CONNECTED -> handleTrigger(context, address) {
+                    it is Trigger.BluetoothConnected && it.deviceAddress == address
+                }
+
+                BluetoothDevice.ACTION_ACL_DISCONNECTED -> handleTrigger(context, address) {
+                    it is Trigger.BluetoothDisconnected && it.deviceAddress == address
+                }
+            }
+        }
+    }
+
+    override fun start(context: Context) {
+        val filter = IntentFilter().apply {
+            addAction(BluetoothDevice.ACTION_ACL_CONNECTED)
+            addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED)
+        }
+        context.registerReceiver(receiver, filter)
+    }
+
+    override fun stop(context: Context) {
+        try {
+            context.unregisterReceiver(receiver)
+        } catch (e: Exception) {
+            // Ignore if not registered
+        }
+    }
+
+    override fun updateAutomations(automations: List<Automation>) {
+        this.automations = automations
+    }
+
+    private fun handleTrigger(context: Context, address: String, matches: (Trigger) -> Boolean) {
+        scope.launch {
+            automations.filter { it.type == Automation.Type.TRIGGER && it.trigger?.let(matches) == true }
+                .forEach { automation ->
+                    automation.actions.forEach { action ->
+                        CombinedActionExecutor.execute(context, action)
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/modules/BluetoothModule.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/modules/BluetoothModule.kt
@@ -46,20 +46,26 @@ class BluetoothModule : AutomationModule {
         }
     }
 
+    private var appContext: Context? = null
+
     override fun start(context: Context) {
+        val appCtx = context.applicationContext
+        appContext = appCtx
         val filter = IntentFilter().apply {
             addAction(BluetoothDevice.ACTION_ACL_CONNECTED)
             addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED)
         }
-        context.registerReceiver(receiver, filter)
+        appCtx.registerReceiver(receiver, filter)
     }
 
     override fun stop(context: Context) {
+        val appCtx = appContext ?: context.applicationContext
         try {
-            context.unregisterReceiver(receiver)
+            appCtx.unregisterReceiver(receiver)
         } catch (e: Exception) {
             // Ignore if not registered
         }
+        appContext = null
     }
 
     override fun updateAutomations(automations: List<Automation>) {

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/modules/WifiModule.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/modules/WifiModule.kt
@@ -25,25 +25,7 @@ class WifiModule : AutomationModule {
     private val scope = CoroutineScope(Dispatchers.IO)
     private var connectivityManager: ConnectivityManager? = null
     private var appContext: Context? = null
-    private var currentSsid: String? = null
-
-    // NetworkCapabilities.getTransportInfo() only exists from API 31 onward, and querying it
-    // on older OS versions throws NoSuchMethodError inside the (system-swallowed) callback.
-    // WifiManager.connectionInfo works on every API level and respects the same location
-    // permission gating, so it's used unconditionally instead of branching by SDK level.
-    @Suppress("DEPRECATION")
-    private fun currentWifiSsid(): String? {
-        val wifiManager =
-            appContext?.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return null
-        val ssid = try {
-            wifiManager.connectionInfo?.ssid
-        } catch (e: Exception) {
-            Log.w(ID, "Failed to read current SSID", e)
-            null
-        }
-        if (ssid.isNullOrEmpty() || ssid == UNKNOWN_SSID) return null
-        return ssid.removeSurrounding("\"")
-    }
+    private val activeNetworkSsids = java.util.concurrent.ConcurrentHashMap<Network, String>()
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
@@ -53,16 +35,15 @@ class WifiModule : AutomationModule {
                 Log.d(ID, "Wi-Fi capabilities changed but SSID unavailable (check location permission/services)")
                 return
             }
-            if (ssid == currentSsid) return
+            if (activeNetworkSsids[network] == ssid) return
             Log.d(ID, "Wi-Fi connected: $ssid")
-            currentSsid = ssid
+            activeNetworkSsids[network] = ssid
             handleTrigger { it is Trigger.WifiConnected && it.ssid == ssid }
         }
 
         override fun onLost(network: Network) {
-            val ssid = currentSsid ?: return
+            val ssid = activeNetworkSsids.remove(network) ?: return
             Log.d(ID, "Wi-Fi disconnected: $ssid")
-            currentSsid = null
             handleTrigger { it is Trigger.WifiDisconnected && it.ssid == ssid }
         }
     }
@@ -85,6 +66,24 @@ class WifiModule : AutomationModule {
         }
     }
 
+    // NetworkCapabilities.getTransportInfo() only exists from API 31 onward, and querying it
+    // on older OS versions throws NoSuchMethodError inside the (system-swallowed) callback.
+    // WifiManager.connectionInfo works on every API level and respects the same location
+    // permission gating, so it's used unconditionally instead of branching by SDK level.
+    @Suppress("DEPRECATION")
+    private fun currentWifiSsid(): String? {
+        val wifiManager =
+            appContext?.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return null
+        val ssid = try {
+            wifiManager.connectionInfo?.ssid
+        } catch (e: Exception) {
+            Log.w(ID, "Failed to read current SSID", e)
+            null
+        }
+        if (ssid.isNullOrEmpty() || ssid == UNKNOWN_SSID) return null
+        return ssid.removeSurrounding("\"")
+    }
+
     override fun stop(context: Context) {
         try {
             connectivityManager?.unregisterNetworkCallback(networkCallback)
@@ -93,7 +92,7 @@ class WifiModule : AutomationModule {
         }
         connectivityManager = null
         appContext = null
-        currentSsid = null
+        activeNetworkSsids.clear()
     }
 
     override fun updateAutomations(automations: List<Automation>) {

--- a/app/src/main/java/com/sameerasw/essentials/services/automation/modules/WifiModule.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/automation/modules/WifiModule.kt
@@ -1,0 +1,114 @@
+package com.sameerasw.essentials.services.automation.modules
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiManager
+import android.util.Log
+import com.sameerasw.essentials.domain.diy.Automation
+import com.sameerasw.essentials.domain.diy.Trigger
+import com.sameerasw.essentials.services.automation.executors.CombinedActionExecutor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class WifiModule : AutomationModule {
+    companion object {
+        const val ID = "wifi_module"
+        private const val UNKNOWN_SSID = "<unknown ssid>"
+    }
+
+    override val id: String = ID
+    private var automations: List<Automation> = emptyList()
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var connectivityManager: ConnectivityManager? = null
+    private var appContext: Context? = null
+    private var currentSsid: String? = null
+
+    // NetworkCapabilities.getTransportInfo() only exists from API 31 onward, and querying it
+    // on older OS versions throws NoSuchMethodError inside the (system-swallowed) callback.
+    // WifiManager.connectionInfo works on every API level and respects the same location
+    // permission gating, so it's used unconditionally instead of branching by SDK level.
+    @Suppress("DEPRECATION")
+    private fun currentWifiSsid(): String? {
+        val wifiManager =
+            appContext?.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return null
+        val ssid = try {
+            wifiManager.connectionInfo?.ssid
+        } catch (e: Exception) {
+            Log.w(ID, "Failed to read current SSID", e)
+            null
+        }
+        if (ssid.isNullOrEmpty() || ssid == UNKNOWN_SSID) return null
+        return ssid.removeSurrounding("\"")
+    }
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+            if (!capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) return
+            val ssid = currentWifiSsid()
+            if (ssid == null) {
+                Log.d(ID, "Wi-Fi capabilities changed but SSID unavailable (check location permission/services)")
+                return
+            }
+            if (ssid == currentSsid) return
+            Log.d(ID, "Wi-Fi connected: $ssid")
+            currentSsid = ssid
+            handleTrigger { it is Trigger.WifiConnected && it.ssid == ssid }
+        }
+
+        override fun onLost(network: Network) {
+            val ssid = currentSsid ?: return
+            Log.d(ID, "Wi-Fi disconnected: $ssid")
+            currentSsid = null
+            handleTrigger { it is Trigger.WifiDisconnected && it.ssid == ssid }
+        }
+    }
+
+    override fun start(context: Context) {
+        appContext = context.applicationContext
+        val manager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        connectivityManager = manager
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            // Default builder requires validated internet access; many Wi-Fi networks
+            // (captive portals, offline IoT/local networks) never satisfy that, so the
+            // callback would otherwise never fire for them.
+            .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        try {
+            manager.registerNetworkCallback(request, networkCallback)
+        } catch (e: Exception) {
+            Log.e(ID, "Failed to register Wi-Fi network callback", e)
+        }
+    }
+
+    override fun stop(context: Context) {
+        try {
+            connectivityManager?.unregisterNetworkCallback(networkCallback)
+        } catch (e: Exception) {
+            // Ignore if not registered
+        }
+        connectivityManager = null
+        appContext = null
+        currentSsid = null
+    }
+
+    override fun updateAutomations(automations: List<Automation>) {
+        this.automations = automations
+    }
+
+    private fun handleTrigger(matches: (Trigger) -> Boolean) {
+        val context = appContext ?: return
+        scope.launch {
+            automations.filter { it.type == Automation.Type.TRIGGER && it.trigger?.let(matches) == true }
+                .forEach { automation ->
+                    automation.actions.forEach { action ->
+                        CombinedActionExecutor.execute(context, action)
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/AutomationEditorActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/AutomationEditorActivity.kt
@@ -70,9 +70,11 @@ import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenu
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
 import com.sameerasw.essentials.ui.components.pickers.SegmentedPicker
+import com.sameerasw.essentials.ui.components.sheets.BluetoothDeviceSelectionSheet
 import com.sameerasw.essentials.ui.components.sheets.DimWallpaperSettingsSheet
 import com.sameerasw.essentials.ui.components.sheets.ScreenOffSettingsSheet
 import com.sameerasw.essentials.ui.components.sheets.SoundModeSettingsSheet
+import com.sameerasw.essentials.ui.components.sheets.WifiNetworkSelectionSheet
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.AppUtil
 import com.sameerasw.essentials.utils.HapticUtil
@@ -228,10 +230,20 @@ class AutomationEditorActivity : ComponentActivity() {
                 var showDeviceEffectsSettings by remember { mutableStateOf(false) }
                 var showSoundModeSettings by remember { mutableStateOf(false) }
                 var showTimeSettings by remember { mutableStateOf(false) }
+                var showBluetoothSettings by remember { mutableStateOf(false) }
+                var showWifiSettings by remember { mutableStateOf(false) }
                 var configAction by remember { mutableStateOf<Action?>(null) } // Generic config action
 
+                val isTriggerConfigured = when (val trigger = selectedTrigger) {
+                    is Trigger.BluetoothConnected -> trigger.deviceAddress.isNotBlank()
+                    is Trigger.BluetoothDisconnected -> trigger.deviceAddress.isNotBlank()
+                    is Trigger.WifiConnected -> trigger.ssid.isNotBlank()
+                    is Trigger.WifiDisconnected -> trigger.ssid.isNotBlank()
+                    else -> true
+                }
+
                 val isValid = when (automationType) {
-                    Automation.Type.TRIGGER -> selectedTrigger != null && selectedAction != null
+                    Automation.Type.TRIGGER -> selectedTrigger != null && selectedAction != null && isTriggerConfigured
                     Automation.Type.ACTION_SHORTCUT, Automation.Type.PIXEL_SEARCHBAR -> selectedAction != null
                     Automation.Type.STATE -> selectedState != null && (selectedInAction != null || selectedOutAction != null)
                     Automation.Type.APP -> selectedApps.isNotEmpty() && (selectedInAction != null || selectedOutAction != null)
@@ -504,6 +516,26 @@ class AutomationEditorActivity : ComponentActivity() {
                                                                 ?: 0,
                                                             days = (selectedTrigger as? Trigger.Schedule)?.days
                                                                 ?: emptySet()
+                                                        ),
+                                                        Trigger.BluetoothConnected(
+                                                            deviceAddress = (selectedTrigger as? Trigger.BluetoothConnected)?.deviceAddress
+                                                                ?: "",
+                                                            deviceName = (selectedTrigger as? Trigger.BluetoothConnected)?.deviceName
+                                                                ?: ""
+                                                        ),
+                                                        Trigger.BluetoothDisconnected(
+                                                            deviceAddress = (selectedTrigger as? Trigger.BluetoothDisconnected)?.deviceAddress
+                                                                ?: "",
+                                                            deviceName = (selectedTrigger as? Trigger.BluetoothDisconnected)?.deviceName
+                                                                ?: ""
+                                                        ),
+                                                        Trigger.WifiConnected(
+                                                            ssid = (selectedTrigger as? Trigger.WifiConnected)?.ssid
+                                                                ?: ""
+                                                        ),
+                                                        Trigger.WifiDisconnected(
+                                                            ssid = (selectedTrigger as? Trigger.WifiDisconnected)?.ssid
+                                                                ?: ""
                                                         )
                                                     )
                                                     triggers.forEach { trigger ->
@@ -514,8 +546,19 @@ class AutomationEditorActivity : ComponentActivity() {
                                                             isConfigurable = trigger.isConfigurable,
                                                             onClick = { selectedTrigger = trigger },
                                                             onSettingsClick = {
-                                                                if (trigger is Trigger.Schedule) {
-                                                                    showTimeSettings = true
+                                                                when (trigger) {
+                                                                    is Trigger.Schedule -> showTimeSettings =
+                                                                        true
+
+                                                                    is Trigger.BluetoothConnected,
+                                                                    is Trigger.BluetoothDisconnected -> showBluetoothSettings =
+                                                                        true
+
+                                                                    is Trigger.WifiConnected,
+                                                                    is Trigger.WifiDisconnected -> showWifiSettings =
+                                                                        true
+
+                                                                    else -> {}
                                                                 }
                                                             }
                                                         )
@@ -716,6 +759,47 @@ class AutomationEditorActivity : ComponentActivity() {
                                 onSaveState = {
                                     selectedState = it
                                     showTimeSettings = false
+                                }
+                            )
+                        }
+
+                        if (showBluetoothSettings) {
+                            BluetoothDeviceSelectionSheet(
+                                onDismiss = { showBluetoothSettings = false },
+                                onSave = { address, name ->
+                                    selectedTrigger = when (selectedTrigger) {
+                                        is Trigger.BluetoothConnected -> Trigger.BluetoothConnected(
+                                            deviceAddress = address,
+                                            deviceName = name
+                                        )
+
+                                        is Trigger.BluetoothDisconnected -> Trigger.BluetoothDisconnected(
+                                            deviceAddress = address,
+                                            deviceName = name
+                                        )
+
+                                        else -> selectedTrigger
+                                    }
+                                    showBluetoothSettings = false
+                                }
+                            )
+                        }
+
+                        if (showWifiSettings) {
+                            WifiNetworkSelectionSheet(
+                                initialSsid = when (val trigger = selectedTrigger) {
+                                    is Trigger.WifiConnected -> trigger.ssid
+                                    is Trigger.WifiDisconnected -> trigger.ssid
+                                    else -> null
+                                },
+                                onDismiss = { showWifiSettings = false },
+                                onSave = { ssid ->
+                                    selectedTrigger = when (selectedTrigger) {
+                                        is Trigger.WifiConnected -> Trigger.WifiConnected(ssid = ssid)
+                                        is Trigger.WifiDisconnected -> Trigger.WifiDisconnected(ssid = ssid)
+                                        else -> selectedTrigger
+                                    }
+                                    showWifiSettings = false
                                 }
                             )
                         }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/cards/SelectionCardItem.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/cards/SelectionCardItem.kt
@@ -1,0 +1,55 @@
+package com.sameerasw.essentials.ui.components.cards
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.utils.HapticUtil
+
+@Composable
+fun SelectionCardItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    iconRes: Int? = null
+) {
+    val view = LocalView.current
+
+    ListItem(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.extraSmall)
+            .clickable {
+                HapticUtil.performUIHaptic(view)
+                onClick()
+            },
+        headlineContent = { Text(title) },
+        supportingContent = if (description != null) {
+            { Text(description) }
+        } else null,
+        leadingContent = if (iconRes != null && iconRes != 0) {
+            {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        } else null,
+        colors = ListItemDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surfaceBright
+        )
+    )
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/BluetoothDeviceSelectionSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/BluetoothDeviceSelectionSheet.kt
@@ -1,0 +1,133 @@
+package com.sameerasw.essentials.ui.components.sheets
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.utils.BluetoothPairedDevicesUtil
+import com.sameerasw.essentials.utils.HapticUtil
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BluetoothDeviceSelectionSheet(
+    onDismiss: () -> Unit,
+    onSave: (address: String, name: String) -> Unit
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    var hasPermission by remember {
+        mutableStateOf(
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+                    ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.BLUETOOTH_CONNECT
+                    ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted -> hasPermission = granted }
+
+    LaunchedEffect(Unit) {
+        if (!hasPermission) {
+            permissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+    }
+
+    val devices = remember(hasPermission) {
+        if (hasPermission) BluetoothPairedDevicesUtil.getPairedDevices(context) else emptyList()
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.diy_select_bluetooth_device_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            if (!hasPermission) {
+                Text(
+                    text = stringResource(R.string.diy_bluetooth_permission_required),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else if (devices.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.diy_no_paired_bluetooth_devices),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(devices) { device ->
+                        ListItem(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    HapticUtil.performUIHaptic(view)
+                                    onSave(device.address, device.name)
+                                },
+                            headlineContent = { Text(device.name) },
+                            supportingContent = { Text(device.address) },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.rounded_bluetooth_24),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            },
+                            colors = ListItemDefaults.colors(
+                                containerColor = MaterialTheme.colorScheme.surfaceBright
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/BluetoothDeviceSelectionSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/BluetoothDeviceSelectionSheet.kt
@@ -5,7 +5,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,9 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -27,15 +23,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.cards.SelectionCardItem
+import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.utils.BluetoothPairedDevicesUtil
-import com.sameerasw.essentials.utils.HapticUtil
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,7 +39,6 @@ fun BluetoothDeviceSelectionSheet(
     onSave: (address: String, name: String) -> Unit
 ) {
     val context = LocalContext.current
-    val view = LocalView.current
 
     var hasPermission by remember {
         mutableStateOf(
@@ -101,30 +95,18 @@ fun BluetoothDeviceSelectionSheet(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    items(devices) { device ->
-                        ListItem(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    HapticUtil.performUIHaptic(view)
-                                    onSave(device.address, device.name)
-                                },
-                            headlineContent = { Text(device.name) },
-                            supportingContent = { Text(device.address) },
-                            leadingContent = {
-                                Icon(
-                                    painter = painterResource(R.drawable.rounded_bluetooth_24),
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            },
-                            colors = ListItemDefaults.colors(
-                                containerColor = MaterialTheme.colorScheme.surfaceBright
+                RoundedCardContainer {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        items(devices) { device ->
+                            SelectionCardItem(
+                                title = device.name,
+                                description = device.address,
+                                iconRes = R.drawable.rounded_bluetooth_24,
+                                onClick = { onSave(device.address, device.name) }
                             )
-                        )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WifiNetworkSelectionSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WifiNetworkSelectionSheet.kt
@@ -1,0 +1,228 @@
+package com.sameerasw.essentials.ui.components.sheets
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.utils.WifiUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WifiNetworkSelectionSheet(
+    initialSsid: String? = null,
+    onDismiss: () -> Unit,
+    onSave: (ssid: String) -> Unit
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    var ssid by remember { mutableStateOf(initialSsid ?: "") }
+    var isLoadingSavedNetworks by remember { mutableStateOf(true) }
+    var savedNetworks by remember { mutableStateOf<List<String>>(emptyList()) }
+
+    LaunchedEffect(Unit) {
+        val networks = withContext(Dispatchers.IO) {
+            if (WifiUtil.canReadSavedNetworks(context)) {
+                WifiUtil.getSavedNetworkSsids(context)
+            } else {
+                emptyList()
+            }
+        }
+        savedNetworks = networks
+        isLoadingSavedNetworks = false
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            WifiUtil.getCurrentSsid(context)?.let { ssid = it }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.diy_select_wifi_network_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            when {
+                isLoadingSavedNetworks -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                savedNetworks.isNotEmpty() -> {
+                    Text(
+                        text = stringResource(R.string.diy_saved_networks_via_shizuku),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        items(savedNetworks) { network ->
+                            ListItem(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        HapticUtil.performUIHaptic(view)
+                                        onSave(network)
+                                    },
+                                headlineContent = { Text(network) },
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.rounded_android_wifi_4_bar_plus_24),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                },
+                                colors = ListItemDefaults.colors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceBright
+                                )
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    OutlinedTextField(
+                        value = ssid,
+                        onValueChange = { ssid = it },
+                        label = { Text(stringResource(R.string.diy_wifi_ssid_label)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true
+                    )
+
+                    OutlinedButton(
+                        onClick = {
+                            HapticUtil.performUIHaptic(view)
+                            val hasPermission = ContextCompat.checkSelfPermission(
+                                context,
+                                Manifest.permission.ACCESS_FINE_LOCATION
+                            ) == PackageManager.PERMISSION_GRANTED
+                            if (hasPermission) {
+                                WifiUtil.getCurrentSsid(context)?.let { ssid = it }
+                            } else {
+                                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.rounded_android_wifi_4_bar_plus_24),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(stringResource(R.string.diy_use_current_network))
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Button(
+                            onClick = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                onDismiss()
+                            },
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceBright,
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            )
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_close_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(modifier = Modifier.size(8.dp))
+                            Text(stringResource(R.string.action_cancel))
+                        }
+
+                        Button(
+                            onClick = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                if (ssid.isNotBlank()) {
+                                    onSave(ssid.trim())
+                                }
+                            },
+                            modifier = Modifier.weight(1f),
+                            enabled = ssid.isNotBlank()
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_check_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(modifier = Modifier.size(8.dp))
+                            Text(stringResource(R.string.action_save))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WifiNetworkSelectionSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/sheets/WifiNetworkSelectionSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -43,6 +44,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.cards.SelectionCardItem
+import com.sameerasw.essentials.ui.components.containers.RoundedCardContainer
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.WifiUtil
 import kotlinx.coroutines.Dispatchers
@@ -118,29 +121,17 @@ fun WifiNetworkSelectionSheet(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        items(savedNetworks) { network ->
-                            ListItem(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable {
-                                        HapticUtil.performUIHaptic(view)
-                                        onSave(network)
-                                    },
-                                headlineContent = { Text(network) },
-                                leadingContent = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.rounded_android_wifi_4_bar_plus_24),
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
-                                },
-                                colors = ListItemDefaults.colors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceBright
+                    RoundedCardContainer {
+                        LazyColumn(
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
+                            items(savedNetworks) { network ->
+                                SelectionCardItem(
+                                    title = network,
+                                    iconRes = R.drawable.rounded_android_wifi_4_bar_plus_24,
+                                    onClick = { onSave(network) }
                                 )
-                            )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/BatteryInfoUtil.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/BatteryInfoUtil.kt
@@ -177,7 +177,7 @@ object BatteryInfoUtil {
             ?: dumpsysMap["mCycle"]?.cleanNumericValue()?.toIntOrNull()
             ?: dumpsysMap["CycleCount"]?.cleanNumericValue()?.toIntOrNull()
             ?: readSysfsLong(context, "/sys/class/power_supply/battery/cycle_count")?.toInt()
-            ?: readSysfsLong(context, "/efs/FactoryApp/batt_discharge_level")?.toInt()?.let { it / 100 }
+            ?: readSysfsLong(context, "/efs/FactoryApp/batt_discharge_level")?.toInt()?.let { if (it > 0) it / 100 else null }
             ?: readSysfsLong(context, "/sys/class/power_supply/battery/battery_cycle")?.toInt()
 
         val samsungSoH = dumpsysMap["mSavedBatteryAsoc"]?.cleanNumericValue()?.toIntOrNull()
@@ -185,15 +185,15 @@ object BatteryInfoUtil {
             ?: readSysfsLong(context, "/sys/class/power_supply/battery/fg_asoc")?.toInt()
 
         if (chargeFull == null) {
-            dumpsysMap["mSavedBatteryMax"]?.cleanNumericValue()?.toLongOrNull()?.let { chargeFull = it * 1000 }
+            dumpsysMap["mSavedBatteryMax"]?.cleanNumericValue()?.toDoubleOrNull()?.toLong()?.let { chargeFull = it * 1000 }
         }
 
-        val chargeCounter = dumpsysMap["Charge counter"]?.cleanNumericValue()?.toLongOrNull()
-            ?: dumpsysMap["mSavedBattery"]?.cleanNumericValue()?.toLongOrNull()?.let { it * 1000 }
+        val chargeCounter = dumpsysMap["Charge counter"]?.cleanNumericValue()?.toDoubleOrNull()?.toLong()
+            ?: dumpsysMap["mSavedBattery"]?.cleanNumericValue()?.toDoubleOrNull()?.toLong()?.let { it * 1000 }
             ?: readSysfsLong(context, "/sys/class/power_supply/battery/charge_counter")
 
-        val maxChargingCurrent = dumpsysMap["Max charging current"]?.cleanNumericValue()?.toIntOrNull()
-        val maxChargingVoltage = dumpsysMap["Max charging voltage"]?.cleanNumericValue()?.toIntOrNull()
+        val maxChargingCurrent = dumpsysMap["Max charging current"]?.cleanNumericValue()?.toDoubleOrNull()?.toInt()
+        val maxChargingVoltage = dumpsysMap["Max charging voltage"]?.cleanNumericValue()?.toDoubleOrNull()?.toInt()
         val chargingState = dumpsysMap["Charging state"]?.cleanNumericValue()?.toIntOrNull()
         val chargingPolicy = dumpsysMap["Charging policy"]?.cleanNumericValue()?.toIntOrNull()
         val capacityLevel = dumpsysMap["Capacity level"]?.cleanNumericValue()?.toIntOrNull()
@@ -257,11 +257,11 @@ object BatteryInfoUtil {
 
     private fun readSysfsLong(context: Context, path: String): Long? {
         val out = ShellUtils.runCommandWithOutput(context, "cat $path") ?: return null
-        return out.trim().cleanNumericValue().toLongOrNull()
+        return out.trim().cleanNumericValue().toDoubleOrNull()?.toLong()
     }
 
     private fun String.cleanNumericValue(): String {
-        return this.filter { it.isDigit() || it == '-' }
+        return this.filter { it.isDigit() || it == '-' || it == '.' }
     }
 
     private fun parseDumpsysBattery(output: String?): Map<String, String> {

--- a/app/src/main/java/com/sameerasw/essentials/utils/BluetoothPairedDevicesUtil.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/BluetoothPairedDevicesUtil.kt
@@ -1,0 +1,35 @@
+package com.sameerasw.essentials.utils
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import androidx.annotation.Keep
+
+object BluetoothPairedDevicesUtil {
+
+    @Keep
+    data class PairedDevice(
+        val name: String,
+        val address: String
+    )
+
+    @SuppressLint("MissingPermission")
+    fun getPairedDevices(context: Context): List<PairedDevice> {
+        val bluetoothManager =
+            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter = bluetoothManager?.adapter ?: return emptyList()
+
+        val devices = try {
+            adapter.bondedDevices
+        } catch (e: SecurityException) {
+            return emptyList()
+        }
+
+        return devices.map { device ->
+            PairedDevice(
+                name = device.alias ?: device.name ?: device.address,
+                address = device.address
+            )
+        }.sortedBy { it.name.lowercase() }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/DeviceUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DeviceUtils.kt
@@ -33,14 +33,14 @@ data class DeviceInfo(
 
 object DeviceUtils {
     fun isGoogleDevice(): Boolean {
-        return Build.MANUFACTURER.equalsIgnoreCase("google") ||
-                Build.BRAND.equalsIgnoreCase("google") ||
+        return Build.MANUFACTURER.equals("google", ignoreCase = true) ||
+                Build.BRAND.equals("google", ignoreCase = true) ||
                 Build.PRODUCT.contains("pixel", ignoreCase = true)
     }
 
     fun isSamsungDevice(): Boolean {
-        return Build.MANUFACTURER.equalsIgnoreCase("samsung") ||
-                Build.BRAND.equalsIgnoreCase("samsung")
+        return Build.MANUFACTURER.equals("samsung", ignoreCase = true) ||
+                Build.BRAND.equals("samsung", ignoreCase = true)
     }
 
     fun getDeviceInfo(context: Context): DeviceInfo {

--- a/app/src/main/java/com/sameerasw/essentials/utils/WifiUtil.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/WifiUtil.kt
@@ -1,0 +1,38 @@
+package com.sameerasw.essentials.utils
+
+import android.content.Context
+import android.net.wifi.WifiManager
+
+object WifiUtil {
+    private const val UNKNOWN_SSID = "<unknown ssid>"
+    private val SSID_REGEX = Regex("\"([^\"]*)\"")
+
+    @Suppress("DEPRECATION")
+    fun getCurrentSsid(context: Context): String? {
+        val wifiManager =
+            context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                ?: return null
+        val ssid = wifiManager.connectionInfo?.ssid ?: return null
+        if (ssid.isEmpty() || ssid == UNKNOWN_SSID) return null
+        return ssid.removeSurrounding("\"")
+    }
+
+    /**
+     * Shizuku/root grant shell-level privileges, which can run `cmd wifi list-networks`
+     * (normally restricted to system apps) to read the device's saved Wi-Fi networks.
+     */
+    fun canReadSavedNetworks(context: Context): Boolean {
+        return ShellUtils.isAvailable(context) && ShellUtils.hasPermission(context)
+    }
+
+    fun getSavedNetworkSsids(context: Context): List<String> {
+        val output = ShellUtils.runCommandWithOutput(context, "cmd wifi list-networks")
+            ?: return emptyList()
+        return output.lineSequence()
+            .drop(1) // header row: "Network Id      SSID      Security type"
+            .mapNotNull { line -> SSID_REGEX.find(line)?.groupValues?.get(1) }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .toList()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -877,6 +877,17 @@
     <string name="diy_trigger_charger_connected">Charger Connected</string>
     <string name="diy_trigger_charger_disconnected">Charger Disconnected</string>
     <string name="diy_trigger_schedule">Schedule</string>
+    <string name="diy_trigger_bluetooth_connected">Bluetooth Device Connected</string>
+    <string name="diy_trigger_bluetooth_disconnected">Bluetooth Device Disconnected</string>
+    <string name="diy_trigger_wifi_connected">Wi-Fi Network Connected</string>
+    <string name="diy_trigger_wifi_disconnected">Wi-Fi Network Disconnected</string>
+    <string name="diy_select_bluetooth_device_title">Select Bluetooth Device</string>
+    <string name="diy_bluetooth_permission_required">Bluetooth permission is required to list paired devices.</string>
+    <string name="diy_no_paired_bluetooth_devices">No paired Bluetooth devices found. Pair a device first in system settings.</string>
+    <string name="diy_select_wifi_network_title">Select Wi-Fi Network</string>
+    <string name="diy_wifi_ssid_label">Network name (SSID)</string>
+    <string name="diy_use_current_network">Use Current Network</string>
+    <string name="diy_saved_networks_via_shizuku">Saved networks (via Shizuku)</string>
     <string name="diy_state_time_period">Time Period</string>
     <string name="diy_time_selection_title">Select Time</string>
     <string name="diy_time_range_selection_title">Select Time Range</string>


### PR DESCRIPTION
This pull request adds support for Bluetooth and Wi-Fi connection triggers in the automation system. It introduces new trigger types for Bluetooth and Wi-Fi connect/disconnect events, implements corresponding modules to detect these events, and updates the automation editor UI to allow users to configure these triggers. The changes also ensure that automations using these triggers are only valid when properly configured.

**New Trigger Types and Modules:**

* Added `BluetoothConnected`, `BluetoothDisconnected`, `WifiConnected`, and `WifiDisconnected` triggers to the `Trigger` sealed interface, each with their own configuration and required permissions.
* Implemented `BluetoothModule` and `WifiModule` classes to detect Bluetooth and Wi-Fi connect/disconnect events and execute corresponding automations. [[1]](diffhunk://#diff-f20c1c0d72e31e14d0db563bd5e7619ed04fa7b601da1ac0d1c61db051b8e9e3R1-R85) [[2]](diffhunk://#diff-260ea79f9937573c09dc4fb7587e3c83ddcd65d6eb2aa9a41a714f6ba5294324R1-R113)

**Automation Manager Integration:**

* Updated `AutomationManager` to recognize and manage automations with the new Bluetooth and Wi-Fi triggers, including starting/stopping the new modules and updating their automations. [[1]](diffhunk://#diff-c87dd31090c188f0848b1a1f6e5029f6310a0f44d177907469cacf71832ab829R9-R13) [[2]](diffhunk://#diff-c87dd31090c188f0848b1a1f6e5029f6310a0f44d177907469cacf71832ab829R68-R69) [[3]](diffhunk://#diff-c87dd31090c188f0848b1a1f6e5029f6310a0f44d177907469cacf71832ab829R90-R99) [[4]](diffhunk://#diff-c87dd31090c188f0848b1a1f6e5029f6310a0f44d177907469cacf71832ab829R175-R194)

**UI and Configuration Improvements:**

* Enhanced the automation editor UI to support configuration of Bluetooth and Wi-Fi triggers, including device/network selection sheets and validation to ensure triggers are properly configured before saving. [[1]](diffhunk://#diff-a92131255b03d0107adaea9f58451f043fb58eaf3315ef7089091e969ce56328R73-R77) [[2]](diffhunk://#diff-a92131255b03d0107adaea9f58451f043fb58eaf3315ef7089091e969ce56328R233-R246) [[3]](diffhunk://#diff-a92131255b03d0107adaea9f58451f043fb58eaf3315ef7089091e969ce56328R519-R538) [[4]](diffhunk://#diff-a92131255b03d0107adaea9f58451f043fb58eaf3315ef7089091e969ce56328L517-R561)

**Permissions:**

* Added `android.permission.ACCESS_WIFI_STATE` to the manifest to support Wi-Fi trigger functionality.