### PR TITLE
fix(bubbles): fix native conversation bubble previews, add permission controls, and improve toolbar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,13 +9,11 @@ plugins {
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
         optIn.addAll(
             "androidx.compose.material3.ExperimentalMaterial3Api",
             "androidx.compose.material3.ExperimentalMaterial3ExpressiveApi",
             "androidx.compose.foundation.ExperimentalFoundationApi",
             "androidx.compose.ui.text.ExperimentalTextApi",
-            "androidx.compose.foundation.ExperimentalFoundationApi",
             "androidx.compose.foundation.layout.ExperimentalLayoutApi",
         )
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -331,7 +331,12 @@
             android:documentLaunchMode="always"
             android:exported="true"
             android:resizeableActivity="true"
-            android:theme="@style/Theme.Essentials" />
+            android:theme="@style/Theme.Essentials">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".ui.activities.AutomationEditorActivity"

--- a/app/src/main/java/com/sameerasw/essentials/domain/model/AppPermission.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/model/AppPermission.kt
@@ -127,6 +127,11 @@ enum class AppPermission(
         titleRes = R.string.perm_storage_title,
         iconRes = R.drawable.rounded_image_24,
         aliases = listOf("READ_MEDIA_IMAGES", "READ_EXTERNAL_STORAGE", "MANAGE_EXTERNAL_STORAGE"),
+    ),
+    NOTIFICATION_BUBBLES(
+        key = "NOTIFICATION_BUBBLES",
+        titleRes = R.string.perm_bubbles_title,
+        iconRes = R.drawable.rounded_bubble_24,
     );
 
     companion object {

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
@@ -176,4 +176,7 @@ fun initPermissionRegistry() {
 
     // AOD Wallpaper feature
     PermissionRegistry.register("STORAGE", R.string.feat_aod_wallpaper_title)
+
+    // Floating Bubbles preview
+    PermissionRegistry.register("NOTIFICATION_BUBBLES", R.string.preview_web_title)
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
@@ -38,11 +38,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -62,15 +61,10 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import android.view.View
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
@@ -79,6 +73,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -88,6 +83,7 @@ import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.viewmodels.MainViewModel
+import kotlin.math.roundToInt
 
 class BubbleWebActivity : ComponentActivity() {
 
@@ -192,16 +188,6 @@ private fun BubbleWebScreen(
     val toolbarMaxOffsetPx = with(density) { 160.dp.toPx() }
     var toolbarOffsetPx by remember { mutableFloatStateOf(0f) }
 
-    val nestedScrollConnection = remember {
-        object : NestedScrollConnection {
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                val delta = available.y
-                toolbarOffsetPx = (toolbarOffsetPx - delta).coerceIn(0f, toolbarMaxOffsetPx)
-                return Offset.Zero
-            }
-        }
-    }
-
     BackHandler(enabled = true) {
         if (webViewRef?.canGoBack() == true) {
             webViewRef?.goBack()
@@ -217,9 +203,7 @@ private fun BubbleWebScreen(
         color = MaterialTheme.colorScheme.surface,
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .nestedScroll(nestedScrollConnection),
+            modifier = Modifier.fillMaxSize(),
         ) {
             Box(
                 modifier = Modifier
@@ -241,7 +225,6 @@ private fun BubbleWebScreen(
                                 ViewGroup.LayoutParams.MATCH_PARENT,
                                 ViewGroup.LayoutParams.MATCH_PARENT,
                             )
-                            setLayerType(View.LAYER_TYPE_HARDWARE, null)
 
                             settings.apply {
                                 javaScriptEnabled = true
@@ -257,6 +240,11 @@ private fun BubbleWebScreen(
 
                             if (isPrivate) {
                                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, false)
+                            }
+
+                            setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
+                                val delta = (scrollY - oldScrollY).toFloat()
+                                toolbarOffsetPx = (toolbarOffsetPx + delta).coerceIn(0f, toolbarMaxOffsetPx)
                             }
 
                             webChromeClient = object : WebChromeClient() {
@@ -310,6 +298,7 @@ private fun BubbleWebScreen(
                 )
             }
 
+            val toolbarVisibilityRatio = 1f - (toolbarOffsetPx / toolbarMaxOffsetPx).coerceIn(0f, 1f)
             val currentDomain = remember(currentUrl) { extractDomain(currentUrl) }
             val copyFeedbackText = stringResource(R.string.bubble_web_link_copied)
 
@@ -319,10 +308,8 @@ private fun BubbleWebScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .padding(bottom = navBarBottom + 12.dp)
-                    .graphicsLayer {
-                        translationY = toolbarOffsetPx
-                        alpha = (1f - (toolbarOffsetPx / toolbarMaxOffsetPx)).coerceIn(0f, 1f)
-                    },
+                    .offset { IntOffset(0, toolbarOffsetPx.roundToInt()) }
+                    .alpha(toolbarVisibilityRatio),
                 contentAlignment = Alignment.Center,
             ) {
                 HorizontalFloatingToolbar(
@@ -441,30 +428,6 @@ private fun BubbleWebScreen(
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.rounded_share_24),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-
-                    IconButton(
-                        onClick = {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            try {
-                                val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl)).apply {
-                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                }
-                                context.startActivity(browserIntent)
-                                onClose()
-                            } catch (_: Exception) {}
-                        },
-                        modifier = Modifier.size(40.dp),
-                        colors = IconButtonDefaults.iconButtonColors(
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                        ),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.rounded_open_in_browser_24),
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.size(20.dp),

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
@@ -38,7 +38,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.offset
+
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -95,16 +95,24 @@ class BubbleWebActivity : ComponentActivity() {
         const val EXTRA_URL = "extra_bubble_url"
         const val EXTRA_PRIVATE_MODE = "extra_bubble_private_mode"
         const val EXTRA_FULLSCREEN = "extra_bubble_fullscreen"
+
+        fun sanitizeUrl(raw: String): String {
+            val trimmed = raw.trim()
+            return if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) trimmed
+            else "https://google.com"
+        }
     }
 
     private var webViewInstance: WebView? = null
+    private var isPrivateSession = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        val initialUrl = intent.getStringExtra(EXTRA_URL) ?: intent.dataString ?: "https://google.com"
-        val isPrivateMode = intent.getBooleanExtra(EXTRA_PRIVATE_MODE, true)
+        val rawUrl = intent.getStringExtra(EXTRA_URL) ?: intent.dataString ?: "https://google.com"
+        val initialUrl = sanitizeUrl(rawUrl)
+        isPrivateSession = intent.getBooleanExtra(EXTRA_PRIVATE_MODE, true)
 
         setContent {
             val viewModel: MainViewModel = viewModel()
@@ -113,7 +121,7 @@ class BubbleWebActivity : ComponentActivity() {
             EssentialsTheme(pitchBlackTheme = isPitchBlackThemeEnabled) {
                 BubbleWebScreen(
                     initialUrl = initialUrl,
-                    isPrivate = isPrivateMode,
+                    isPrivate = isPrivateSession,
                     onCollapse = { moveTaskToBack(true) },
                     onClose = { finish() },
                     onAttachWebView = { webViewInstance = it },
@@ -136,11 +144,13 @@ class BubbleWebActivity : ComponentActivity() {
 
     override fun onDestroy() {
         try {
-            webViewInstance?.clearCache(true)
+            webViewInstance?.clearCache(isPrivateSession)
             webViewInstance?.clearHistory()
-            webViewInstance?.clearFormData()
-            WebStorage.getInstance().deleteAllData()
-            CookieManager.getInstance().removeAllCookies(null)
+            if (isPrivateSession) {
+                webViewInstance?.clearFormData()
+                WebStorage.getInstance().deleteAllData()
+                CookieManager.getInstance().removeAllCookies(null)
+            }
             webViewInstance?.destroy()
             webViewInstance = null
         } catch (_: Exception) {}
@@ -235,8 +245,8 @@ private fun BubbleWebScreen(
 
                             settings.apply {
                                 javaScriptEnabled = true
-                                domStorageEnabled = true
-                                cacheMode = WebSettings.LOAD_DEFAULT
+                                domStorageEnabled = !isPrivate
+                                cacheMode = if (isPrivate) WebSettings.LOAD_NO_CACHE else WebSettings.LOAD_DEFAULT
                                 setSupportZoom(true)
                                 builtInZoomControls = true
                                 displayZoomControls = false
@@ -247,11 +257,6 @@ private fun BubbleWebScreen(
 
                             if (isPrivate) {
                                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, false)
-                            }
-
-                            setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
-                                val delta = (scrollY - oldScrollY).toFloat()
-                                toolbarOffsetPx = (toolbarOffsetPx + delta).coerceIn(0f, toolbarMaxOffsetPx)
                             }
 
                             webChromeClient = object : WebChromeClient() {
@@ -366,9 +371,7 @@ private fun BubbleWebScreen(
                             .combinedClickable(
                                 onClick = {
                                     HapticUtil.performVirtualKeyHaptic(view)
-                                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                    clipboard.setPrimaryClip(ClipData.newPlainText("URL", currentUrl))
-                                    Toast.makeText(context, copyFeedbackText, Toast.LENGTH_SHORT).show()
+                                    copyUrlToClipboard(context, currentUrl, copyFeedbackText)
                                 },
                                 onLongClick = {
                                     HapticUtil.performHeavyHaptic(view)
@@ -406,9 +409,7 @@ private fun BubbleWebScreen(
                     IconButton(
                         onClick = {
                             HapticUtil.performVirtualKeyHaptic(view)
-                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                            clipboard.setPrimaryClip(ClipData.newPlainText("URL", currentUrl))
-                            Toast.makeText(context, copyFeedbackText, Toast.LENGTH_SHORT).show()
+                            copyUrlToClipboard(context, currentUrl, copyFeedbackText)
                         },
                         modifier = Modifier.size(40.dp),
                         colors = IconButtonDefaults.iconButtonColors(
@@ -483,4 +484,10 @@ private fun extractDomain(url: String): String {
     } catch (_: Exception) {
         url
     }
+}
+
+private fun copyUrlToClipboard(context: Context, url: String, feedbackText: String) {
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    cm.setPrimaryClip(ClipData.newPlainText("URL", url))
+    Toast.makeText(context, feedbackText, Toast.LENGTH_SHORT).show()
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
@@ -62,11 +62,12 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import android.view.View
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -78,7 +79,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -88,7 +88,6 @@ import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.ui.theme.EssentialsTheme
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.viewmodels.MainViewModel
-import kotlin.math.roundToInt
 
 class BubbleWebActivity : ComponentActivity() {
 
@@ -121,6 +120,18 @@ class BubbleWebActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        webViewInstance?.onPause()
+        webViewInstance?.pauseTimers()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        webViewInstance?.onResume()
+        webViewInstance?.resumeTimers()
     }
 
     override fun onDestroy() {
@@ -220,16 +231,18 @@ private fun BubbleWebScreen(
                                 ViewGroup.LayoutParams.MATCH_PARENT,
                                 ViewGroup.LayoutParams.MATCH_PARENT,
                             )
+                            setLayerType(View.LAYER_TYPE_HARDWARE, null)
 
                             settings.apply {
                                 javaScriptEnabled = true
-                                domStorageEnabled = !isPrivate
-                                cacheMode = if (isPrivate) WebSettings.LOAD_NO_CACHE else WebSettings.LOAD_DEFAULT
+                                domStorageEnabled = true
+                                cacheMode = WebSettings.LOAD_DEFAULT
                                 setSupportZoom(true)
                                 builtInZoomControls = true
                                 displayZoomControls = false
                                 loadWithOverviewMode = true
                                 useWideViewPort = true
+                                mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                             }
 
                             if (isPrivate) {
@@ -251,7 +264,21 @@ private fun BubbleWebScreen(
 
                             webViewClient = object : WebViewClient() {
                                 override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                                    val url = request?.url?.toString() ?: return false
+                                    val uri = request?.url ?: return false
+                                    val scheme = uri.scheme?.lowercase() ?: return false
+
+                                    if (scheme != "http" && scheme != "https") {
+                                        try {
+                                            val intent = Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME).apply {
+                                                addCategory(Intent.CATEGORY_BROWSABLE)
+                                                component = null
+                                            }
+                                            context.startActivity(intent)
+                                        } catch (_: Exception) {}
+                                        return true
+                                    }
+
+                                    val url = uri.toString()
                                     currentUrl = url
                                     canGoBack = view?.canGoBack() == true
                                     return false
@@ -278,7 +305,6 @@ private fun BubbleWebScreen(
                 )
             }
 
-            val toolbarVisibilityRatio = 1f - (toolbarOffsetPx / toolbarMaxOffsetPx).coerceIn(0f, 1f)
             val currentDomain = remember(currentUrl) { extractDomain(currentUrl) }
             val copyFeedbackText = stringResource(R.string.bubble_web_link_copied)
 
@@ -288,8 +314,10 @@ private fun BubbleWebScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .padding(bottom = navBarBottom + 12.dp)
-                    .offset { IntOffset(0, toolbarOffsetPx.roundToInt()) }
-                    .alpha(toolbarVisibilityRatio),
+                    .graphicsLayer {
+                        translationY = toolbarOffsetPx
+                        alpha = (1f - (toolbarOffsetPx / toolbarMaxOffsetPx)).coerceIn(0f, 1f)
+                    },
                 contentAlignment = Alignment.Center,
             ) {
                 HorizontalFloatingToolbar(

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/BubbleWebActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -114,6 +115,7 @@ class BubbleWebActivity : ComponentActivity() {
                 BubbleWebScreen(
                     initialUrl = initialUrl,
                     isPrivate = isPrivateMode,
+                    onCollapse = { moveTaskToBack(true) },
                     onClose = { finish() },
                     onAttachWebView = { webViewInstance = it },
                 )
@@ -140,6 +142,7 @@ class BubbleWebActivity : ComponentActivity() {
 private fun BubbleWebScreen(
     initialUrl: String,
     isPrivate: Boolean,
+    onCollapse: () -> Unit,
     onClose: () -> Unit,
     onAttachWebView: (WebView) -> Unit,
 ) {
@@ -182,7 +185,7 @@ private fun BubbleWebScreen(
         if (webViewRef?.canGoBack() == true) {
             webViewRef?.goBack()
         } else {
-            onClose()
+            onCollapse()
         }
     }
 
@@ -284,7 +287,7 @@ private fun BubbleWebScreen(
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .padding(bottom = navBarBottom + 16.dp)
+                    .padding(bottom = navBarBottom + 12.dp)
                     .offset { IntOffset(0, toolbarOffsetPx.roundToInt()) }
                     .alpha(toolbarVisibilityRatio),
                 contentAlignment = Alignment.Center,
@@ -295,37 +298,43 @@ private fun BubbleWebScreen(
                         toolbarContainerColor = MaterialTheme.colorScheme.primary,
                         toolbarContentColor = MaterialTheme.colorScheme.onPrimary,
                     ),
-                    modifier = Modifier.height(72.dp),
+                    modifier = Modifier.height(54.dp),
                 ) {
-                    IconButton(
-                        onClick = {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            if (webViewRef?.canGoBack() == true) {
-                                webViewRef?.goBack()
-                            } else {
-                                onClose()
-                            }
-                        },
-                        modifier = Modifier.size(52.dp),
-                        colors = IconButtonDefaults.iconButtonColors(
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                        ),
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(RoundedCornerShape(20.dp))
+                            .combinedClickable(
+                                onClick = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    if (webViewRef?.canGoBack() == true) {
+                                        webViewRef?.goBack()
+                                    } else {
+                                        onCollapse()
+                                    }
+                                },
+                                onLongClick = {
+                                    HapticUtil.performHeavyHaptic(view)
+                                    onClose()
+                                },
+                            ),
+                        contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             painter = painterResource(
-                                if (canGoBack) R.drawable.rounded_arrow_back_24 else R.drawable.rounded_close_24
+                                if (canGoBack) R.drawable.rounded_arrow_back_24 else R.drawable.rounded_keyboard_arrow_down_24
                             ),
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(26.dp),
+                            modifier = Modifier.size(20.dp),
                         )
                     }
 
                     Box(
                         modifier = Modifier
-                            .width(180.dp)
-                            .height(48.dp)
-                            .clip(RoundedCornerShape(24.dp))
+                            .widthIn(min = 80.dp, max = 130.dp)
+                            .height(36.dp)
+                            .clip(RoundedCornerShape(18.dp))
                             .combinedClickable(
                                 onClick = {
                                     HapticUtil.performVirtualKeyHaptic(view)
@@ -348,14 +357,14 @@ private fun BubbleWebScreen(
                                 progress = { pageProgress },
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(16.dp),
+                                    .height(12.dp),
                                 color = MaterialTheme.colorScheme.onPrimary,
                                 trackColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.28f),
                             )
                         } else {
                             Text(
                                 text = currentDomain,
-                                style = MaterialTheme.typography.titleMedium,
+                                style = MaterialTheme.typography.labelLarge,
                                 color = MaterialTheme.colorScheme.onPrimary,
                                 fontWeight = FontWeight.Bold,
                                 maxLines = 1,
@@ -373,7 +382,7 @@ private fun BubbleWebScreen(
                             clipboard.setPrimaryClip(ClipData.newPlainText("URL", currentUrl))
                             Toast.makeText(context, copyFeedbackText, Toast.LENGTH_SHORT).show()
                         },
-                        modifier = Modifier.size(52.dp),
+                        modifier = Modifier.size(40.dp),
                         colors = IconButtonDefaults.iconButtonColors(
                             contentColor = MaterialTheme.colorScheme.onPrimary,
                         ),
@@ -382,7 +391,7 @@ private fun BubbleWebScreen(
                             painter = painterResource(R.drawable.rounded_link_24),
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(26.dp),
+                            modifier = Modifier.size(20.dp),
                         )
                     }
 
@@ -396,7 +405,7 @@ private fun BubbleWebScreen(
                             }
                             context.startActivity(shareIntent)
                         },
-                        modifier = Modifier.size(52.dp),
+                        modifier = Modifier.size(40.dp),
                         colors = IconButtonDefaults.iconButtonColors(
                             contentColor = MaterialTheme.colorScheme.onPrimary,
                         ),
@@ -405,7 +414,31 @@ private fun BubbleWebScreen(
                             painter = painterResource(R.drawable.rounded_share_24),
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(26.dp),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+
+                    IconButton(
+                        onClick = {
+                            HapticUtil.performVirtualKeyHaptic(view)
+                            try {
+                                val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl)).apply {
+                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                                context.startActivity(browserIntent)
+                                onClose()
+                            } catch (_: Exception) {}
+                        },
+                        modifier = Modifier.size(40.dp),
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.rounded_open_in_browser_24),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(20.dp),
                         )
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/SettingsActivity.kt
@@ -312,6 +312,7 @@ fun SettingsContent(
     val isBackgroundLocationPermissionGranted by viewModel.isBackgroundLocationPermissionGranted
     val isDeviceAdminEnabled by viewModel.isDeviceAdminEnabled
     val isCalendarPermissionGranted by viewModel.isCalendarPermissionGranted
+    val isBubblePermissionGranted by viewModel.isBubblePermissionGranted
     val isUsageStatsPermissionGranted by viewModel.isUsageStatsPermissionGranted
     val context = LocalContext.current
     val isAppHapticsEnabled = remember { mutableStateOf(HapticUtil.loadAppHapticsEnabled(context)) }
@@ -842,6 +843,7 @@ fun SettingsContent(
                         isBackgroundLocationPermissionGranted,
                         isDeviceAdminEnabled,
                         isCalendarPermissionGranted,
+                        isBubblePermissionGranted,
                     ) {
                         PermissionUIHelper.getAllPermissionItems(context, viewModel, context as? ComponentActivity)
                     }

--- a/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/PermissionUtils.kt
@@ -135,6 +135,59 @@ object PermissionUtils {
             false
         }
 
+    fun hasBubblePermission(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as? android.app.NotificationManager ?: return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (nm.bubblePreference == android.app.NotificationManager.BUBBLE_PREFERENCE_NONE) return false
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            @Suppress("DEPRECATION")
+            if (!nm.areBubblesAllowed()) return false
+        }
+        val channel = nm.getNotificationChannel(WindowingUtils.BUBBLE_CHANNEL_ID)
+        if (channel != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return channel.canBubble()
+        }
+        return WindowingUtils.areNotificationBubblesEnabled(context)
+    }
+
+    fun openBubbleSettings(context: Context) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val intent = Intent(Settings.ACTION_APP_NOTIFICATION_BUBBLE_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+                context.startActivity(intent)
+                return
+            }
+        } catch (_: Exception) {}
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+                context.startActivity(intent)
+                return
+            }
+        } catch (_: Exception) {}
+
+        try {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        } catch (_: Exception) {
+            val intent = Intent(Settings.ACTION_SETTINGS).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        }
+    }
+
     /**
      * Executes the is default browser operation.
      *

--- a/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
@@ -30,7 +30,7 @@ import com.sameerasw.essentials.ui.activities.BubbleWebActivity
 
 object WindowingUtils {
     private const val TAG = "WindowingUtils"
-    private const val BUBBLE_CHANNEL_ID = "bubble_web_preview_channel"
+    const val BUBBLE_CHANNEL_ID = "bubble_web_preview_channel"
     private const val NOTIFICATION_ID = 90210
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
@@ -121,7 +121,7 @@ object WindowingUtils {
 
         val targetUrl = uri.toString()
         val host = uri.host ?: targetUrl
-        val shortcutId = "bubble_web_preview_${Math.abs(targetUrl.hashCode())}"
+        val shortcutId = "bubble_web_preview_${targetUrl.hashCode().toUInt()}"
         val iconRes = R.drawable.rounded_globe_24
         val bubbleIcon = IconCompat.createWithResource(context, iconRes)
 
@@ -171,7 +171,7 @@ object WindowingUtils {
             }
             val bubblePendingIntent = PendingIntent.getActivity(
                 context,
-                Math.abs(targetUrl.hashCode()),
+                targetUrl.hashCode().toUInt().toInt(),
                 bubbleIntent,
                 flags,
             )

--- a/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
@@ -15,9 +15,9 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
-import android.graphics.drawable.Icon
+import androidx.core.app.Person
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -55,7 +55,7 @@ object WindowingUtils {
      */
     fun areNotificationBubblesEnabled(context: Context): Boolean {
         return try {
-            Settings.Global.getInt(context.contentResolver, "notification_bubbles", 1) == 1
+            Settings.Secure.getInt(context.contentResolver, "notification_bubbles", 1) == 1
         } catch (_: Exception) {
             true
         }
@@ -67,7 +67,7 @@ object WindowingUtils {
     fun enableNotificationBubbles(context: Context): Boolean {
         return try {
             if (PermissionUtils.canWriteSecureSettings(context)) {
-                Settings.Global.putInt(context.contentResolver, "notification_bubbles", 1)
+                Settings.Secure.putInt(context.contentResolver, "notification_bubbles", 1)
                 true
             } else {
                 false
@@ -120,6 +120,11 @@ object WindowingUtils {
         }
 
         val targetUrl = uri.toString()
+        val host = uri.host ?: targetUrl
+        val shortcutId = "bubble_web_preview_${Math.abs(host.hashCode())}"
+        val iconRes = R.drawable.rounded_globe_24
+        val bubbleIcon = IconCompat.createWithResource(context, iconRes)
+
         val bubbleIntent = Intent(context, BubbleWebActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             data = uri
@@ -128,80 +133,73 @@ object WindowingUtils {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
 
-        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        } else {
-            PendingIntent.FLAG_UPDATE_CURRENT
-        }
+        // 1. AndroidX Person with matching unique key
+        val person = Person.Builder()
+            .setName(host)
+            .setIcon(bubbleIcon)
+            .setKey(shortcutId)
+            .setImportant(true)
+            .build()
 
-        val bubblePendingIntent = PendingIntent.getActivity(
-            context,
-            NOTIFICATION_ID,
-            bubbleIntent,
-            flags,
-        )
+        // 2. Publish Dynamic Conversation Shortcut via ShortcutManagerCompat
+        val shortcut = ShortcutInfoCompat.Builder(context, shortcutId)
+            .setShortLabel(host.take(25))
+            .setLongLabel(context.getString(R.string.preview_web_title))
+            .setIcon(bubbleIcon)
+            .setIntent(bubbleIntent)
+            .setLongLived(true)
+            .setPerson(person)
+            .setCategories(setOf("android.shortcut.conversation"))
+            .build()
 
-        val iconRes = R.drawable.rounded_globe_24
-        val bubbleIcon = IconCompat.createWithResource(context, iconRes)
-
-        val host = uri.host ?: targetUrl
-        val title = context.getString(R.string.preview_web_title)
-        val shortcutId = "bubble_web_preview_${host.hashCode()}"
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val shortcut = ShortcutInfo.Builder(context, shortcutId)
-                .setCategories(setOf("android.shortcut.conversation"))
-                .setShortLabel(host)
-                .setLongLabel(title)
-                .setIcon(Icon.createWithResource(context, iconRes))
-                .setIntent(bubbleIntent)
-                .setLongLived(true)
-                .setPerson(
-                    android.app.Person.Builder()
-                        .setName(host)
-                        .setIcon(Icon.createWithResource(context, iconRes))
-                        .setImportant(true)
-                        .build()
-                )
-                .build()
-
-            val sm = context.getSystemService(ShortcutManager::class.java)
-            sm?.pushDynamicShortcut(shortcut)
-        }
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
 
         val displayMetrics = context.resources.displayMetrics
         val screenHeightDp = (displayMetrics.heightPixels / displayMetrics.density).toInt()
 
-        val bubbleMetadata = NotificationCompat.BubbleMetadata.Builder(bubblePendingIntent, bubbleIcon)
-            .setDesiredHeight(screenHeightDp)
-            .setAutoExpandBubble(true)
-            .setSuppressNotification(true)
-            .build()
+        // 3. Build BubbleMetadata using shortcutId on Android 11+ (API 30+)
+        val bubbleMetadata = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            NotificationCompat.BubbleMetadata.Builder(shortcutId)
+                .setDesiredHeight(screenHeightDp)
+                .setAutoExpandBubble(true)
+                .build()
+        } else {
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            val bubblePendingIntent = PendingIntent.getActivity(
+                context,
+                NOTIFICATION_ID,
+                bubbleIntent,
+                flags,
+            )
+            NotificationCompat.BubbleMetadata.Builder(bubblePendingIntent, bubbleIcon)
+                .setDesiredHeight(screenHeightDp)
+                .setAutoExpandBubble(true)
+                .build()
+        }
 
-        val person = androidx.core.app.Person.Builder()
-            .setName(host)
-            .setIcon(bubbleIcon)
-            .setImportant(true)
-            .build()
-
+        // 4. Create MessagingStyle Notification linked to the conversation shortcut
         val messagingStyle = NotificationCompat.MessagingStyle(person)
             .addMessage(
                 NotificationCompat.MessagingStyle.Message(
-                    title,
+                    targetUrl,
                     System.currentTimeMillis(),
                     person,
                 )
             )
 
         val builder = NotificationCompat.Builder(context, BUBBLE_CHANNEL_ID)
-            .setContentTitle(title)
+            .setContentTitle(context.getString(R.string.preview_web_title))
             .setContentText(host)
             .setSmallIcon(iconRes)
             .setStyle(messagingStyle)
-            .setBubbleMetadata(bubbleMetadata)
+            .setShortcutInfo(shortcut)
             .setShortcutId(shortcutId)
+            .setBubbleMetadata(bubbleMetadata)
             .setAutoCancel(true)
-            .setSilent(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/WindowingUtils.kt
@@ -121,7 +121,7 @@ object WindowingUtils {
 
         val targetUrl = uri.toString()
         val host = uri.host ?: targetUrl
-        val shortcutId = "bubble_web_preview_${Math.abs(host.hashCode())}"
+        val shortcutId = "bubble_web_preview_${Math.abs(targetUrl.hashCode())}"
         val iconRes = R.drawable.rounded_globe_24
         val bubbleIcon = IconCompat.createWithResource(context, iconRes)
 
@@ -171,7 +171,7 @@ object WindowingUtils {
             }
             val bubblePendingIntent = PendingIntent.getActivity(
                 context,
-                NOTIFICATION_ID,
+                Math.abs(targetUrl.hashCode()),
                 bubbleIntent,
                 flags,
             )
@@ -206,7 +206,7 @@ object WindowingUtils {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
             ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
         ) {
-            nm.notify(NOTIFICATION_ID, builder.build())
+            nm.notify(shortcutId, NOTIFICATION_ID, builder.build())
         } else {
             // If notification permission is denied on Android 13+, launch activity directly
             context.startActivity(bubbleIntent)

--- a/app/src/main/java/com/sameerasw/essentials/utils/ui/PermissionUIHelper.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/ui/PermissionUIHelper.kt
@@ -486,6 +486,47 @@ object PermissionUIHelper {
                     },
                     isGranted = PermissionUtils.hasStoragePermission(context),
                 )
+
+            AppPermission.NOTIFICATION_BUBBLES ->
+                PermissionItem(
+                    iconRes = permission.iconRes,
+                    title = permission.titleRes,
+                    description = R.string.perm_bubbles_desc,
+                    dependentFeatures = PermissionRegistry.getFeatures(permission),
+                    actionLabel = if (viewModel.isBubblePermissionGranted.value) R.string.perm_action_granted else R.string.perm_action_grant,
+                    action = {
+                        PermissionUtils.openBubbleSettings(context)
+                    },
+                    secondaryActionLabel = R.string.perm_action_copy_adb,
+                    secondaryAction = {
+                        val adbCommand =
+                            "cmd notification set_bubbles ${context.packageName} 1 && cmd notification set_bubbles_channel ${context.packageName} bubble_web_preview_channel true"
+                        val clipboard = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                        val clip = ClipData.newPlainText("adb_command", adbCommand)
+                        clipboard.setPrimaryClip(clip)
+                    },
+                    isGranted = viewModel.isBubblePermissionGranted.value,
+                    shizukuActionLabel = if (viewModel.isRootEnabled.value) R.string.perm_action_grant_root else R.string.perm_action_grant_shizuku,
+                    shizukuActionEnabled =
+                        if (viewModel.isRootEnabled.value) {
+                            viewModel.isRootAvailable.value
+                        } else {
+                            ShizukuUtils.hasPermission()
+                        },
+                    shizukuAction = {
+                        val command =
+                            "cmd notification set_bubbles ${context.packageName} 1 && cmd notification set_bubbles_channel ${context.packageName} bubble_web_preview_channel true"
+                        if (viewModel.isRootEnabled.value) {
+                            if (RootUtils.runCommand(command)) {
+                                viewModel.check(context)
+                            }
+                        } else {
+                            ShizukuUtils.runCommand(command)
+                            viewModel.check(context)
+                        }
+                    },
+                    instructions = R.string.perm_bubbles_instructions,
+                )
         }
 
     fun getPermissionItem(

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -331,6 +331,7 @@ class MainViewModel : ViewModel() {
     val isKeyboardSelected = mutableStateOf(false)
     val isWriteSettingsEnabled = mutableStateOf(false)
     val isCalendarPermissionGranted = mutableStateOf(false)
+    val isBubblePermissionGranted = mutableStateOf(false)
     val isUserDictionaryEnabled = mutableStateOf(false)
     val userDictionaryWords = mutableStateOf<Map<String, Long>>(emptyMap())
     val isUserDictionarySheetVisible = mutableStateOf(false)
@@ -1208,6 +1209,7 @@ class MainViewModel : ViewModel() {
 
         isAccessibilityEnabled.value = PermissionUtils.isAccessibilityServiceEnabled(context)
         isWriteSecureSettingsEnabled.value = PermissionUtils.canWriteSecureSettings(context)
+        isBubblePermissionGranted.value = PermissionUtils.hasBubblePermission(context)
         isShizukuAvailable.value = ShizukuUtils.isShizukuAvailable()
         isShizukuPermissionGranted.value = ShizukuUtils.hasPermission()
         if (cachedIsUpdateAvailable) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2446,4 +2446,7 @@
     <string name="settings_section_more">More</string>
     <string name="action_show_granted">Show granted</string>
     <string name="action_hide_granted">Hide granted</string>
+    <string name="perm_bubbles_title">Floating Bubbles</string>
+    <string name="perm_bubbles_desc">Allow web previews to open in floating conversation bubbles above other apps</string>
+    <string name="perm_bubbles_instructions">Set to "All conversations can bubble" in app notification settings, or grant via Shizuku / Root.</string>
 </resources>


### PR DESCRIPTION
## Summary

This pull request addresses several issues with native Android conversation bubbles when previewing links, adds bubble permission controls to settings, and improves toolbar navigation and WebView performance.

## Context and Root Cause

On Android 11 through 16, link preview bubbles were failing to launch or closing unexpectedly for several reasons:

1. `BubbleWebActivity` was missing an `ACTION_VIEW` intent filter, causing Android's `ShortcutService` to reject dynamic conversation shortcuts.
2. The notification builder used the deprecated `BubbleMetadata.Builder(pendingIntent, icon)` rather than referencing dynamic shortcuts by ID.
3. Notifications were hardcoded to a single notification ID with no tag, which prevented Android SystemUI from stacking multiple preview bubbles or displaying the bubble tab switcher.
4. Pressing the back button destroyed the activity, closing the bubble entirely instead of collapsing it back to its floating icon.

## Changes

### Native bubbles and windowing
- Added dynamic shortcut generation with unique shortcut IDs and matching `Person` metadata via `ShortcutManagerCompat`.
- Migrated bubble creation to `BubbleMetadata.Builder(shortcutId)` for API 30+.
- Tagged notifications by target URL hash code so multiple links open in separate stacked bubbles.
- Configured back gesture handling with `moveTaskToBack(true)` to collapse the expanded bubble window without terminating the underlying session.
- Removed notification suppression so bubbles surface reliably when launched.

### UI and toolbar
- Added an "Open in browser" action to the floating bottom toolbar with virtual key haptics.
- Adjusted the floating toolbar height from 72dp to 54dp and centered the domain text.
- Added a floating bubbles permission entry to the settings screen with a direct link to the app notification channel settings.

### WebView performance
- Switched toolbar scroll translation and alpha to draw-phase `graphicsLayer` modifiers, avoiding recompositions during scroll events.
- Enabled DOM storage and standard caching for single-page applications.
- Paused WebView JavaScript timers and rendering in `onPause()` and resumed them in `onResume()` to eliminate background CPU and battery drain when bubbles are collapsed.
- Added intent handling for non-HTTP links so external app schemes resolve through the package manager.

## Verification

- Built using `./gradlew :app:assembleDebug` with zero compiler warnings or errors.
- Installed and tested on a physical device running Android 16 (Vivo V2513).
- Verified bubble expansion, multi-bubble stacking with the native tab switcher, link opening in external browsers, back gesture collapse, and permission channel routing.