### PR TITLE
Develop - improved keyboard typing, zoom release notes and AOD wallpaper

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ android {
         minSdk = 26
         targetSdk = 37
         versionCode = 62
-        versionName = "17.3"
+        versionName = "17.4-beta.1"
 
         val whatsNewCounter = 2
         buildConfigField("int", "WHATS_NEW_COUNTER", whatsNewCounter.toString())

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
     <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_WALLPAPER_INTERNAL" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -317,6 +317,7 @@ class SettingsRepository(
         const val KEY_AOD_FORCE_TURN_OFF_ENABLED = "aod_force_turn_off_enabled"
         const val KEY_AOD_WALLPAPER_ENABLED = "aod_wallpaper_enabled"
         const val KEY_AOD_WALLPAPER_OPACITY = "aod_wallpaper_opacity"
+        const val KEY_AOD_WALLPAPER_TIMEOUT = "aod_wallpaper_timeout"
         const val KEY_AUTO_ACCESSIBILITY_ENABLED = "auto_accessibility_enabled"
         const val KEY_USE_BLUR = "use_blur"
         const val KEY_USE_RIPPLE = "use_ripple"
@@ -2943,4 +2944,9 @@ class SettingsRepository(
     fun getAodWallpaperOpacity(): Float = getFloat(KEY_AOD_WALLPAPER_OPACITY, 0.3f)
 
     fun setAodWallpaperOpacity(value: Float) = putFloat(KEY_AOD_WALLPAPER_OPACITY, value)
+
+    // timeout in minutes; 0 = Never, default = 3
+    fun getAodWallpaperTimeout(): Int = getInt(KEY_AOD_WALLPAPER_TIMEOUT, 3)
+
+    fun setAodWallpaperTimeout(value: Int) = putInt(KEY_AOD_WALLPAPER_TIMEOUT, value)
 }

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -316,6 +316,7 @@ class SettingsRepository(
         const val KEY_NOTIFICATION_GLANCE_SELECTED_APPS = "notification_glance_selected_apps"
         const val KEY_AOD_FORCE_TURN_OFF_ENABLED = "aod_force_turn_off_enabled"
         const val KEY_AOD_WALLPAPER_ENABLED = "aod_wallpaper_enabled"
+        const val KEY_AOD_WALLPAPER_OPACITY = "aod_wallpaper_opacity"
         const val KEY_AUTO_ACCESSIBILITY_ENABLED = "auto_accessibility_enabled"
         const val KEY_USE_BLUR = "use_blur"
         const val KEY_USE_RIPPLE = "use_ripple"
@@ -2938,4 +2939,8 @@ class SettingsRepository(
     fun getLocationReachedFullScreenAlarmEnabled(): Boolean = getBoolean(KEY_LOCATION_REACHED_FULL_SCREEN_ALARM_ENABLED, true)
 
     fun setLocationReachedFullScreenAlarmEnabled(value: Boolean) = putBoolean(KEY_LOCATION_REACHED_FULL_SCREEN_ALARM_ENABLED, value)
+
+    fun getAodWallpaperOpacity(): Float = getFloat(KEY_AOD_WALLPAPER_OPACITY, 0.3f)
+
+    fun setAodWallpaperOpacity(value: Float) = putFloat(KEY_AOD_WALLPAPER_OPACITY, value)
 }

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -318,6 +318,8 @@ class SettingsRepository(
         const val KEY_AOD_WALLPAPER_ENABLED = "aod_wallpaper_enabled"
         const val KEY_AOD_WALLPAPER_OPACITY = "aod_wallpaper_opacity"
         const val KEY_AOD_WALLPAPER_TIMEOUT = "aod_wallpaper_timeout"
+        const val KEY_AOD_WALLPAPER_BLUR = "aod_wallpaper_blur"
+        const val KEY_AOD_WALLPAPER_VIGNETTE = "aod_wallpaper_vignette"
         const val KEY_AUTO_ACCESSIBILITY_ENABLED = "auto_accessibility_enabled"
         const val KEY_USE_BLUR = "use_blur"
         const val KEY_USE_RIPPLE = "use_ripple"
@@ -2949,4 +2951,14 @@ class SettingsRepository(
     fun getAodWallpaperTimeout(): Int = getInt(KEY_AOD_WALLPAPER_TIMEOUT, 3)
 
     fun setAodWallpaperTimeout(value: Int) = putInt(KEY_AOD_WALLPAPER_TIMEOUT, value)
+
+    // blur  0-25
+    fun getAodWallpaperBlur(): Float = getFloat(KEY_AOD_WALLPAPER_BLUR, 0f)
+
+    fun setAodWallpaperBlur(value: Float) = putFloat(KEY_AOD_WALLPAPER_BLUR, value)
+
+    // vignette 0-100
+    fun getAodWallpaperVignette(): Float = getFloat(KEY_AOD_WALLPAPER_VIGNETTE, 0f)
+
+    fun setAodWallpaperVignette(value: Float) = putFloat(KEY_AOD_WALLPAPER_VIGNETTE, value)
 }

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -315,6 +315,7 @@ class SettingsRepository(
         const val KEY_NOTIFICATION_GLANCE_SAME_AS_LIGHTING = "notification_glance_same_as_lighting"
         const val KEY_NOTIFICATION_GLANCE_SELECTED_APPS = "notification_glance_selected_apps"
         const val KEY_AOD_FORCE_TURN_OFF_ENABLED = "aod_force_turn_off_enabled"
+        const val KEY_AOD_WALLPAPER_ENABLED = "aod_wallpaper_enabled"
         const val KEY_AUTO_ACCESSIBILITY_ENABLED = "auto_accessibility_enabled"
         const val KEY_USE_BLUR = "use_blur"
         const val KEY_USE_RIPPLE = "use_ripple"
@@ -2472,6 +2473,12 @@ class SettingsRepository(
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    fun isAodWallpaperEnabled(): Boolean = prefs.getBoolean(KEY_AOD_WALLPAPER_ENABLED, false)
+
+    fun setAodWallpaperEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_AOD_WALLPAPER_ENABLED, enabled).apply()
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
@@ -33,6 +33,7 @@ fun initPermissionRegistry() {
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_dynamic_night_light_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_app_lock_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_essentials_on_display_title)
+    PermissionRegistry.register("ACCESSIBILITY", R.string.feat_aod_wallpaper_title)
 
     // Write secure settings permission
     PermissionRegistry.register("WRITE_SECURE_SETTINGS", R.string.feat_statusbar_icons_title)
@@ -150,4 +151,7 @@ fun initPermissionRegistry() {
     // DIY Automations feature
     PermissionRegistry.register("WRITE_SECURE_SETTINGS", R.string.tab_diy)
     PermissionRegistry.register("WRITE_SETTINGS", R.string.tab_diy)
+
+    // AOD Wallpaper feature
+    PermissionRegistry.register("STORAGE", R.string.feat_aod_wallpaper_title)
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -58,6 +58,12 @@ class AodWallpaperOverlayHandler(
         }
     }
 
+    private val timeoutRunnable = Runnable {
+        if (isOverlayAdded && isScreenOff) {
+            hideOverlay()
+        }
+    }
+
     private val prefs by lazy {
         service.getSharedPreferences(
             SettingsRepository.PREFS_NAME,
@@ -72,6 +78,7 @@ class AodWallpaperOverlayHandler(
 
     fun onScreenOn() {
         isScreenOff = false
+        handler.removeCallbacks(timeoutRunnable)
         hideOverlay()
     }
 
@@ -178,6 +185,7 @@ class AodWallpaperOverlayHandler(
 
                 handler.removeCallbacks(burnInShiftRunnable)
                 handler.postDelayed(burnInShiftRunnable, BURN_IN_INTERVAL_MS)
+                scheduleTimeout()
             } catch (e: Exception) {
                 Log.e("AodWallpaperOverlay", "Failed to add AOD wallpaper overlay", e)
             }
@@ -190,6 +198,15 @@ class AodWallpaperOverlayHandler(
             }
             handler.removeCallbacks(burnInShiftRunnable)
             handler.postDelayed(burnInShiftRunnable, BURN_IN_INTERVAL_MS)
+            scheduleTimeout()
+        }
+    }
+
+    private fun scheduleTimeout() {
+        handler.removeCallbacks(timeoutRunnable)
+        val timeoutMinutes = prefs.getInt(SettingsRepository.KEY_AOD_WALLPAPER_TIMEOUT, 3)
+        if (timeoutMinutes > 0) {
+            handler.postDelayed(timeoutRunnable, timeoutMinutes * 60_000L)
         }
     }
 
@@ -249,6 +266,7 @@ class AodWallpaperOverlayHandler(
 
     private fun hideOverlay() {
         handler.removeCallbacks(burnInShiftRunnable)
+        handler.removeCallbacks(timeoutRunnable)
         if (isOverlayAdded && overlayContainer != null) {
             val currentView = overlayContainer ?: return
             val imageView = wallpaperImageView
@@ -299,6 +317,7 @@ class AodWallpaperOverlayHandler(
 
     fun removeOverlay() {
         handler.removeCallbacks(burnInShiftRunnable)
+        handler.removeCallbacks(timeoutRunnable)
         hideOverlay()
         overlayContainer = null
         wallpaperImageView = null

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -46,6 +46,18 @@ class AodWallpaperOverlayHandler(
     private val handler = Handler(Looper.getMainLooper())
     private val handlerScope = CoroutineScope(Dispatchers.Main + Job())
 
+    private val BURN_IN_INTERVAL_MS = 5 * 60 * 1000L
+    // private val BURN_IN_INTERVAL_MS = 10 * 1500L // 10s for testing
+
+    private val burnInShiftRunnable = object : Runnable {
+        override fun run() {
+            if (isOverlayAdded && isScreenOff) {
+                applyBurnInShift(animated = false)
+                handler.postDelayed(this, BURN_IN_INTERVAL_MS)
+            }
+        }
+    }
+
     private val prefs by lazy {
         service.getSharedPreferences(
             SettingsRepository.PREFS_NAME,
@@ -69,6 +81,37 @@ class AodWallpaperOverlayHandler(
             showOverlay()
         } else {
             hideOverlay()
+        }
+    }
+
+    private fun applyBurnInShift(animated: Boolean) {
+        val imageView = wallpaperImageView ?: return
+        val maxShiftPx = (8 * service.resources.displayMetrics.density).toInt()
+        val targetX = (-maxShiftPx..maxShiftPx).random().toFloat()
+        val targetY = (-maxShiftPx..maxShiftPx).random().toFloat()
+
+        if (animated) {
+            ObjectAnimator.ofFloat(imageView, "scaleX", imageView.scaleX, 1.05f).apply {
+                duration = 1000
+                start()
+            }
+            ObjectAnimator.ofFloat(imageView, "scaleY", imageView.scaleY, 1.05f).apply {
+                duration = 1000
+                start()
+            }
+            ObjectAnimator.ofFloat(imageView, "translationX", imageView.translationX, targetX).apply {
+                duration = 1000
+                start()
+            }
+            ObjectAnimator.ofFloat(imageView, "translationY", imageView.translationY, targetY).apply {
+                duration = 1000
+                start()
+            }
+        } else {
+            imageView.scaleX = 1.05f
+            imageView.scaleY = 1.05f
+            imageView.translationX = targetX
+            imageView.translationY = targetY
         }
     }
 
@@ -124,6 +167,7 @@ class AodWallpaperOverlayHandler(
                 val container = overlayContainer ?: return
                 container.visibility = View.VISIBLE
                 container.alpha = 0f
+                applyBurnInShift(animated = false)
                 windowManager?.addView(container, params)
                 isOverlayAdded = true
 
@@ -131,6 +175,9 @@ class AodWallpaperOverlayHandler(
                     duration = 2000
                     start()
                 }
+
+                handler.removeCallbacks(burnInShiftRunnable)
+                handler.postDelayed(burnInShiftRunnable, BURN_IN_INTERVAL_MS)
             } catch (e: Exception) {
                 Log.e("AodWallpaperOverlay", "Failed to add AOD wallpaper overlay", e)
             }
@@ -141,6 +188,8 @@ class AodWallpaperOverlayHandler(
                 duration = 2000
                 start()
             }
+            handler.removeCallbacks(burnInShiftRunnable)
+            handler.postDelayed(burnInShiftRunnable, BURN_IN_INTERVAL_MS)
         }
     }
 
@@ -199,13 +248,43 @@ class AodWallpaperOverlayHandler(
     }
 
     private fun hideOverlay() {
+        handler.removeCallbacks(burnInShiftRunnable)
         if (isOverlayAdded && overlayContainer != null) {
             val currentView = overlayContainer ?: return
+            val imageView = wallpaperImageView
+
+            if (imageView != null) {
+                if (imageView.translationX != 0f || imageView.translationY != 0f) {
+                    ObjectAnimator.ofFloat(imageView, "translationX", imageView.translationX, 0f).apply {
+                        duration = 500
+                        start()
+                    }
+                    ObjectAnimator.ofFloat(imageView, "translationY", imageView.translationY, 0f).apply {
+                        duration = 500
+                        start()
+                    }
+                }
+                if (imageView.scaleX != 1.0f || imageView.scaleY != 1.0f) {
+                    ObjectAnimator.ofFloat(imageView, "scaleX", imageView.scaleX, 1.0f).apply {
+                        duration = 500
+                        start()
+                    }
+                    ObjectAnimator.ofFloat(imageView, "scaleY", imageView.scaleY, 1.0f).apply {
+                        duration = 500
+                        start()
+                    }
+                }
+            }
+
             ObjectAnimator.ofFloat(currentView, "alpha", currentView.alpha, 0f).apply {
                 duration = 500
                 addListener(object : android.animation.AnimatorListenerAdapter() {
                     override fun onAnimationEnd(animation: android.animation.Animator) {
                         currentView.visibility = View.GONE
+                        imageView?.translationX = 0f
+                        imageView?.translationY = 0f
+                        imageView?.scaleX = 1.0f
+                        imageView?.scaleY = 1.0f
                         try {
                             windowManager?.removeView(currentView)
                         } catch (_: Exception) {
@@ -219,6 +298,7 @@ class AodWallpaperOverlayHandler(
     }
 
     fun removeOverlay() {
+        handler.removeCallbacks(burnInShiftRunnable)
         hideOverlay()
         overlayContainer = null
         wallpaperImageView = null

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -16,6 +16,8 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.PixelFormat
+import android.graphics.RadialGradient
+import android.graphics.Shader
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
@@ -122,12 +124,62 @@ class AodWallpaperOverlayHandler(
         }
     }
 
+    private fun applyBlurEffect(imageView: ImageView, blurRadius: Float) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (blurRadius > 0f) {
+                val effect = android.graphics.RenderEffect.createBlurEffect(
+                    blurRadius * 4f,
+                    blurRadius * 4f,
+                    Shader.TileMode.CLAMP,
+                )
+                imageView.setRenderEffect(effect)
+            } else {
+                imageView.setRenderEffect(null)
+            }
+        }
+    }
+
+    private fun buildMaskedContainer(vignetteIntensity: Float): FrameLayout {
+        return object : FrameLayout(service) {
+            private val maskPaint = android.graphics.Paint().apply {
+                xfermode = android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.DST_IN)
+                isAntiAlias = true
+            }
+
+            override fun dispatchDraw(canvas: android.graphics.Canvas) {
+                super.dispatchDraw(canvas)
+                val intensity = prefs.getFloat(SettingsRepository.KEY_AOD_WALLPAPER_VIGNETTE, 0f)
+                if (intensity <= 0f || width == 0 || height == 0) return
+                val cx = width / 2f
+                val cy = height / 2f
+                val radius = Math.hypot(cx.toDouble(), cy.toDouble()).toFloat()
+                val edgeAlpha = ((1f - intensity / 100f).coerceIn(0f, 1f) * 255).toInt()
+                maskPaint.shader = RadialGradient(
+                    cx, cy, radius,
+                    intArrayOf(
+                        Color.BLACK,
+                        Color.BLACK,
+                        Color.argb(edgeAlpha, 0, 0, 0),
+                    ),
+                    floatArrayOf(0f, 0.45f, 1f),
+                    Shader.TileMode.CLAMP,
+                )
+                canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), maskPaint)
+            }
+        }.apply {
+            setLayerType(View.LAYER_TYPE_HARDWARE, null)
+            setBackgroundColor(Color.TRANSPARENT)
+        }
+    }
+
     private fun showOverlay() {
         val opacity = prefs.getFloat(SettingsRepository.KEY_AOD_WALLPAPER_OPACITY, 0.3f)
+        val blurRadius = prefs.getFloat(SettingsRepository.KEY_AOD_WALLPAPER_BLUR, 0f)
+
         if (overlayContainer == null) {
-            val root = FrameLayout(service).apply {
-                setBackgroundColor(Color.TRANSPARENT)
-            }
+            val root = buildMaskedContainer(
+                prefs.getFloat(SettingsRepository.KEY_AOD_WALLPAPER_VIGNETTE, 0f)
+            )
             val imageView = ImageView(service).apply {
                 layoutParams = FrameLayout.LayoutParams(
                     FrameLayout.LayoutParams.MATCH_PARENT,
@@ -136,11 +188,13 @@ class AodWallpaperOverlayHandler(
                 scaleType = ImageView.ScaleType.CENTER_CROP
                 alpha = opacity
             }
+            applyBlurEffect(imageView, blurRadius)
             root.addView(imageView)
             wallpaperImageView = imageView
             overlayContainer = root
         } else {
             wallpaperImageView?.alpha = opacity
+            applyBlurEffect(wallpaperImageView ?: return, blurRadius)
         }
 
         loadAndApplyWallpaper()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -73,6 +73,7 @@ class AodWallpaperOverlayHandler(
     }
 
     private fun showOverlay() {
+        val opacity = prefs.getFloat(SettingsRepository.KEY_AOD_WALLPAPER_OPACITY, 0.3f)
         if (overlayContainer == null) {
             val root = FrameLayout(service).apply {
                 setBackgroundColor(Color.TRANSPARENT)
@@ -83,11 +84,13 @@ class AodWallpaperOverlayHandler(
                     FrameLayout.LayoutParams.MATCH_PARENT,
                 )
                 scaleType = ImageView.ScaleType.CENTER_CROP
-                alpha = 0.3f
+                alpha = opacity
             }
             root.addView(imageView)
             wallpaperImageView = imageView
             overlayContainer = root
+        } else {
+            wallpaperImageView?.alpha = opacity
         }
 
         loadAndApplyWallpaper()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Background Services & Receivers
+ * File: AodWallpaperOverlayHandler.kt
+ * Description: Background service component managing AOD wallpaper overlay at 30% opacity.
+ */
+
+package com.sameerasw.essentials.services.handlers
+
+import android.accessibilityservice.AccessibilityService
+import android.animation.ObjectAnimator
+import android.app.WallpaperManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.ImageView
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class AodWallpaperOverlayHandler(
+    private val service: AccessibilityService,
+) {
+    private var windowManager: WindowManager? = null
+    private var overlayContainer: FrameLayout? = null
+    private var wallpaperImageView: ImageView? = null
+    private var isOverlayAdded = false
+    private var isScreenOff = false
+    private var cachedWallpaperBitmap: Bitmap? = null
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val handlerScope = CoroutineScope(Dispatchers.Main + Job())
+
+    private val prefs by lazy {
+        service.getSharedPreferences(
+            SettingsRepository.PREFS_NAME,
+            AccessibilityService.MODE_PRIVATE,
+        )
+    }
+
+    fun onScreenOff() {
+        isScreenOff = true
+        updateState()
+    }
+
+    fun onScreenOn() {
+        isScreenOff = false
+        hideOverlay()
+    }
+
+    fun updateState() {
+        val enabled = prefs.getBoolean(SettingsRepository.KEY_AOD_WALLPAPER_ENABLED, false)
+        if (enabled && isScreenOff) {
+            showOverlay()
+        } else {
+            hideOverlay()
+        }
+    }
+
+    private fun showOverlay() {
+        if (overlayContainer == null) {
+            val root = FrameLayout(service).apply {
+                setBackgroundColor(Color.TRANSPARENT)
+            }
+            val imageView = ImageView(service).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                )
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                alpha = 0.3f
+            }
+            root.addView(imageView)
+            wallpaperImageView = imageView
+            overlayContainer = root
+        }
+
+        loadAndApplyWallpaper()
+
+        if (windowManager == null) {
+            windowManager = service.getSystemService(AccessibilityService.WINDOW_SERVICE) as? WindowManager
+        }
+
+        if (!isOverlayAdded && windowManager != null && overlayContainer != null) {
+            val params =
+                WindowManager.LayoutParams(
+                    WindowManager.LayoutParams.MATCH_PARENT,
+                    WindowManager.LayoutParams.MATCH_PARENT,
+                    WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+                    WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                        WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS or
+                        WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+                    PixelFormat.TRANSLUCENT,
+                ).apply {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        layoutInDisplayCutoutMode =
+                            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                    }
+                }
+
+            try {
+                val container = overlayContainer ?: return
+                container.visibility = View.VISIBLE
+                container.alpha = 0f
+                windowManager?.addView(container, params)
+                isOverlayAdded = true
+
+                ObjectAnimator.ofFloat(container, "alpha", 0f, 1f).apply {
+                    duration = 250
+                    start()
+                }
+            } catch (e: Exception) {
+                Log.e("AodWallpaperOverlay", "Failed to add AOD wallpaper overlay", e)
+            }
+        } else if (isOverlayAdded && overlayContainer != null) {
+            overlayContainer?.visibility = View.VISIBLE
+            overlayContainer?.alpha = 1f
+        }
+    }
+
+    private fun loadAndApplyWallpaper() {
+        if (cachedWallpaperBitmap != null) {
+            wallpaperImageView?.setImageBitmap(cachedWallpaperBitmap)
+            return
+        }
+
+        handlerScope.launch(Dispatchers.IO) {
+            val bitmap = extractCurrentWallpaper()
+            if (bitmap != null) {
+                cachedWallpaperBitmap = bitmap
+                withContext(Dispatchers.Main) {
+                    wallpaperImageView?.setImageBitmap(bitmap)
+                }
+            }
+        }
+    }
+
+    private fun extractCurrentWallpaper(): Bitmap? {
+        return try {
+            val wallpaperManager = WallpaperManager.getInstance(service)
+            val drawable: Drawable? =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    wallpaperManager.getDrawable(WallpaperManager.FLAG_LOCK)
+                        ?: wallpaperManager.drawable
+                } else {
+                    wallpaperManager.drawable
+                }
+
+            drawableToBitmap(drawable)
+        } catch (e: Exception) {
+            Log.e("AodWallpaperOverlay", "Error extracting current wallpaper", e)
+            null
+        }
+    }
+
+    private fun drawableToBitmap(drawable: Drawable?): Bitmap? {
+        if (drawable == null) return null
+        if (drawable is BitmapDrawable && drawable.bitmap != null) {
+            return drawable.bitmap
+        }
+
+        val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 1080
+        val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 2400
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        return bitmap
+    }
+
+    fun invalidateWallpaperCache() {
+        cachedWallpaperBitmap = null
+    }
+
+    private fun hideOverlay() {
+        if (isOverlayAdded && overlayContainer != null) {
+            val currentView = overlayContainer ?: return
+            currentView.visibility = View.GONE
+            try {
+                windowManager?.removeView(currentView)
+            } catch (_: Exception) {
+            }
+            isOverlayAdded = false
+        }
+    }
+
+    fun removeOverlay() {
+        hideOverlay()
+        overlayContainer = null
+        wallpaperImageView = null
+        cachedWallpaperBitmap = null
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -12,6 +12,7 @@ package com.sameerasw.essentials.services.handlers
 import android.accessibilityservice.AccessibilityService
 import android.animation.ObjectAnimator
 import android.app.WallpaperManager
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -71,6 +72,80 @@ class AodWallpaperOverlayHandler(
             SettingsRepository.PREFS_NAME,
             AccessibilityService.MODE_PRIVATE,
         )
+    }
+
+    private val wallpaperChangeReceiver = object : android.content.BroadcastReceiver() {
+        override fun onReceive(context: android.content.Context?, intent: android.content.Intent?) {
+            invalidateWallpaperCache()
+        }
+    }
+
+    private val wallpaperColorsListener =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            WallpaperManager.OnColorsChangedListener { _, _ ->
+                invalidateWallpaperCache()
+            }
+        } else {
+            null
+        }
+
+    private var isReceiverRegistered = false
+
+    init {
+        registerWallpaperChangeListeners()
+    }
+
+    private fun registerWallpaperChangeListeners() {
+        if (!isReceiverRegistered) {
+            try {
+                val filter = android.content.IntentFilter(Intent.ACTION_WALLPAPER_CHANGED)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    service.registerReceiver(
+                        wallpaperChangeReceiver,
+                        filter,
+                        AccessibilityService.RECEIVER_NOT_EXPORTED,
+                    )
+                } else {
+                    service.registerReceiver(wallpaperChangeReceiver, filter)
+                }
+                isReceiverRegistered = true
+            } catch (e: Exception) {
+                Log.e("AodWallpaperOverlay", "Failed to register wallpaper broadcast receiver", e)
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            wallpaperColorsListener?.let {
+                try {
+                    val wm = WallpaperManager.getInstance(service)
+                    wm.addOnColorsChangedListener(it, handler)
+                } catch (e: Exception) {
+                    Log.e("AodWallpaperOverlay", "Failed to add wallpaper colors changed listener", e)
+                }
+            }
+        }
+    }
+
+    private fun unregisterWallpaperChangeListeners() {
+        if (isReceiverRegistered) {
+            try {
+                service.unregisterReceiver(wallpaperChangeReceiver)
+            } catch (e: Exception) {
+                // Ignore
+            }
+            isReceiverRegistered = false
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            wallpaperColorsListener?.let {
+                try {
+                    val wm = WallpaperManager.getInstance(service)
+                    wm.removeOnColorsChangedListener(it)
+                } catch (e: Exception) {
+                    // Ignore
+                }
+            }
+        }
     }
 
     fun onScreenOff() {
@@ -264,7 +339,20 @@ class AodWallpaperOverlayHandler(
         }
     }
 
+    private var lastWallpaperId = -1
+
     private fun loadAndApplyWallpaper() {
+        val wallpaperManager = WallpaperManager.getInstance(service)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val currentLockId = wallpaperManager.getWallpaperId(WallpaperManager.FLAG_LOCK)
+            val currentSystemId = wallpaperManager.getWallpaperId(WallpaperManager.FLAG_SYSTEM)
+            val effectiveId = if (currentLockId > 0) currentLockId else currentSystemId
+            if (effectiveId > 0 && effectiveId != lastWallpaperId) {
+                cachedWallpaperBitmap = null
+                lastWallpaperId = effectiveId
+            }
+        }
+
         if (cachedWallpaperBitmap != null) {
             wallpaperImageView?.setImageBitmap(cachedWallpaperBitmap)
             return
@@ -316,6 +404,7 @@ class AodWallpaperOverlayHandler(
 
     fun invalidateWallpaperCache() {
         cachedWallpaperBitmap = null
+        lastWallpaperId = -1
     }
 
     private fun hideOverlay() {
@@ -370,6 +459,7 @@ class AodWallpaperOverlayHandler(
     }
 
     fun removeOverlay() {
+        unregisterWallpaperChangeListeners()
         handler.removeCallbacks(burnInShiftRunnable)
         handler.removeCallbacks(timeoutRunnable)
         hideOverlay()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/AodWallpaperOverlayHandler.kt
@@ -128,15 +128,19 @@ class AodWallpaperOverlayHandler(
                 isOverlayAdded = true
 
                 ObjectAnimator.ofFloat(container, "alpha", 0f, 1f).apply {
-                    duration = 250
+                    duration = 2000
                     start()
                 }
             } catch (e: Exception) {
                 Log.e("AodWallpaperOverlay", "Failed to add AOD wallpaper overlay", e)
             }
         } else if (isOverlayAdded && overlayContainer != null) {
-            overlayContainer?.visibility = View.VISIBLE
-            overlayContainer?.alpha = 1f
+            val container = overlayContainer ?: return
+            container.visibility = View.VISIBLE
+            ObjectAnimator.ofFloat(container, "alpha", container.alpha, 1f).apply {
+                duration = 2000
+                start()
+            }
         }
     }
 
@@ -197,12 +201,20 @@ class AodWallpaperOverlayHandler(
     private fun hideOverlay() {
         if (isOverlayAdded && overlayContainer != null) {
             val currentView = overlayContainer ?: return
-            currentView.visibility = View.GONE
-            try {
-                windowManager?.removeView(currentView)
-            } catch (_: Exception) {
+            ObjectAnimator.ofFloat(currentView, "alpha", currentView.alpha, 0f).apply {
+                duration = 500
+                addListener(object : android.animation.AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: android.animation.Animator) {
+                        currentView.visibility = View.GONE
+                        try {
+                            windowManager?.removeView(currentView)
+                        } catch (_: Exception) {
+                        }
+                        isOverlayAdded = false
+                    }
+                })
+                start()
             }
-            isOverlayAdded = false
         }
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -226,7 +226,9 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_SMART_PIXELS_DISABLE_ON_CAST
             ) {
                 smartPixelsHandler.updateState()
-            } else if (key == SettingsRepository.KEY_AOD_WALLPAPER_ENABLED) {
+            } else if (key == SettingsRepository.KEY_AOD_WALLPAPER_ENABLED ||
+                key == SettingsRepository.KEY_AOD_WALLPAPER_OPACITY
+            ) {
                 aodWallpaperOverlayHandler.updateState()
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -33,6 +33,7 @@ import com.sameerasw.essentials.services.InputEventListenerService
 import com.sameerasw.essentials.services.NotificationListener
 import com.sameerasw.essentials.services.handlers.AmbientGlanceHandler
 import com.sameerasw.essentials.services.handlers.AodForceTurnOffHandler
+import com.sameerasw.essentials.services.handlers.AodWallpaperOverlayHandler
 import com.sameerasw.essentials.services.handlers.AppFlowHandler
 import com.sameerasw.essentials.services.handlers.ButtonRemapHandler
 import com.sameerasw.essentials.services.handlers.FlashlightHandler
@@ -63,6 +64,7 @@ class ScreenOffAccessibilityService :
     private lateinit var appFlowHandler: AppFlowHandler
     private lateinit var ambientGlanceHandler: AmbientGlanceHandler
     private lateinit var aodForceTurnOffHandler: AodForceTurnOffHandler
+    private lateinit var aodWallpaperOverlayHandler: AodWallpaperOverlayHandler
     private lateinit var omniGestureOverlayHandler: OmniGestureOverlayHandler
     private lateinit var statusBarIconHandler: StatusBarIconHandler
     private lateinit var pocketModeHandler: PocketModeHandler
@@ -224,6 +226,8 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_SMART_PIXELS_DISABLE_ON_CAST
             ) {
                 smartPixelsHandler.updateState()
+            } else if (key == SettingsRepository.KEY_AOD_WALLPAPER_ENABLED) {
+                aodWallpaperOverlayHandler.updateState()
             }
         }
 
@@ -238,6 +242,7 @@ class ScreenOffAccessibilityService :
         appFlowHandler = AppFlowHandler(this, this)
         ambientGlanceHandler = AmbientGlanceHandler(this)
         aodForceTurnOffHandler = AodForceTurnOffHandler(this)
+        aodWallpaperOverlayHandler = AodWallpaperOverlayHandler(this)
         omniGestureOverlayHandler = OmniGestureOverlayHandler(this)
         statusBarIconHandler = StatusBarIconHandler(this)
         pocketModeHandler = PocketModeHandler(this)
@@ -262,6 +267,7 @@ class ScreenOffAccessibilityService :
                             notificationLightingHandler.onScreenOn()
                             ambientGlanceHandler.dismissImmediately()
                             aodForceTurnOffHandler.removeOverlay()
+                            aodWallpaperOverlayHandler.onScreenOn()
                             freezeHandler.removeCallbacks(freezeRunnable)
                             stopInputEventListener()
                             updateOmniOverlay()
@@ -274,12 +280,14 @@ class ScreenOffAccessibilityService :
                             scheduleFreeze()
                             startInputEventListenerIfEnabled()
                             ambientGlanceHandler.checkAndShowOnScreenOff()
+                            aodWallpaperOverlayHandler.onScreenOff()
                             omniGestureOverlayHandler.updateOverlay(false) // Always hide when screen is off
                             pocketModeHandler.onScreenOff()
                             updatePocketModeSensors()
                         }
 
                         Intent.ACTION_USER_PRESENT -> {
+                            aodWallpaperOverlayHandler.onScreenOn()
                             val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
                             if (prefs.getBoolean("pocket_mode_lock_screen_only", false)) {
                                 pocketModeHandler.onScreenOff() // cancel pending timer + remove overlay
@@ -399,6 +407,7 @@ class ScreenOffAccessibilityService :
         notificationLightingHandler.removeOverlay()
         ambientGlanceHandler.removeOverlay()
         aodForceTurnOffHandler.removeOverlay()
+        aodWallpaperOverlayHandler.removeOverlay()
         pocketModeHandler.removeOverlay()
         omniGestureOverlayHandler.removeOverlay()
         smartPixelsHandler.destroy()

--- a/app/src/main/java/com/sameerasw/essentials/ui/components/text/SimpleMarkdown.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/components/text/SimpleMarkdown.kt
@@ -9,7 +9,16 @@
 
 package com.sameerasw.essentials.ui.components.text
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateCentroid
+import androidx.compose.foundation.gestures.calculateCentroidSize
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,10 +37,17 @@ import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
@@ -47,7 +63,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.SubcomposeAsyncImage
+import kotlinx.coroutines.launch
 
 @Composable
 fun SimpleMarkdown(
@@ -420,11 +438,14 @@ private fun ImageBlock(
     images: List<ImageData>,
     isCentered: Boolean,
 ) {
+    var hasActiveZoom by remember { mutableStateOf(false) }
+
     FlowRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(vertical = 8.dp),
+                .padding(vertical = 8.dp)
+                .zIndex(if (hasActiveZoom) 999f else 0f),
         horizontalArrangement = if (isCentered) Arrangement.Center else Arrangement.Start,
     ) {
         images.forEach { image ->
@@ -433,6 +454,9 @@ private fun ImageBlock(
                 alt = image.alt,
                 widthFraction = image.widthFraction,
                 isCentered = isCentered,
+                onZoomStateChange = { zooming ->
+                    hasActiveZoom = zooming
+                },
             )
         }
     }
@@ -445,6 +469,7 @@ private fun RenderImage(
     alt: String,
     widthFraction: Float?,
     isCentered: Boolean,
+    onZoomStateChange: (Boolean) -> Unit = {},
 ) {
     val modifier =
         if (widthFraction != null) {
@@ -453,13 +478,93 @@ private fun RenderImage(
             Modifier.fillMaxWidth()
         }
 
+    val coroutineScope = rememberCoroutineScope()
+    val scaleAnim = remember { Animatable(1f) }
+    val offsetAnim = remember { Animatable(Offset.Zero, Offset.VectorConverter) }
+
+    val isZooming = scaleAnim.value > 1.01f || scaleAnim.isRunning || offsetAnim.isRunning
+
+    androidx.compose.runtime.LaunchedEffect(isZooming) {
+        onZoomStateChange(isZooming)
+    }
+
     Box(
-        modifier = modifier.padding(4.dp),
+        modifier =
+            modifier
+                .padding(4.dp)
+                .zIndex(if (isZooming) 999f else 0f),
         contentAlignment = if (isCentered) Alignment.Center else Alignment.CenterStart,
     ) {
         Box(
             modifier =
                 Modifier
+                    .graphicsLayer {
+                        scaleX = scaleAnim.value
+                        scaleY = scaleAnim.value
+                        translationX = offsetAnim.value.x
+                        translationY = offsetAnim.value.y
+                        clip = false
+                    }
+                    .pointerInput(Unit) {
+                        awaitEachGesture {
+                            awaitFirstDown(requireUnconsumed = false)
+                            var isInteracting = false
+                            do {
+                                val event = awaitPointerEvent()
+                                val pressedCount = event.changes.count { it.pressed }
+
+                                if (pressedCount >= 2) {
+                                    isInteracting = true
+                                    val zoomChange = event.calculateZoom()
+                                    val panChange = event.calculatePan()
+                                    val centroid = event.calculateCentroid(useCurrent = true)
+
+                                    val oldScale = scaleAnim.value
+                                    val newScale = (oldScale * zoomChange).coerceIn(1f, 6f)
+
+                                    val centerOffset = centroid - Offset(size.width / 2f, size.height / 2f)
+                                    val newOffset = (offsetAnim.value + panChange) + centerOffset * (1f - newScale / oldScale)
+
+                                    coroutineScope.launch {
+                                        scaleAnim.snapTo(newScale)
+                                        if (newScale > 1.01f) {
+                                            offsetAnim.snapTo(newOffset)
+                                        } else {
+                                            offsetAnim.snapTo(Offset.Zero)
+                                        }
+                                    }
+                                    event.changes.forEach { it.consume() }
+                                } else if (isInteracting || scaleAnim.value > 1.05f) {
+                                    // While zoomed, single finger moves the zoomed image freely relative to finger
+                                    isInteracting = true
+                                    val panChange = event.calculatePan()
+                                    if (panChange != Offset.Zero) {
+                                        coroutineScope.launch {
+                                            offsetAnim.snapTo(offsetAnim.value + panChange)
+                                        }
+                                    }
+                                    event.changes.forEach { it.consume() }
+                                }
+                            } while (event.changes.any { it.pressed })
+
+                            if (isInteracting || scaleAnim.value > 1.01f) {
+                                coroutineScope.launch {
+                                    launch {
+                                        scaleAnim.animateTo(
+                                            targetValue = 1f,
+                                            animationSpec = spring(dampingRatio = 0.8f, stiffness = 400f),
+                                        )
+                                    }
+                                    launch {
+                                        offsetAnim.animateTo(
+                                            targetValue = Offset.Zero,
+                                            animationSpec = spring(dampingRatio = 0.8f, stiffness = 400f),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
                     .clip(RoundedCornerShape(12.dp)),
         ) {
             SubcomposeAsyncImage(

--- a/app/src/main/java/com/sameerasw/essentials/ui/core/sheets/UpdateBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/core/sheets/UpdateBottomSheet.kt
@@ -227,18 +227,13 @@ fun UpdateBottomSheet(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             RoundedCardContainer {
-                                Surface(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    color = MaterialTheme.colorScheme.surfaceContainer,
-                                ) {
-                                    SimpleMarkdown(
-                                        content = notesToDisplay,
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .padding(16.dp),
-                                    )
-                                }
+                                SimpleMarkdown(
+                                    content = notesToDisplay,
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(16.dp),
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
@@ -9,6 +9,13 @@
 
 package com.sameerasw.essentials.ui.features.system
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -203,31 +210,44 @@ fun AlwaysOnDisplaySettingsUI(
             }
         }
 
+        val isWallpaperEnabled = viewModel.isAodWallpaperEnabled.value
+        val animatedPreviewAlpha by animateFloatAsState(
+            targetValue = if (isWallpaperEnabled) opacity else 0f,
+            animationSpec = tween(durationMillis = 300),
+            label = "aodWallpaperPreviewAlpha",
+        )
+
         RoundedCardContainer {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(140.dp)
-                    .background(Color.Black),
-                contentAlignment = Alignment.Center,
+            AnimatedVisibility(
+                visible = isWallpaperEnabled,
+                enter = expandVertically(animationSpec = tween(durationMillis = 300)) + fadeIn(animationSpec = tween(durationMillis = 300)),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = 300)) + fadeOut(animationSpec = tween(durationMillis = 300)),
             ) {
-                if (wallpaperBitmap != null) {
-                    Image(
-                        bitmap = wallpaperBitmap.asImageBitmap(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(140.dp)
-                            .alpha(if (viewModel.isAodWallpaperEnabled.value) opacity else 0f),
-                    )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(140.dp)
+                        .background(Color.Black),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (wallpaperBitmap != null) {
+                        Image(
+                            bitmap = wallpaperBitmap.asImageBitmap(),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(140.dp)
+                                .alpha(animatedPreviewAlpha),
+                        )
+                    }
                 }
             }
 
             IconToggleItem(
                 iconRes = R.drawable.rounded_wallpaper_24,
                 title = stringResource(R.string.feat_aod_wallpaper_title),
-                isChecked = viewModel.isAodWallpaperEnabled.value,
+                isChecked = isWallpaperEnabled,
                 onCheckedChange = { checked ->
                     HapticUtil.performVirtualKeyHaptic(view)
                     if (checked) {
@@ -256,14 +276,18 @@ fun AlwaysOnDisplaySettingsUI(
                 modifier = Modifier.highlight(highlightSetting == "aod_wallpaper"),
             )
 
-            if (viewModel.isAodWallpaperEnabled.value) {
+            AnimatedVisibility(
+                visible = isWallpaperEnabled,
+                enter = expandVertically(animationSpec = tween(durationMillis = 300)) + fadeIn(animationSpec = tween(durationMillis = 300)),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = 300)) + fadeOut(animationSpec = tween(durationMillis = 300)),
+            ) {
                 ConfigSliderItem(
                     title = stringResource(R.string.feat_aod_wallpaper_opacity),
-                    value = opacity * 100f,
+                    value = (opacity * 100f).coerceIn(10f, 75f),
                     onValueChange = {
                         viewModel.setAodWallpaperOpacity(it / 100f)
                     },
-                    valueRange = 5f..100f,
+                    valueRange = 10f..75f,
                     increment = 5f,
                     valueFormatter = { "${it.toInt()}%" },
                     iconRes = R.drawable.rounded_visibility_24,

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
@@ -29,12 +29,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
 import com.sameerasw.essentials.R
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
+import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.utils.PermissionUIHelper
 import com.sameerasw.essentials.viewmodels.MainViewModel
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -48,6 +51,27 @@ fun AlwaysOnDisplaySettingsUI(
     val view = LocalView.current
 
     var showAppSelectionSheet by remember { mutableStateOf(false) }
+    var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
+
+    val isAccessibilityEnabled = viewModel.isAccessibilityEnabled.value
+    val isStoragePermissionGranted = viewModel.isStoragePermissionGranted.value
+
+    LaunchedEffect(Unit) {
+        viewModel.check(context)
+    }
+
+    if (requestingPermissionsFor != null) {
+        val (featureTitle, permKeys) = requestingPermissionsFor!!
+        val permissionItems = PermissionUIHelper.getPermissionItems(permKeys, context, viewModel)
+        PermissionsBottomSheet(
+            onDismissRequest = {
+                requestingPermissionsFor = null
+                viewModel.check(context)
+            },
+            featureTitle = featureTitle,
+            permissions = permissionItems,
+        )
+    }
 
     Column(
         modifier =
@@ -103,24 +127,24 @@ fun AlwaysOnDisplaySettingsUI(
                 modifier = Modifier.highlight(highlightSetting == "notification_glance_same_apps"),
             )
 
-            viewModel.isAccessibilityEnabled.value
             IconToggleItem(
                 iconRes = R.drawable.rounded_power_settings_new_24,
                 title = stringResource(R.string.feat_aod_force_turn_off_title),
                 isChecked = viewModel.isAodForceTurnOffEnabled.value,
                 onCheckedChange = { checked ->
                     HapticUtil.performVirtualKeyHaptic(view)
-                    // Check latest snapshot inside lambda
-                    val currentlyEnabled =
-                        com.sameerasw.essentials.utils.PermissionUtils.isAccessibilityServiceEnabled(
-                            context,
-                        )
-                    if (checked && !currentlyEnabled) {
-                        com.sameerasw.essentials.utils.PermissionUtils.openAccessibilitySettings(
-                            context,
-                        )
+                    if (checked && !isAccessibilityEnabled) {
+                        requestingPermissionsFor =
+                            Pair(R.string.feat_aod_force_turn_off_title, listOf("ACCESSIBILITY"))
                     } else {
                         viewModel.toggleAodForceTurnOffEnabled(checked)
+                    }
+                },
+                enabled = true,
+                onDisabledClick = {
+                    if (!isAccessibilityEnabled) {
+                        requestingPermissionsFor =
+                            Pair(R.string.feat_aod_force_turn_off_title, listOf("ACCESSIBILITY"))
                     }
                 },
                 modifier = Modifier.highlight(highlightSetting == "aod_force_turn_off"),
@@ -153,6 +177,53 @@ fun AlwaysOnDisplaySettingsUI(
                 Text(stringResource(R.string.action_select_apps))
             }
         }
+
+        Text(
+            text = stringResource(R.string.feat_aod_wallpaper_section_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        RoundedCardContainer {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_wallpaper_24,
+                title = stringResource(R.string.feat_aod_wallpaper_title),
+                isChecked = viewModel.isAodWallpaperEnabled.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    if (checked) {
+                        if (!isAccessibilityEnabled || !isStoragePermissionGranted) {
+                            val missing = mutableListOf<String>()
+                            if (!isAccessibilityEnabled) missing.add("ACCESSIBILITY")
+                            if (!isStoragePermissionGranted) missing.add("STORAGE")
+                            requestingPermissionsFor = Pair(R.string.feat_aod_wallpaper_title, missing)
+                        } else {
+                            viewModel.toggleAodWallpaperEnabled(true)
+                        }
+                    } else {
+                        viewModel.toggleAodWallpaperEnabled(false)
+                    }
+                },
+                enabled = true,
+                onDisabledClick = {
+                    if (!isAccessibilityEnabled || !isStoragePermissionGranted) {
+                        val missing = mutableListOf<String>()
+                        if (!isAccessibilityEnabled) missing.add("ACCESSIBILITY")
+                        if (!isStoragePermissionGranted) missing.add("STORAGE")
+                        requestingPermissionsFor = Pair(R.string.feat_aod_wallpaper_title, missing)
+                    }
+                },
+                modifier = Modifier.highlight(highlightSetting == "aod_wallpaper"),
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.feat_aod_wallpaper_desc),
+            modifier = Modifier.padding(horizontal = 16.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
 
         Spacer(modifier = Modifier.height(80.dp))
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
@@ -46,7 +46,9 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
 import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
+import com.sameerasw.essentials.ui.core.cards.ConfigPickerItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
@@ -292,6 +294,38 @@ fun AlwaysOnDisplaySettingsUI(
                     valueFormatter = { "${it.toInt()}%" },
                     iconRes = R.drawable.rounded_visibility_24,
                 )
+            }
+
+            AnimatedVisibility(
+                visible = isWallpaperEnabled,
+                enter = expandVertically(animationSpec = tween(durationMillis = 300)) + fadeIn(animationSpec = tween(durationMillis = 300)),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = 300)) + fadeOut(animationSpec = tween(durationMillis = 300)),
+            ) {
+                val timeoutOptions = listOf(
+                    0 to stringResource(R.string.feat_aod_wallpaper_timeout_never),
+                    1 to stringResource(R.string.feat_aod_wallpaper_timeout_1m),
+                    3 to stringResource(R.string.feat_aod_wallpaper_timeout_3m),
+                    5 to stringResource(R.string.feat_aod_wallpaper_timeout_5m),
+                    10 to stringResource(R.string.feat_aod_wallpaper_timeout_10m),
+                )
+                val currentTimeout = viewModel.aodWallpaperTimeout.intValue
+                val selectedLabel = timeoutOptions.firstOrNull { it.first == currentTimeout }?.second
+                    ?: stringResource(R.string.feat_aod_wallpaper_timeout_3m)
+                ConfigPickerItem(
+                    title = stringResource(R.string.feat_aod_wallpaper_timeout),
+                    selectedValue = selectedLabel,
+                    iconRes = R.drawable.rounded_timer_24,
+                ) {
+                    timeoutOptions.forEach { (minutes, label) ->
+                        SegmentedDropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                viewModel.setAodWallpaperTimeout(minutes)
+                            },
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -38,13 +39,28 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.sameerasw.essentials.R
 import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
 import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
@@ -213,11 +229,36 @@ fun AlwaysOnDisplaySettingsUI(
         }
 
         val isWallpaperEnabled = viewModel.isAodWallpaperEnabled.value
+        val blurRadius = viewModel.aodWallpaperBlur.floatValue
+        val vignetteIntensity = viewModel.aodWallpaperVignette.floatValue
+
         val animatedPreviewAlpha by animateFloatAsState(
             targetValue = if (isWallpaperEnabled) opacity else 0f,
             animationSpec = tween(durationMillis = 300),
             label = "aodWallpaperPreviewAlpha",
         )
+
+        @OptIn(ExperimentalTextApi::class)
+        val aodClockFont = remember {
+            FontFamily(
+                Font(
+                    R.font.google_sans_flex,
+                    weight = FontWeight.Thin,
+                    variationSettings = FontVariation.Settings(
+                        FontVariation.Setting("wght", 100f),
+                        FontVariation.Setting("ROND", 100f),
+                        FontVariation.Setting("wdth", 150f),
+                    ),
+                )
+            )
+        }
+
+        val timeText = remember {
+            val cal = java.util.Calendar.getInstance()
+            val is24Hour = android.text.format.DateFormat.is24HourFormat(context)
+            val pattern = if (is24Hour) "HH mm" else "hh mm"
+            java.text.SimpleDateFormat(pattern, java.util.Locale.getDefault()).format(cal.time)
+        }
 
         RoundedCardContainer {
             AnimatedVisibility(
@@ -228,19 +269,60 @@ fun AlwaysOnDisplaySettingsUI(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(140.dp)
+                        .height(200.dp)
                         .background(Color.Black),
                     contentAlignment = Alignment.Center,
                 ) {
-                    if (wallpaperBitmap != null) {
-                        Image(
-                            bitmap = wallpaperBitmap.asImageBitmap(),
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(140.dp)
-                                .alpha(animatedPreviewAlpha),
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                            .drawWithContent {
+                                drawContent()
+                                if (vignetteIntensity > 0f && isWallpaperEnabled) {
+                                    val edgeAlpha = (1f - vignetteIntensity / 100f).coerceIn(0f, 1f)
+                                    drawRect(
+                                        brush = Brush.radialGradient(
+                                            colorStops = arrayOf(
+                                                0.0f to Color.Black,
+                                                0.45f to Color.Black,
+                                                1.0f to Color.Black.copy(alpha = edgeAlpha),
+                                            ),
+                                            center = center,
+                                            radius = maxOf(size.width, size.height) * 0.75f,
+                                        ),
+                                        blendMode = BlendMode.DstIn,
+                                    )
+                                }
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (wallpaperBitmap != null) {
+                            Image(
+                                bitmap = wallpaperBitmap.asImageBitmap(),
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .alpha(animatedPreviewAlpha)
+                                    .then(
+                                        if (blurRadius > 0f) Modifier.blur(blurRadius.dp) else Modifier
+                                    ),
+                            )
+                        }
+
+                        Text(
+                            text = timeText,
+                            style = TextStyle(
+                                fontFamily = aodClockFont,
+                                fontWeight = FontWeight.Thin,
+                                fontSize = 52.sp,
+                                letterSpacing = 4.sp,
+                                color = MaterialTheme.colorScheme.primaryContainer.copy(
+                                    alpha = if (isWallpaperEnabled) (animatedPreviewAlpha * 1.4f).coerceIn(0f, 1f) else 0f,
+                                ),
+                            ),
+                            textAlign = TextAlign.Center,
                         )
                     }
                 }
@@ -293,6 +375,38 @@ fun AlwaysOnDisplaySettingsUI(
                     increment = 5f,
                     valueFormatter = { "${it.toInt()}%" },
                     iconRes = R.drawable.rounded_visibility_24,
+                )
+            }
+
+            AnimatedVisibility(
+                visible = isWallpaperEnabled,
+                enter = expandVertically(animationSpec = tween(durationMillis = 300)) + fadeIn(animationSpec = tween(durationMillis = 300)),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = 300)) + fadeOut(animationSpec = tween(durationMillis = 300)),
+            ) {
+                ConfigSliderItem(
+                    title = stringResource(R.string.feat_aod_wallpaper_blur),
+                    value = blurRadius,
+                    onValueChange = { viewModel.setAodWallpaperBlur(it) },
+                    valueRange = 0f..25f,
+                    increment = 1f,
+                    valueFormatter = { if (it == 0f) "Off" else "${it.toInt()}" },
+                    iconRes = R.drawable.rounded_blur_on_24,
+                )
+            }
+
+            AnimatedVisibility(
+                visible = isWallpaperEnabled,
+                enter = expandVertically(animationSpec = tween(durationMillis = 300)) + fadeIn(animationSpec = tween(durationMillis = 300)),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = 300)) + fadeOut(animationSpec = tween(durationMillis = 300)),
+            ) {
+                ConfigSliderItem(
+                    title = stringResource(R.string.feat_aod_wallpaper_vignette),
+                    value = vignetteIntensity,
+                    onValueChange = { viewModel.setAodWallpaperVignette(it) },
+                    valueRange = 0f..100f,
+                    increment = 5f,
+                    valueFormatter = { if (it == 0f) "Off" else "${it.toInt()}%" },
+                    iconRes = R.drawable.rounded_grain_24,
                 )
             }
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/AlwaysOnDisplaySettingsUI.kt
@@ -9,7 +9,10 @@
 
 package com.sameerasw.essentials.ui.features.system
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,17 +23,23 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.LaunchedEffect
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
@@ -185,7 +194,36 @@ fun AlwaysOnDisplaySettingsUI(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
+        val wallpaperBitmap = viewModel.currentWallpaperBitmap.value
+        val opacity = viewModel.aodWallpaperOpacity.floatValue
+
+        LaunchedEffect(isStoragePermissionGranted) {
+            if (isStoragePermissionGranted) {
+                viewModel.loadCurrentWallpaperBitmap(context)
+            }
+        }
+
         RoundedCardContainer {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .background(Color.Black),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (wallpaperBitmap != null) {
+                    Image(
+                        bitmap = wallpaperBitmap.asImageBitmap(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(140.dp)
+                            .alpha(if (viewModel.isAodWallpaperEnabled.value) opacity else 0f),
+                    )
+                }
+            }
+
             IconToggleItem(
                 iconRes = R.drawable.rounded_wallpaper_24,
                 title = stringResource(R.string.feat_aod_wallpaper_title),
@@ -200,6 +238,7 @@ fun AlwaysOnDisplaySettingsUI(
                             requestingPermissionsFor = Pair(R.string.feat_aod_wallpaper_title, missing)
                         } else {
                             viewModel.toggleAodWallpaperEnabled(true)
+                            viewModel.loadCurrentWallpaperBitmap(context)
                         }
                     } else {
                         viewModel.toggleAodWallpaperEnabled(false)
@@ -216,6 +255,20 @@ fun AlwaysOnDisplaySettingsUI(
                 },
                 modifier = Modifier.highlight(highlightSetting == "aod_wallpaper"),
             )
+
+            if (viewModel.isAodWallpaperEnabled.value) {
+                ConfigSliderItem(
+                    title = stringResource(R.string.feat_aod_wallpaper_opacity),
+                    value = opacity * 100f,
+                    onValueChange = {
+                        viewModel.setAodWallpaperOpacity(it / 100f)
+                    },
+                    valueRange = 5f..100f,
+                    increment = 5f,
+                    valueFormatter = { "${it.toInt()}%" },
+                    iconRes = R.drawable.rounded_visibility_24,
+                )
+            }
         }
 
         Text(

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/KeyboardInputView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/KeyboardInputView.kt
@@ -599,11 +599,11 @@ fun KeyboardInputView(
                 rows.add(RowDef(keys = r3Keys, expandEdges = true))
 
                 val r4Keys = listOf(
-                    KeyDef("sym", if (isSymbols) "ABC" else "?123", "", KeyAction.SYMBOLS, weight = 1.5f),
+                    KeyDef("sym", if (isSymbols) "ABC" else "?123", "", KeyAction.SYMBOLS, weight = 1.2f),
                     KeyDef("comma", ",", ",", KeyAction.COMMA, weight = 0.7f),
-                    KeyDef("space", " ", " ", KeyAction.SPACE, weight = 3f),
+                    KeyDef("space", " ", " ", KeyAction.SPACE, weight = 3.3f),
                     KeyDef("dot", ".", ".", KeyAction.DOT, weight = 0.7f),
-                    KeyDef("return", "enter", "\n", KeyAction.ENTER, weight = 1.5f),
+                    KeyDef("return", "enter", "\n", KeyAction.ENTER, weight = 1.2f),
                 )
                 rows.add(RowDef(keys = r4Keys, expandEdges = true))
 
@@ -2080,7 +2080,7 @@ fun KeyboardInputView(
                                             Box(
                                                 modifier =
                                                     Modifier
-                                                        .weight(3f)
+                                                        .weight(3.3f)
                                                         .fillMaxHeight()
                                                         .bounceClick(isPressedSpace)
                                                         .clip(RoundedCornerShape(animatedRadiusSpace))
@@ -2271,7 +2271,7 @@ fun KeyboardInputView(
                                                 shape = RoundedCornerShape(animatedRadiusReturn),
                                                 modifier =
                                                     Modifier
-                                                        .weight(1.5f)
+                                                        .weight(1.2f)
                                                         .fillMaxHeight(),
                                             ) {
                                                 Icon(

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/KeyboardInputView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/KeyboardInputView.kt
@@ -79,10 +79,14 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.painterResource
@@ -100,6 +104,14 @@ import androidx.compose.ui.zIndex
 import com.sameerasw.essentials.R
 import com.sameerasw.essentials.ime.Suggestion
 import com.sameerasw.essentials.ime.SuggestionType
+import com.sameerasw.essentials.ui.ime.touch.KeyAction
+import com.sameerasw.essentials.ui.ime.touch.KeyDef
+import com.sameerasw.essentials.ui.ime.touch.KeyGeometry
+import com.sameerasw.essentials.ui.ime.touch.KeyboardLayout
+import com.sameerasw.essentials.ui.ime.touch.KeyboardLayoutBuilder
+import com.sameerasw.essentials.ui.ime.touch.KeyboardTouchState
+import com.sameerasw.essentials.ui.ime.touch.PointerMode
+import com.sameerasw.essentials.ui.ime.touch.RowDef
 import com.sameerasw.essentials.utils.HapticUtil
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -212,14 +224,19 @@ class LiquidShape(
     }
 }
 
-private fun Modifier.bounceClick(interactionSource: MutableInteractionSource): Modifier =
+private fun Modifier.bounceClick(isPressed: Boolean): Modifier =
     composed {
-        val isPressed by interactionSource.collectIsPressedAsState()
         val scale by animateFloatAsState(targetValue = if (isPressed) 0.9f else 1f, label = "scale")
         this.graphicsLayer {
             scaleX = scale
             scaleY = scale
         }
+    }
+
+private fun Modifier.bounceClick(interactionSource: MutableInteractionSource): Modifier =
+    composed {
+        val isPressed by interactionSource.collectIsPressedAsState()
+        this.bounceClick(isPressed)
     }
 
 @Composable
@@ -235,9 +252,11 @@ fun KeyButton(
     contentColor: androidx.compose.ui.graphics.Color,
     onRepeat: (() -> Unit)? = null,
     canRepeat: (() -> Boolean)? = null,
+    isExternallyPressed: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val isPressed by interactionSource.collectIsPressedAsState()
+    val interactionPressed by interactionSource.collectIsPressedAsState()
+    val isPressed = interactionPressed || isExternallyPressed
     val animatedContainerColor by animateColorAsState(
         targetValue = if (isPressed) MaterialTheme.colorScheme.primaryContainer else containerColor,
         label = "ButtonContainerColor",
@@ -254,7 +273,7 @@ fun KeyButton(
     Box(
         modifier =
             modifier
-                .bounceClick(interactionSource)
+                .bounceClick(isPressed)
                 .clip(shape)
                 .background(animatedContainerColor)
                 .pointerInput(onClick, onLongClick, onPress) {
@@ -542,7 +561,63 @@ fun KeyboardInputView(
     val currentRow2 = if (isSymbols) row2Symbols else row2Letters
     val currentRow3 = if (isSymbols) row3Symbols else row3Letters
 
+    var activePressedKeyId by remember { mutableStateOf<String?>(null) }
+    var keyboardPanelSize by remember { mutableStateOf(IntSize.Zero) }
+
     val density = LocalDensity.current
+
+    val keyboardLayout =
+        remember(currentRow1, currentRow2, currentRow3, isSymbols, keyboardPanelSize) {
+            if (keyboardPanelSize.width <= 0 || keyboardPanelSize.height <= 0) {
+                KeyboardLayout(emptyList(), 0f, 0f, 0f, 0f, 0)
+            } else {
+                val rows = mutableListOf<RowDef>()
+                rows.add(
+                    RowDef(
+                        keys = numberRow.map { KeyDef("num_$it", it, it) },
+                        expandEdges = true,
+                    ),
+                )
+                rows.add(
+                    RowDef(
+                        keys = currentRow1.map { KeyDef("r1_$it", it, it) },
+                        expandEdges = true,
+                    ),
+                )
+                rows.add(
+                    RowDef(
+                        keys = currentRow2.map { KeyDef("r2_$it", it, it) },
+                        startSpacerWeight = if (!isSymbols) 0.5f else 0f,
+                        endSpacerWeight = if (!isSymbols) 0.5f else 0f,
+                        expandEdges = isSymbols,
+                    ),
+                )
+                val r3Keys = mutableListOf<KeyDef>()
+                r3Keys.add(KeyDef("shift", "shift", "", KeyAction.SHIFT, weight = 1.5f))
+                r3Keys.addAll(currentRow3.map { KeyDef("r3_$it", it, it, KeyAction.CHAR, weight = 1f) })
+                r3Keys.add(KeyDef("del", "del", "", KeyAction.DELETE, weight = 1.5f))
+                rows.add(RowDef(keys = r3Keys, expandEdges = true))
+
+                val r4Keys = listOf(
+                    KeyDef("sym", if (isSymbols) "ABC" else "?123", "", KeyAction.SYMBOLS, weight = 1.5f),
+                    KeyDef("comma", ",", ",", KeyAction.COMMA, weight = 0.7f),
+                    KeyDef("space", " ", " ", KeyAction.SPACE, weight = 3f),
+                    KeyDef("dot", ".", ".", KeyAction.DOT, weight = 0.7f),
+                    KeyDef("return", "enter", "\n", KeyAction.ENTER, weight = 1.5f),
+                )
+                rows.add(RowDef(keys = r4Keys, expandEdges = true))
+
+                with(density) {
+                    KeyboardLayoutBuilder.place(
+                        rows = rows,
+                        width = keyboardPanelSize.width.toFloat(),
+                        totalHeight = keyboardPanelSize.height.toFloat(),
+                        insetH = 2.dp.toPx(),
+                        insetV = 2.dp.toPx(),
+                    )
+                }
+            }
+        }
     val containerShape =
         remember(keyboardShape, keyRoundness) {
             when (keyboardShape) {
@@ -1080,11 +1155,97 @@ fun KeyboardInputView(
                     }
 
                     else -> {
+                        val touchCoordinator = remember { KeyboardTouchState() }
+
                         Column(
                             modifier =
                                 Modifier
                                     .fillMaxSize()
-                                    .blur(animatedBlurRadius),
+                                    .blur(animatedBlurRadius)
+                                    .onGloballyPositioned { coordinates ->
+                                        if (keyboardPanelSize != coordinates.size) {
+                                            keyboardPanelSize = coordinates.size
+                                        }
+                                    }
+                                    .pointerInput(keyboardLayout) {
+                                        if (keyboardLayout.keys.isEmpty()) return@pointerInput
+                                        awaitPointerEventScope {
+                                            while (true) {
+                                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                                val change = event.changes.firstOrNull() ?: continue
+
+                                                if (change.changedToDownIgnoreConsumed()) {
+                                                    val key = touchCoordinator.onDown(
+                                                        change.position.x,
+                                                        change.position.y,
+                                                        keyboardLayout,
+                                                    )
+                                                    activePressedKeyId = key?.id
+                                                    if (key != null && !key.visual.contains(change.position.x, change.position.y)) {
+                                                        performLightHaptic()
+                                                    }
+                                                } else if (change.pressed) {
+                                                    val key = touchCoordinator.onMove(
+                                                        change.position.x,
+                                                        change.position.y,
+                                                        keyboardLayout,
+                                                    )
+                                                    if (touchCoordinator.mode == PointerMode.PRESSED) {
+                                                        activePressedKeyId = key?.id
+                                                    }
+                                                } else if (change.changedToUpIgnoreConsumed()) {
+                                                    val downKey = touchCoordinator.pressedKey
+                                                    val downInsideVisual = downKey?.visual?.contains(touchCoordinator.downX, touchCoordinator.downY) == true
+                                                    val finalKey = touchCoordinator.onUp()
+                                                    activePressedKeyId = null
+
+                                                    if (finalKey != null && !downInsideVisual && finalKey.id == downKey?.id) {
+                                                        when (finalKey.action) {
+                                                            KeyAction.CHAR -> {
+                                                                val textToType = if (shiftState != ShiftState.OFF && !isSymbols) {
+                                                                    finalKey.label.uppercase()
+                                                                } else {
+                                                                    finalKey.label
+                                                                }
+                                                                handleType(textToType)
+                                                                if (shiftState == ShiftState.ON) {
+                                                                    shiftState = ShiftState.OFF
+                                                                }
+                                                            }
+                                                            KeyAction.DELETE -> {
+                                                                if (canDelete()) {
+                                                                    handleKeyPress(KeyEvent.KEYCODE_DEL)
+                                                                }
+                                                            }
+                                                            KeyAction.SPACE -> {
+                                                                handleType(" ")
+                                                            }
+                                                            KeyAction.ENTER -> {
+                                                                handleKeyPress(KeyEvent.KEYCODE_ENTER)
+                                                            }
+                                                            KeyAction.SHIFT -> {
+                                                                shiftState = when (shiftState) {
+                                                                    ShiftState.OFF -> ShiftState.ON
+                                                                    ShiftState.ON -> ShiftState.LOCKED
+                                                                    ShiftState.LOCKED -> ShiftState.OFF
+                                                                }
+                                                            }
+                                                            KeyAction.SYMBOLS -> {
+                                                                isSymbols = !isSymbols
+                                                            }
+                                                            KeyAction.COMMA -> {
+                                                                handleType(",")
+                                                            }
+                                                            KeyAction.DOT -> {
+                                                                handleType(".")
+                                                            }
+                                                            else -> {}
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
                             verticalArrangement = Arrangement.spacedBy(4.dp),
                         ) {
                             // Dedicated Number Row
@@ -1106,6 +1267,7 @@ fun KeyboardInputView(
                                                         onClick = { handleType(char) },
                                                         onPress = { performLightHaptic() },
                                                         interactionSource = numInteraction,
+                                                        isExternallyPressed = activePressedKeyId == "num_$char",
                                                         containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                                         contentColor = MaterialTheme.colorScheme.onSurface,
                                                         shape = RoundedCornerShape(keyRoundness),
@@ -1233,6 +1395,7 @@ fun KeyboardInputView(
                                                         },
                                                         secondaryText = secondary,
                                                         interactionSource = row1Interaction,
+                                                        isExternallyPressed = activePressedKeyId == "r1_$char",
                                                         containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                                         contentColor = MaterialTheme.colorScheme.onSurface,
                                                         shape = RoundedCornerShape(animatedRadius),
@@ -1373,6 +1536,7 @@ fun KeyboardInputView(
                                                             },
                                                             secondaryText = secondary,
                                                             interactionSource = row2Interaction,
+                                                            isExternallyPressed = activePressedKeyId == "r2_$char",
                                                             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                                             contentColor = MaterialTheme.colorScheme.onSurface,
                                                             shape =
@@ -1478,6 +1642,7 @@ fun KeyboardInputView(
                                                     }
                                                 },
                                                 interactionSource = shiftInteraction,
+                                                isExternallyPressed = activePressedKeyId == "shift",
                                                 containerColor =
                                                     if (isSymbols) {
                                                         MaterialTheme.colorScheme.surfaceContainerHighest.copy(
@@ -1617,6 +1782,7 @@ fun KeyboardInputView(
                                                         },
                                                         secondaryText = secondary,
                                                         interactionSource = row3Interaction,
+                                                        isExternallyPressed = activePressedKeyId == "r3_$char",
                                                         containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                                         contentColor = MaterialTheme.colorScheme.onSurface,
                                                         shape = RoundedCornerShape(animatedRadius),
@@ -1644,7 +1810,8 @@ fun KeyboardInputView(
                                         buttonGroupContent = {
                                             val backspaceInteraction =
                                                 remember { MutableInteractionSource() }
-                                            val isPressedDel by backspaceInteraction.collectIsPressedAsState()
+                                            val backspaceInteractionPressed by backspaceInteraction.collectIsPressedAsState()
+                                            val isPressedDel = backspaceInteractionPressed || (activePressedKeyId == "del")
                                             val animatedRadiusDel by animateDpAsState(
                                                 targetValue = if (isPressedDel) 4.dp else keyRoundness,
                                                 label = "cornerRadius",
@@ -1667,7 +1834,7 @@ fun KeyboardInputView(
                                                     Modifier
                                                         .weight(1.5f)
                                                         .fillMaxHeight()
-                                                        .bounceClick(backspaceInteraction)
+                                                        .bounceClick(isPressedDel)
                                                         .clip(RoundedCornerShape(animatedRadiusDel))
                                                         .pointerInput(Unit) {
                                                             detectHorizontalDragGestures(
@@ -1835,6 +2002,7 @@ fun KeyboardInputView(
                                                     }
                                                 },
                                                 interactionSource = symInteraction,
+                                                isExternallyPressed = activePressedKeyId == "sym",
                                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                                 shape = RoundedCornerShape(animatedRadiusSym),
@@ -1871,6 +2039,7 @@ fun KeyboardInputView(
                                                 onClick = { handleType(",") },
                                                 onPress = { performLightHaptic() },
                                                 interactionSource = commaInteraction,
+                                                isExternallyPressed = activePressedKeyId == "comma",
                                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                                 shape = RoundedCornerShape(animatedRadiusComma),
@@ -1895,7 +2064,8 @@ fun KeyboardInputView(
                                         buttonGroupContent = {
                                             val spaceInteraction =
                                                 remember { MutableInteractionSource() }
-                                            val isPressedSpace by spaceInteraction.collectIsPressedAsState()
+                                            val spaceInteractionPressed by spaceInteraction.collectIsPressedAsState()
+                                            val isPressedSpace = spaceInteractionPressed || (activePressedKeyId == "space")
                                             val animatedRadiusSpace by animateDpAsState(
                                                 targetValue = if (isPressedSpace) 4.dp else keyRoundness,
                                                 label = "cornerRadius",
@@ -1912,7 +2082,7 @@ fun KeyboardInputView(
                                                     Modifier
                                                         .weight(3f)
                                                         .fillMaxHeight()
-                                                        .bounceClick(spaceInteraction)
+                                                        .bounceClick(isPressedSpace)
                                                         .clip(RoundedCornerShape(animatedRadiusSpace))
                                                         .pointerInput(Unit) {
                                                             val viewConfig = viewConfiguration
@@ -2061,6 +2231,7 @@ fun KeyboardInputView(
                                                 onClick = { handleType(".") },
                                                 onPress = { performLightHaptic() },
                                                 interactionSource = dotInteraction,
+                                                isExternallyPressed = activePressedKeyId == "dot",
                                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                                 shape = RoundedCornerShape(animatedRadiusDot),
@@ -2094,6 +2265,7 @@ fun KeyboardInputView(
                                                 onClick = { handleKeyPress(KeyEvent.KEYCODE_ENTER) },
                                                 onPress = { performLightHaptic() },
                                                 interactionSource = returnInteraction,
+                                                isExternallyPressed = activePressedKeyId == "return",
                                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                                 shape = RoundedCornerShape(animatedRadiusReturn),

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/HysteresisSelector.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/HysteresisSelector.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Module
+ * File: HysteresisSelector.kt
+ * Description: Prevents edge-sliding jitter between keys.
+ */
+
+package com.sameerasw.essentials.ui.ime.touch
+
+import kotlin.math.hypot
+
+internal class HysteresisSelector(
+    private val fraction: Float = KeyGeometry.HYSTERESIS,
+) {
+    var current: KeySpec? = null
+        private set
+
+    fun reset() {
+        current = null
+    }
+
+    fun select(
+        touchX: Float,
+        touchY: Float,
+        decoded: KeySpec?,
+        letterWidth: Float,
+    ): KeySpec? {
+        val held = current
+        if (held == null) {
+            current = decoded
+            return current
+        }
+        if (decoded == null || decoded.id == held.id) return held
+
+        val hysteresisPx = fraction * letterWidth
+        val hx = held.geometricCenterX
+        val hy = held.geometricCenterY
+        val nx = decoded.geometricCenterX
+        val ny = decoded.geometricCenterY
+
+        val keep = hypot(touchX - hx, touchY - hy) < hypot(touchX - nx, touchY - ny) + hysteresisPx
+        if (!keep) {
+            current = decoded
+        }
+        return current
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyGeometry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyGeometry.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Module
+ * File: KeyGeometry.kt
+ * Description: Geometry constants and bounds models for intelligent touch decoding.
+ */
+
+package com.sameerasw.essentials.ui.ime.touch
+
+internal object KeyGeometry {
+    const val LETTER = 0.10f
+    const val HYSTERESIS = 0.14f
+    const val SEARCH_KEYS = 1.15f
+    const val SIGMA_X = 0.45f
+    const val SIGMA_Y = 0.52f
+    const val CLEAR_CENTER = 0.70f
+    const val SPACE_STEAL = 0.28f
+    const val LONG_PRESS_MS = 400L
+    const val DELETE_REPEAT_START_MS = 420L
+    const val DELETE_REPEAT_MS = 60L
+    const val SPACE_DRAG_DP = 12f
+    const val DELETE_SWIPE_DP = 20f
+    const val SWEEP_STEP_PX = 25f
+}
+
+internal data class Bounds(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+) {
+    val width: Float get() = right - left
+    val height: Float get() = bottom - top
+    val centerX: Float get() = (left + right) * 0.5f
+    val centerY: Float get() = (top + bottom) * 0.5f
+
+    fun contains(x: Float, y: Float): Boolean = x >= left && x < right && y >= top && y < bottom
+
+    fun inset(dx: Float, dy: Float): Bounds = Bounds(left + dx, top + dy, right - dx, bottom - dy)
+}
+
+internal enum class KeyAction {
+    CHAR,
+    SHIFT,
+    DELETE,
+    SPACE,
+    ENTER,
+    SYMBOLS,
+    COMMA,
+    DOT,
+    EMOJI,
+}
+
+internal data class KeyDef(
+    val id: String,
+    val label: String,
+    val output: String,
+    val action: KeyAction = KeyAction.CHAR,
+    val weight: Float = 1f,
+    val secondary: String? = null,
+    val iconRes: Int? = null,
+)
+
+internal data class RowDef(
+    val keys: List<KeyDef>,
+    val startSpacerWeight: Float = 0f,
+    val endSpacerWeight: Float = 0f,
+    val expandEdges: Boolean = true,
+)
+
+internal data class KeySpec(
+    val id: String,
+    val label: String,
+    val output: String,
+    val action: KeyAction,
+    val logical: Bounds,
+    val visual: Bounds,
+    val row: Int,
+    val secondary: String? = null,
+    val iconRes: Int? = null,
+) {
+    val geometricCenterX: Float get() = visual.centerX
+    val geometricCenterY: Float get() = visual.centerY
+}
+
+internal data class KeyboardLayout(
+    val keys: List<KeySpec>,
+    val width: Float,
+    val height: Float,
+    val rowHeight: Float,
+    val letterWidth: Float,
+    val rows: Int,
+) {
+    fun keyAtLogical(x: Float, y: Float): KeySpec? = keys.firstOrNull { it.logical.contains(x, y) }
+    fun keyById(id: String): KeySpec? = keys.firstOrNull { it.id == id }
+    fun rowKeys(row: Int): List<KeySpec> = keys.filter { it.row == row }
+}
+
+internal data class ScoredCandidate(
+    val key: KeySpec,
+    val spatial: Float,
+    val distance: Float,
+)
+
+internal data class DecodeResult(
+    val selected: KeySpec?,
+    val candidates: List<ScoredCandidate>,
+    val containing: KeySpec?,
+    val clearCenter: Boolean,
+)

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyboardLayoutBuilder.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyboardLayoutBuilder.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Module
+ * File: KeyboardLayoutBuilder.kt
+ * Description: Places keys with zero-gap logical tiles, edge expansion, and spacebar boundary stealing.
+ */
+
+package com.sameerasw.essentials.ui.ime.touch
+
+internal object KeyboardLayoutBuilder {
+    fun place(
+        rows: List<RowDef>,
+        width: Float,
+        totalHeight: Float,
+        insetH: Float,
+        insetV: Float,
+    ): KeyboardLayout {
+        if (rows.isEmpty() || width <= 0f || totalHeight <= 0f) {
+            return KeyboardLayout(emptyList(), width, totalHeight, 0f, 0f, rows.size)
+        }
+
+        val rowHeight = totalHeight / rows.size.toFloat()
+        val specs = ArrayList<KeySpec>(48)
+
+        rows.forEachIndexed { rowIndex, row ->
+            val y = rowIndex * rowHeight
+            val totalWeight = row.startSpacerWeight + row.endSpacerWeight + row.keys.sumOf { it.weight.toDouble() }.toFloat()
+            if (totalWeight <= 0f) return@forEachIndexed
+
+            var currentX = (row.startSpacerWeight / totalWeight) * width
+            val keyCount = row.keys.size
+
+            row.keys.forEachIndexed { keyIndex, def ->
+                val cellWidth = (def.weight / totalWeight) * width
+                val visualLeft = currentX
+                val visualRight = currentX + cellWidth
+
+                var logicalLeft = visualLeft
+                var logicalRight = visualRight
+
+                if (row.expandEdges && keyIndex == 0 && row.startSpacerWeight == 0f) {
+                    logicalLeft = 0f
+                }
+                if (row.expandEdges && keyIndex == keyCount - 1 && row.endSpacerWeight == 0f) {
+                    logicalRight = width
+                }
+
+                val logical = Bounds(logicalLeft, y, logicalRight, y + rowHeight)
+                val visual = Bounds(
+                    visualLeft + insetH,
+                    y + insetV,
+                    visualRight - insetH,
+                    y + rowHeight - insetV,
+                )
+
+                specs += KeySpec(
+                    id = def.id,
+                    label = def.label,
+                    output = def.output,
+                    action = def.action,
+                    logical = logical,
+                    visual = visual,
+                    row = rowIndex,
+                    secondary = def.secondary,
+                    iconRes = def.iconRes,
+                )
+
+                currentX += cellWidth
+            }
+        }
+
+        val letterWidth = specs.filter { it.action == KeyAction.CHAR }
+            .map { it.logical.width }
+            .average()
+            .toFloat()
+            .takeIf { it.isFinite() && it > 0f }
+            ?: (width * KeyGeometry.LETTER)
+
+        stealSpaceHits(specs, fraction = KeyGeometry.SPACE_STEAL)
+
+        return KeyboardLayout(specs, width, totalHeight, rowHeight, letterWidth, rows.size)
+    }
+
+    /**
+     * Spacebar is tapped far more frequently than comma, dot, or symbols;
+     * steal a portion of the hit area from neighboring keys in the same row.
+     */
+    private fun stealSpaceHits(specs: ArrayList<KeySpec>, fraction: Float = KeyGeometry.SPACE_STEAL) {
+        val spaceIndices = specs.indices.filter { specs[it].action == KeyAction.SPACE }
+        for (spaceIndex in spaceIndices) {
+            val space = specs[spaceIndex]
+            val row = specs.mapIndexed { index, key -> index to key }
+                .filter { it.second.row == space.row }
+                .sortedBy { it.second.logical.left }
+
+            val position = row.indexOfFirst { it.first == spaceIndex }
+            if (position < 0) continue
+
+            // Steal from left neighbor
+            if (position > 0) {
+                stealFromNeighbor(specs, spaceIndex, row[position - 1].first, fromRight = true, fraction)
+            }
+            // Steal from right neighbor
+            if (position < row.lastIndex) {
+                stealFromNeighbor(specs, spaceIndex, row[position + 1].first, fromRight = false, fraction)
+            }
+        }
+    }
+
+    private fun stealFromNeighbor(
+        specs: ArrayList<KeySpec>,
+        spaceIndex: Int,
+        neighborIndex: Int,
+        fromRight: Boolean,
+        fraction: Float,
+    ) {
+        val space = specs[spaceIndex]
+        val neighbor = specs[neighborIndex]
+        val amount = neighbor.logical.width * fraction
+        if (amount <= 0f) return
+
+        if (fromRight) {
+            specs[neighborIndex] = neighbor.copy(
+                logical = neighbor.logical.copy(right = neighbor.logical.right - amount),
+            )
+            specs[spaceIndex] = space.copy(
+                logical = space.logical.copy(left = space.logical.left - amount),
+            )
+        } else {
+            specs[neighborIndex] = neighbor.copy(
+                logical = neighbor.logical.copy(left = neighbor.logical.left + amount),
+            )
+            specs[spaceIndex] = space.copy(
+                logical = space.logical.copy(right = space.logical.right + amount),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyboardTouchState.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/KeyboardTouchState.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Module
+ * File: KeyboardTouchState.kt
+ * Description: State tracking and coordinator for keyboard panel gestures.
+ */
+
+package com.sameerasw.essentials.ui.ime.touch
+
+internal enum class PointerMode {
+    IDLE,
+    PRESSED,
+    LONG_PRESS,
+    SPACE_DRAG,
+    DELETE_SWIPE,
+    CANCELLED,
+}
+
+internal class KeyboardTouchState(
+    private val decoder: TouchDecoder = SpatialTouchDecoder(),
+    private val hysteresis: HysteresisSelector = HysteresisSelector(),
+) {
+    var mode: PointerMode = PointerMode.IDLE
+        private set
+
+    var pressedKey: KeySpec? = null
+        private set
+
+    var downX: Float = 0f
+        private set
+    var downY: Float = 0f
+        private set
+    var lastX: Float = 0f
+        private set
+    var lastY: Float = 0f
+        private set
+
+    fun onDown(x: Float, y: Float, layout: KeyboardLayout): KeySpec? {
+        downX = x
+        downY = y
+        lastX = x
+        lastY = y
+        hysteresis.reset()
+
+        val decoded = decoder.decode(x, y, layout)
+        pressedKey = hysteresis.select(x, y, decoded.selected, layout.letterWidth)
+        mode = PointerMode.PRESSED
+        return pressedKey
+    }
+
+    fun onMove(x: Float, y: Float, layout: KeyboardLayout): KeySpec? {
+        if (mode == PointerMode.IDLE || mode == PointerMode.CANCELLED) return null
+        lastX = x
+        lastY = y
+
+        if (mode == PointerMode.PRESSED) {
+            val decoded = decoder.decode(x, y, layout)
+            val next = hysteresis.select(x, y, decoded.selected, layout.letterWidth)
+            if (next?.id != pressedKey?.id) {
+                pressedKey = next
+            }
+        }
+        return pressedKey
+    }
+
+    fun setMode(newMode: PointerMode) {
+        mode = newMode
+    }
+
+    fun onUp(): KeySpec? {
+        val key = pressedKey
+        reset()
+        return key
+    }
+
+    fun reset() {
+        mode = PointerMode.IDLE
+        pressedKey = null
+        hysteresis.reset()
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/SpatialTouchDecoder.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/ime/touch/SpatialTouchDecoder.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Module
+ * File: SpatialTouchDecoder.kt
+ * Description: Gaussian distance probability touch decoding for gap-free key hits.
+ */
+
+package com.sameerasw.essentials.ui.ime.touch
+
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.hypot
+
+internal interface TouchDecoder {
+    fun decode(
+        x: Float,
+        y: Float,
+        layout: KeyboardLayout,
+    ): DecodeResult
+}
+
+internal class SpatialTouchDecoder : TouchDecoder {
+    override fun decode(
+        x: Float,
+        y: Float,
+        layout: KeyboardLayout,
+    ): DecodeResult {
+        val containing = layout.keys.filter { it.logical.contains(x, y) }
+        val inside = containing.singleOrNull()
+        val sigmaX = layout.letterWidth * KeyGeometry.SIGMA_X
+        val sigmaY = layout.rowHeight * KeyGeometry.SIGMA_Y
+
+        if (inside != null && inside.action == KeyAction.SPACE) {
+            val visualOther = layout.keys.firstOrNull { it.id != inside.id && it.visual.contains(x, y) }
+            val chosen = visualOther ?: inside
+            val cx = chosen.geometricCenterX
+            val cy = chosen.geometricCenterY
+            val spatial = gaussian(x, y, cx, cy, sigmaX, sigmaY)
+            return DecodeResult(
+                selected = chosen,
+                candidates = listOf(ScoredCandidate(chosen, spatial, hypot(x - cx, y - cy))),
+                containing = inside,
+                clearCenter = visualOther == null,
+            )
+        }
+
+        if (inside != null) {
+            val cx = inside.geometricCenterX
+            val cy = inside.geometricCenterY
+            val nx = abs(x - cx) / (inside.logical.width * 0.5f).coerceAtLeast(1f)
+            val ny = abs(y - cy) / (inside.logical.height * 0.5f).coerceAtLeast(1f)
+            if (nx < KeyGeometry.CLEAR_CENTER && ny < KeyGeometry.CLEAR_CENTER) {
+                val spatial = gaussian(x, y, cx, cy, sigmaX, sigmaY)
+                return DecodeResult(
+                    selected = inside,
+                    candidates = listOf(ScoredCandidate(inside, spatial, hypot(x - cx, y - cy))),
+                    containing = inside,
+                    clearCenter = true,
+                )
+            }
+        }
+
+        val candidates = nearby(x, y, layout, sigmaX, sigmaY)
+        if (candidates.isEmpty()) {
+            return DecodeResult(inside, emptyList(), inside, false)
+        }
+
+        return DecodeResult(
+            selected = candidates.first().key,
+            candidates = candidates.take(3),
+            containing = inside,
+            clearCenter = false,
+        )
+    }
+
+    private fun nearby(
+        x: Float,
+        y: Float,
+        layout: KeyboardLayout,
+        sigmaX: Float,
+        sigmaY: Float,
+    ): List<ScoredCandidate> {
+        val radius = layout.letterWidth * KeyGeometry.SEARCH_KEYS
+        return layout.keys.map { key ->
+            val cx = key.geometricCenterX
+            val cy = key.geometricCenterY
+            val distance = hypot(x - cx, y - cy)
+            ScoredCandidate(key, gaussian(x, y, cx, cy, sigmaX, sigmaY), distance)
+        }
+            .filter { it.distance <= radius || it.key.logical.contains(x, y) }
+            .sortedByDescending { it.spatial }
+    }
+
+    private fun gaussian(x: Float, y: Float, cx: Float, cy: Float, sigmaX: Float, sigmaY: Float): Float {
+        val dx = (x - cx) / sigmaX.coerceAtLeast(1f)
+        val dy = (y - cy) / sigmaY.coerceAtLeast(1f)
+        return exp(-0.5f * (dx * dx + dy * dy))
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
@@ -475,4 +475,53 @@ object PermissionUtils {
         } catch (e: Exception) {
         }
     }
+
+    /**
+     * Checks whether all files access / manage external storage permission is granted (for reading wallpaper).
+     */
+    fun hasManageExternalStoragePermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                android.os.Environment.isExternalStorageManager()
+            } catch (_: Exception) {
+                false
+            }
+        } else {
+            androidx.core.content.ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.READ_EXTERNAL_STORAGE,
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    /**
+     * Opens Manage External Storage settings for this app.
+     */
+    fun openManageExternalStorageSettings(context: Context) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+            } else {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+            }
+        } catch (_: Exception) {
+            try {
+                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    fun hasStoragePermission(context: Context): Boolean = hasManageExternalStoragePermission(context)
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/ui/PermissionUIHelper.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/ui/PermissionUIHelper.kt
@@ -429,6 +429,19 @@ object PermissionUIHelper {
                 )
             }
 
+            "STORAGE", "READ_MEDIA_IMAGES", "READ_EXTERNAL_STORAGE", "MANAGE_EXTERNAL_STORAGE" ->
+                PermissionItem(
+                    iconRes = R.drawable.rounded_image_24,
+                    title = R.string.perm_storage_title,
+                    description = R.string.perm_storage_desc,
+                    dependentFeatures = PermissionRegistry.getFeatures("STORAGE"),
+                    actionLabel = if (PermissionUtils.hasStoragePermission(context)) R.string.perm_action_granted else R.string.perm_action_grant,
+                    action = {
+                        PermissionUtils.openManageExternalStorageSettings(context)
+                    },
+                    isGranted = PermissionUtils.hasStoragePermission(context),
+                )
+
             else -> null
         }
 

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -144,6 +144,7 @@ class MainViewModel : ViewModel() {
     val isBackgroundLocationPermissionGranted = mutableStateOf(false)
     val isFullScreenIntentPermissionGranted = mutableStateOf(false)
     val isBluetoothPermissionGranted = mutableStateOf(false)
+    val isStoragePermissionGranted = mutableStateOf(false)
     val isUsageStatsPermissionGranted = mutableStateOf(false)
     val appLanguage = mutableStateOf("en")
 
@@ -157,6 +158,7 @@ class MainViewModel : ViewModel() {
     val isAodEnabled = mutableStateOf(false)
     val isNotificationGlanceEnabled = mutableStateOf(false)
     val isAodForceTurnOffEnabled = mutableStateOf(false)
+    val isAodWallpaperEnabled = mutableStateOf(false)
     val isPocketModeEnabled = mutableStateOf(false)
     val isPocketModeUseLightSensor = mutableStateOf(false)
     val pocketModeTriggerDelay = mutableFloatStateOf(3f) // seconds
@@ -748,6 +750,10 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_AOD_FORCE_TURN_OFF_ENABLED ->
                         isAodForceTurnOffEnabled.value =
+                            settingsRepository.getBoolean(key)
+
+                    SettingsRepository.KEY_AOD_WALLPAPER_ENABLED ->
+                        isAodWallpaperEnabled.value =
                             settingsRepository.getBoolean(key)
 
                     SettingsRepository.KEY_POCKET_MODE_ENABLED ->
@@ -1343,6 +1349,7 @@ class MainViewModel : ViewModel() {
         isUsageStatsPermissionGranted.value = PermissionUtils.hasUsageStatsPermission(context)
 
         isBluetoothPermissionGranted.value = PermissionUtils.hasBluetoothPermission(context)
+        isStoragePermissionGranted.value = PermissionUtils.hasStoragePermission(context)
 
         context.contentResolver.registerContentObserver(
             Settings.System.getUriFor(Settings.System.FONT_SCALE),
@@ -1892,6 +1899,8 @@ class MainViewModel : ViewModel() {
             settingsRepository.getBoolean(SettingsRepository.KEY_NOTIFICATION_GLANCE_ENABLED)
         isAodForceTurnOffEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_AOD_FORCE_TURN_OFF_ENABLED)
+        isAodWallpaperEnabled.value =
+            settingsRepository.getBoolean(SettingsRepository.KEY_AOD_WALLPAPER_ENABLED)
         isPocketModeEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_POCKET_MODE_ENABLED)
         isPocketModeUseLightSensor.value =
@@ -6910,6 +6919,11 @@ class MainViewModel : ViewModel() {
     fun toggleAodForceTurnOffEnabled(enabled: Boolean) {
         settingsRepository.putBoolean(SettingsRepository.KEY_AOD_FORCE_TURN_OFF_ENABLED, enabled)
         isAodForceTurnOffEnabled.value = enabled
+    }
+
+    fun toggleAodWallpaperEnabled(enabled: Boolean) {
+        settingsRepository.setAodWallpaperEnabled(enabled)
+        isAodWallpaperEnabled.value = enabled
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -161,6 +161,8 @@ class MainViewModel : ViewModel() {
     val isAodWallpaperEnabled = mutableStateOf(false)
     val aodWallpaperOpacity = mutableFloatStateOf(0.3f)
     val aodWallpaperTimeout = mutableIntStateOf(3)
+    val aodWallpaperBlur = mutableFloatStateOf(0f)
+    val aodWallpaperVignette = mutableFloatStateOf(0f)
     val currentWallpaperBitmap = mutableStateOf<Bitmap?>(null)
     val isPocketModeEnabled = mutableStateOf(false)
     val isPocketModeUseLightSensor = mutableStateOf(false)
@@ -1912,6 +1914,10 @@ class MainViewModel : ViewModel() {
             settingsRepository.getAodWallpaperOpacity()
         aodWallpaperTimeout.intValue =
             settingsRepository.getAodWallpaperTimeout()
+        aodWallpaperBlur.floatValue =
+            settingsRepository.getAodWallpaperBlur()
+        aodWallpaperVignette.floatValue =
+            settingsRepository.getAodWallpaperVignette()
         isPocketModeEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_POCKET_MODE_ENABLED)
         isPocketModeUseLightSensor.value =
@@ -6945,6 +6951,16 @@ class MainViewModel : ViewModel() {
     fun setAodWallpaperTimeout(minutes: Int) {
         settingsRepository.setAodWallpaperTimeout(minutes)
         aodWallpaperTimeout.intValue = minutes
+    }
+
+    fun setAodWallpaperBlur(radius: Float) {
+        settingsRepository.setAodWallpaperBlur(radius)
+        aodWallpaperBlur.floatValue = radius
+    }
+
+    fun setAodWallpaperVignette(intensity: Float) {
+        settingsRepository.setAodWallpaperVignette(intensity)
+        aodWallpaperVignette.floatValue = intensity
     }
 
     fun loadCurrentWallpaperBitmap(context: Context) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -160,6 +160,7 @@ class MainViewModel : ViewModel() {
     val isAodForceTurnOffEnabled = mutableStateOf(false)
     val isAodWallpaperEnabled = mutableStateOf(false)
     val aodWallpaperOpacity = mutableFloatStateOf(0.3f)
+    val aodWallpaperTimeout = mutableIntStateOf(3)
     val currentWallpaperBitmap = mutableStateOf<Bitmap?>(null)
     val isPocketModeEnabled = mutableStateOf(false)
     val isPocketModeUseLightSensor = mutableStateOf(false)
@@ -1909,6 +1910,8 @@ class MainViewModel : ViewModel() {
             settingsRepository.getBoolean(SettingsRepository.KEY_AOD_WALLPAPER_ENABLED)
         aodWallpaperOpacity.floatValue =
             settingsRepository.getAodWallpaperOpacity()
+        aodWallpaperTimeout.intValue =
+            settingsRepository.getAodWallpaperTimeout()
         isPocketModeEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_POCKET_MODE_ENABLED)
         isPocketModeUseLightSensor.value =
@@ -6937,6 +6940,11 @@ class MainViewModel : ViewModel() {
     fun setAodWallpaperOpacity(opacity: Float) {
         settingsRepository.setAodWallpaperOpacity(opacity)
         aodWallpaperOpacity.floatValue = opacity
+    }
+
+    fun setAodWallpaperTimeout(minutes: Int) {
+        settingsRepository.setAodWallpaperTimeout(minutes)
+        aodWallpaperTimeout.intValue = minutes
     }
 
     fun loadCurrentWallpaperBitmap(context: Context) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -159,6 +159,8 @@ class MainViewModel : ViewModel() {
     val isNotificationGlanceEnabled = mutableStateOf(false)
     val isAodForceTurnOffEnabled = mutableStateOf(false)
     val isAodWallpaperEnabled = mutableStateOf(false)
+    val aodWallpaperOpacity = mutableFloatStateOf(0.3f)
+    val currentWallpaperBitmap = mutableStateOf<Bitmap?>(null)
     val isPocketModeEnabled = mutableStateOf(false)
     val isPocketModeUseLightSensor = mutableStateOf(false)
     val pocketModeTriggerDelay = mutableFloatStateOf(3f) // seconds
@@ -755,6 +757,10 @@ class MainViewModel : ViewModel() {
                     SettingsRepository.KEY_AOD_WALLPAPER_ENABLED ->
                         isAodWallpaperEnabled.value =
                             settingsRepository.getBoolean(key)
+
+                    SettingsRepository.KEY_AOD_WALLPAPER_OPACITY ->
+                        aodWallpaperOpacity.floatValue =
+                            settingsRepository.getFloat(key, 0.3f)
 
                     SettingsRepository.KEY_POCKET_MODE_ENABLED ->
                         isPocketModeEnabled.value =
@@ -1901,6 +1907,8 @@ class MainViewModel : ViewModel() {
             settingsRepository.getBoolean(SettingsRepository.KEY_AOD_FORCE_TURN_OFF_ENABLED)
         isAodWallpaperEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_AOD_WALLPAPER_ENABLED)
+        aodWallpaperOpacity.floatValue =
+            settingsRepository.getAodWallpaperOpacity()
         isPocketModeEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_POCKET_MODE_ENABLED)
         isPocketModeUseLightSensor.value =
@@ -6924,6 +6932,46 @@ class MainViewModel : ViewModel() {
     fun toggleAodWallpaperEnabled(enabled: Boolean) {
         settingsRepository.setAodWallpaperEnabled(enabled)
         isAodWallpaperEnabled.value = enabled
+    }
+
+    fun setAodWallpaperOpacity(opacity: Float) {
+        settingsRepository.setAodWallpaperOpacity(opacity)
+        aodWallpaperOpacity.floatValue = opacity
+    }
+
+    fun loadCurrentWallpaperBitmap(context: Context) {
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            try {
+                if (PermissionUtils.hasManageExternalStoragePermission(context)) {
+                    val wallpaperManager = android.app.WallpaperManager.getInstance(context)
+                    val drawable =
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                            wallpaperManager.getDrawable(android.app.WallpaperManager.FLAG_LOCK)
+                                ?: wallpaperManager.drawable
+                        } else {
+                            wallpaperManager.drawable
+                        }
+                    if (drawable != null) {
+                        val bitmap =
+                            if (drawable is android.graphics.drawable.BitmapDrawable && drawable.bitmap != null) {
+                                drawable.bitmap
+                            } else {
+                                val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 1080
+                                val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 2400
+                                val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                                val canvas = android.graphics.Canvas(bmp)
+                                drawable.setBounds(0, 0, canvas.width, canvas.height)
+                                drawable.draw(canvas)
+                                bmp
+                            }
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                            currentWallpaperBitmap.value = bitmap
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2353,7 +2353,8 @@
     <!-- AOD Wallpaper -->
     <string name="feat_aod_wallpaper_section_title">Wallpaper</string>
     <string name="feat_aod_wallpaper_title">Show wallpaper on AOD</string>
-    <string name="feat_aod_wallpaper_desc">Displays current device wallpaper with 30% opacity on Always on Display.</string>
+    <string name="feat_aod_wallpaper_desc">Displays current device wallpaper overlaid with custom opacity on Always on Display.</string>
+    <string name="feat_aod_wallpaper_opacity">Opacity</string>
     <string name="perm_storage_title">All files access</string>
     <string name="perm_storage_desc">To read your current wallpaper which is not accessible with regular privileges, Essentials needs external storage permissions.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2349,4 +2349,11 @@
     <string name="watch_wireless_debugging_unavailable">Unavailable</string>
     <string name="watch_wireless_debugging_copied">Copied to clipboard</string>
     <string name="watch_wireless_debugging_refresh">Refresh Info</string>
+
+    <!-- AOD Wallpaper -->
+    <string name="feat_aod_wallpaper_section_title">Wallpaper</string>
+    <string name="feat_aod_wallpaper_title">Show wallpaper on AOD</string>
+    <string name="feat_aod_wallpaper_desc">Displays current device wallpaper with 30% opacity on Always on Display.</string>
+    <string name="perm_storage_title">All files access</string>
+    <string name="perm_storage_desc">To read your current wallpaper which is not accessible with regular privileges, Essentials needs external storage permissions.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2361,6 +2361,8 @@
     <string name="feat_aod_wallpaper_timeout_3m">3 min</string>
     <string name="feat_aod_wallpaper_timeout_5m">5 min</string>
     <string name="feat_aod_wallpaper_timeout_10m">10 min</string>
+    <string name="feat_aod_wallpaper_blur">Blur</string>
+    <string name="feat_aod_wallpaper_vignette">Vignette</string>
     <string name="perm_storage_title">All files access</string>
     <string name="perm_storage_desc">To read your current wallpaper which is not accessible with regular privileges, Essentials needs external storage permissions.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2355,6 +2355,12 @@
     <string name="feat_aod_wallpaper_title">Show wallpaper on AOD</string>
     <string name="feat_aod_wallpaper_desc">Displays current device wallpaper overlaid with custom opacity on Always on Display.</string>
     <string name="feat_aod_wallpaper_opacity">Opacity</string>
+    <string name="feat_aod_wallpaper_timeout">Wallpaper timeout</string>
+    <string name="feat_aod_wallpaper_timeout_never">Never</string>
+    <string name="feat_aod_wallpaper_timeout_1m">1 min</string>
+    <string name="feat_aod_wallpaper_timeout_3m">3 min</string>
+    <string name="feat_aod_wallpaper_timeout_5m">5 min</string>
+    <string name="feat_aod_wallpaper_timeout_10m">10 min</string>
     <string name="perm_storage_title">All files access</string>
     <string name="perm_storage_desc">To read your current wallpaper which is not accessible with regular privileges, Essentials needs external storage permissions.</string>
 </resources>


### PR DESCRIPTION
This pull request introduces the new AOD (Always-On Display) Wallpaper feature and enhances the SimpleMarkdown image component with pinch-to-zoom and pan gestures. It also updates permissions and internal settings to support these features, and bumps the app version to 17.4-beta.1.

**AOD Wallpaper Feature**

* Added new settings keys and getter/setter methods for AOD wallpaper enablement, opacity, timeout, blur, and vignette in `SettingsRepository.kt` [[1]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R318-R322) [[2]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R2482-R2487) [[3]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R2945-R2963).
* Integrated the `AodWallpaperOverlayHandler` into `ScreenOffAccessibilityService` for overlay management and state updates when relevant settings change or on screen events [[1]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R36) [[2]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R67) [[3]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R229-R232) [[4]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R247) [[5]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R272) [[6]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R285-R292) [[7]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R412).
* Registered required permissions for the feature in `AndroidManifest.xml` and `PermissionRegistry.kt` [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR31-R32) [[2]](diffhunk://#diff-b1f1d547c9026cdc9d71b988988d5b536d7b0aad6cabde798889fb8abc00d6c6R36) [[3]](diffhunk://#diff-b1f1d547c9026cdc9d71b988988d5b536d7b0aad6cabde798889fb8abc00d6c6R154-R156).

**SimpleMarkdown Image Improvements**

* Added pinch-to-zoom and pan gesture support for images, including smooth animated transitions back to the original state, using Compose's gesture and animation APIs in `SimpleMarkdown.kt` [[1]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR12-R21) [[2]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR40-R50) [[3]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR66-R68) [[4]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR441-R448) [[5]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR457-R459) [[6]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR472) [[7]](diffhunk://#diff-83f2dd587e063f9e54f072e6486bacc7d82dc757ae5d91adeaedd2e0e25d76ccR481-R567).

**Other Changes**

* Updated app version to 17.4-beta.1 in `build.gradle.kts`.
* Minor UI cleanup in `UpdateBottomSheet.kt` by removing an unnecessary `Surface` wrapper [[1]](diffhunk://#diff-d5925d94f7c9db0257edb5d5732bc72b7c2af4762d6086ed9b02637d40fb6dabL230-L233) [[2]](diffhunk://#diff-d5925d94f7c9db0257edb5d5732bc72b7c2af4762d6086ed9b02637d40fb6dabL244).