### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of co
 <!-- 
 # Stars <3
 
-<a href="https://star-history.com/#sameerasw/essentials&Date">
+<a href="https://star-history.dera.page/#sameerasw/essentials&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sameerasw/essentials&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=sameerasw/essentials&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=sameerasw/essentials&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sameerasw/essentials&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=sameerasw/essentials&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=sameerasw/essentials&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README currently fails to render because of GitHub stargazer API restrictions, so it has been sitting disabled in a comment. This restores it and points it to a working data source so contributors and visitors can see the project's growth again.