### PR TITLE
Develop - swap config icons, auto dismiss permissions sheet on granting

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/SettingsActivity.kt
@@ -1212,7 +1212,7 @@ fun SettingsContent(
                                 SimpleDateFormat(
                                     "yyyyMMdd_HHmmss",
                                     Locale.getDefault(),
-                                ).format(Date())
+                                    ).format(Date())
                             exportLauncher.launch("essentials_config_$timeStamp.json")
                         },
                         modifier =
@@ -1222,7 +1222,7 @@ fun SettingsContent(
                         shape = ButtonGroupDefaults.connectedLeadingButtonShapes().shape,
                     ) {
                         Icon(
-                            painter = painterResource(R.drawable.rounded_vertical_align_bottom_24),
+                            painter = painterResource(R.drawable.rounded_vertical_align_top_24),
                             contentDescription = null,
                             modifier = Modifier.size(20.dp),
                         )
@@ -1241,7 +1241,7 @@ fun SettingsContent(
                         shape = ButtonGroupDefaults.connectedTrailingButtonShapes().shape,
                     ) {
                         Icon(
-                            painter = painterResource(R.drawable.rounded_vertical_align_top_24),
+                            painter = painterResource(R.drawable.rounded_vertical_align_bottom_24),
                             contentDescription = null,
                             modifier = Modifier.size(20.dp),
                         )

--- a/app/src/main/java/com/sameerasw/essentials/ui/core/sheets/PermissionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/core/sheets/PermissionsBottomSheet.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -76,6 +77,12 @@ fun PermissionsBottomSheet(
 
     val pendingPermissions = permissions.filter { !it.isGranted }
     val grantedPermissions = permissions.filter { it.isGranted }
+
+    LaunchedEffect(pendingPermissions.isEmpty()) {
+        if (pendingPermissions.isEmpty() && permissions.isNotEmpty()) {
+            onDismissRequest()
+        }
+    }
 
     EssentialsBottomSheet(
         onDismissRequest = onDismissRequest,


### PR DESCRIPTION
This pull request introduces a small UI fix and a functional improvement to the permissions sheet. The most notable change is the automatic dismissal of the permissions bottom sheet when all permissions are granted, improving user experience. There are also minor corrections to icon usage in the settings screen.

**Permissions sheet behavior:**

* The `PermissionsBottomSheet` now automatically dismisses itself by calling `onDismissRequest()` when all permissions have been granted, using a `LaunchedEffect` to observe the state.

**Settings screen icon corrections:**

* Swapped the icons in the settings screen so that the correct icon is displayed for each button: the leading button now uses `rounded_vertical_align_top_24` and the trailing button uses `rounded_vertical_align_bottom_24`, correcting a previous mismatch. [[1]](diffhunk://#diff-9f1204a34b9a77ac6a4a7815b11a33abc2d3930b81dbba4d2b5d9826ab152fd9L1225-R1225) [[2]](diffhunk://#diff-9f1204a34b9a77ac6a4a7815b11a33abc2d3930b81dbba4d2b5d9826ab152fd9L1244-R1244)

**Imports:**

* Added the missing import for `LaunchedEffect` in `PermissionsBottomSheet.kt` to support the new functionality.