### PR TITLE
Feature/duo

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -3095,7 +3095,7 @@ class SettingsRepository(
     fun isDuoShowNetworksEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_NETWORKS, true)
     fun setDuoShowNetworksEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_NETWORKS, enabled)
 
-    fun isDuoHideWhenScreenOffEnabled(): Boolean = getBoolean(KEY_DUO_HIDE_WHEN_SCREEN_OFF, false)
+    fun isDuoHideWhenScreenOffEnabled(): Boolean = getBoolean(KEY_DUO_HIDE_WHEN_SCREEN_OFF, true)
     fun setDuoHideWhenScreenOffEnabled(enabled: Boolean) = putBoolean(KEY_DUO_HIDE_WHEN_SCREEN_OFF, enabled)
 
     fun isDuoUseMaterialYouEnabled(): Boolean = getBoolean(KEY_DUO_USE_MATERIAL_YOU, true)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -365,6 +365,8 @@ class SettingsRepository(
         const val KEY_DUO_DOT_SIZE = "duo_dot_size"
         const val KEY_DUO_RING_RADIUS = "duo_ring_radius"
         const val KEY_DUO_SHOW_NETWORKS = "duo_show_networks"
+        const val KEY_DUO_HIDE_WHEN_SCREEN_OFF = "duo_hide_when_screen_off"
+        const val KEY_DUO_USE_MATERIAL_YOU = "duo_use_material_you"
 
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
@@ -3092,4 +3094,10 @@ class SettingsRepository(
 
     fun isDuoShowNetworksEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_NETWORKS, true)
     fun setDuoShowNetworksEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_NETWORKS, enabled)
+
+    fun isDuoHideWhenScreenOffEnabled(): Boolean = getBoolean(KEY_DUO_HIDE_WHEN_SCREEN_OFF, false)
+    fun setDuoHideWhenScreenOffEnabled(enabled: Boolean) = putBoolean(KEY_DUO_HIDE_WHEN_SCREEN_OFF, enabled)
+
+    fun isDuoUseMaterialYouEnabled(): Boolean = getBoolean(KEY_DUO_USE_MATERIAL_YOU, true)
+    fun setDuoUseMaterialYouEnabled(enabled: Boolean) = putBoolean(KEY_DUO_USE_MATERIAL_YOU, enabled)
 }

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -364,6 +364,7 @@ class SettingsRepository(
         const val KEY_DUO_ARC_THICKNESS = "duo_arc_thickness"
         const val KEY_DUO_DOT_SIZE = "duo_dot_size"
         const val KEY_DUO_RING_RADIUS = "duo_ring_radius"
+        const val KEY_DUO_SHOW_NETWORKS = "duo_show_networks"
 
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
@@ -3088,4 +3089,7 @@ class SettingsRepository(
 
     fun getDuoRingRadius(): Float = getFloat(KEY_DUO_RING_RADIUS, 1.0f)
     fun setDuoRingRadius(value: Float) = putFloat(KEY_DUO_RING_RADIUS, value)
+
+    fun isDuoShowNetworksEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_NETWORKS, true)
+    fun setDuoShowNetworksEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_NETWORKS, enabled)
 }

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -355,6 +355,16 @@ class SettingsRepository(
         const val KEY_LINK_PREVIEW_ENABLED = "link_preview_enabled"
         const val KEY_LINK_PREVIEW_IMAGES_ENABLED = "link_preview_images_enabled"
 
+        // Duo
+        const val KEY_DUO_ENABLED = "duo_enabled"
+        const val KEY_DUO_USE_AUTO_DETECT = "duo_use_auto_detect"
+        const val KEY_DUO_CAMERA_OFFSET_X = "duo_camera_offset_x"
+        const val KEY_DUO_CAMERA_OFFSET_Y = "duo_camera_offset_y"
+        const val KEY_DUO_CAMERA_SIZE = "duo_camera_size"
+        const val KEY_DUO_ARC_THICKNESS = "duo_arc_thickness"
+        const val KEY_DUO_DOT_SIZE = "duo_dot_size"
+        const val KEY_DUO_RING_RADIUS = "duo_ring_radius"
+
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
         const val KEY_LIVE_WALLPAPER_SELECTED_VIDEO = "selected_video"
@@ -3054,4 +3064,28 @@ class SettingsRepository(
 
     fun isLinkPreviewImagesEnabled(): Boolean = getBoolean(KEY_LINK_PREVIEW_IMAGES_ENABLED, true)
     fun setLinkPreviewImagesEnabled(enabled: Boolean) = putBoolean(KEY_LINK_PREVIEW_IMAGES_ENABLED, enabled)
+
+    fun isDuoEnabled(): Boolean = getBoolean(KEY_DUO_ENABLED, false)
+    fun setDuoEnabled(enabled: Boolean) = putBoolean(KEY_DUO_ENABLED, enabled)
+
+    fun isDuoAutoDetectEnabled(): Boolean = getBoolean(KEY_DUO_USE_AUTO_DETECT, true)
+    fun setDuoAutoDetectEnabled(enabled: Boolean) = putBoolean(KEY_DUO_USE_AUTO_DETECT, enabled)
+
+    fun getDuoCameraOffsetX(): Float = getFloat(KEY_DUO_CAMERA_OFFSET_X, 50f)
+    fun setDuoCameraOffsetX(value: Float) = putFloat(KEY_DUO_CAMERA_OFFSET_X, value)
+
+    fun getDuoCameraOffsetY(): Float = getFloat(KEY_DUO_CAMERA_OFFSET_Y, 3f)
+    fun setDuoCameraOffsetY(value: Float) = putFloat(KEY_DUO_CAMERA_OFFSET_Y, value)
+
+    fun getDuoCameraSize(): Float = getFloat(KEY_DUO_CAMERA_SIZE, 1.0f)
+    fun setDuoCameraSize(value: Float) = putFloat(KEY_DUO_CAMERA_SIZE, value)
+
+    fun getDuoArcThickness(): Float = getFloat(KEY_DUO_ARC_THICKNESS, 4f)
+    fun setDuoArcThickness(value: Float) = putFloat(KEY_DUO_ARC_THICKNESS, value)
+
+    fun getDuoDotSize(): Float = getFloat(KEY_DUO_DOT_SIZE, 4f)
+    fun setDuoDotSize(value: Float) = putFloat(KEY_DUO_DOT_SIZE, value)
+
+    fun getDuoRingRadius(): Float = getFloat(KEY_DUO_RING_RADIUS, 1.0f)
+    fun setDuoRingRadius(value: Float) = putFloat(KEY_DUO_RING_RADIUS, value)
 }

--- a/app/src/main/java/com/sameerasw/essentials/domain/model/DuoColorMode.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/model/DuoColorMode.kt
@@ -1,0 +1,5 @@
+package com.sameerasw.essentials.domain.model
+
+enum class DuoColorMode {
+    THEME
+}

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -276,6 +276,31 @@ object FeatureRegistry {
                 ) {}
             },
             object : Feature(
+                id = "Duo",
+                title = R.string.duo_title,
+                iconRes = R.drawable.rounded_motion_play_24,
+                category = R.string.cat_interface,
+                description = R.string.duo_desc,
+                aboutDescription = R.string.duo_desc,
+                permissionKeys = listOf("ACCESSIBILITY"),
+                hasMoreSettings = true,
+                showToggle = true,
+                parentFeatureId = "Display",
+            ) {
+                override fun isEnabled(viewModel: MainViewModel) = viewModel.isDuoEnabled.value
+
+                override fun isToggleEnabled(
+                    viewModel: MainViewModel,
+                    context: Context,
+                ) = viewModel.isAccessibilityEnabled.value
+
+                override fun onToggle(
+                    viewModel: MainViewModel,
+                    context: Context,
+                    enabled: Boolean,
+                ) = viewModel.setDuoEnabled(enabled)
+            },
+            object : Feature(
                 id = "Essentials On Display",
                 title = R.string.feat_essentials_on_display_title,
                 iconRes = R.drawable.rounded_music_video_24,

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -14,6 +14,7 @@ import android.content.Intent
 import com.sameerasw.essentials.EssentialsApp
 import com.sameerasw.essentials.FeatureSettingsActivity
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.domain.model.Feature
 import com.sameerasw.essentials.domain.model.SearchSetting
 import com.sameerasw.essentials.ui.activities.PixelSearchbarSettingsActivity
@@ -287,6 +288,11 @@ object FeatureRegistry {
                 showToggle = true,
                 parentFeatureId = "Display",
             ) {
+                override fun isDeviceSupported(context: Context): Boolean {
+                    val settingsRepository = SettingsRepository(context)
+                    return settingsRepository.getBoolean(SettingsRepository.KEY_DEVELOPER_MODE_ENABLED, false)
+                }
+
                 override fun isEnabled(viewModel: MainViewModel) = viewModel.isDuoEnabled.value
 
                 override fun isToggleEnabled(

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
@@ -55,6 +55,7 @@ fun initPermissionRegistry() {
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_app_lock_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_essentials_on_display_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_aod_wallpaper_title)
+    PermissionRegistry.register("ACCESSIBILITY", R.string.duo_title)
 
     // Write secure settings permission
     PermissionRegistry.register("WRITE_SECURE_SETTINGS", R.string.feat_statusbar_icons_title)

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -15,11 +15,19 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.res.Configuration
-import android.graphics.PixelFormat
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
 import android.os.BatteryManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.telephony.PhoneStateListener
+import android.telephony.SignalStrength
+import android.telephony.TelephonyCallback
+import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import com.sameerasw.essentials.data.repository.SettingsRepository
@@ -35,6 +43,22 @@ class DuoOverlayHandler(
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val settingsRepository by lazy { SettingsRepository(service) }
+    private val telephonyManager by lazy { service.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager }
+    private val connectivityManager by lazy { service.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager }
+    private val wifiManager by lazy { service.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager }
+
+    private var telephonyCallback: Any? = null
+    private var isTelephonyRegistered = false
+    private var isNetworkCallbackRegistered = false
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+            updateCurrentSignal()
+        }
+        override fun onLost(network: Network) {
+            updateCurrentSignal()
+        }
+    }
 
     private val batteryReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -75,6 +99,60 @@ class DuoOverlayHandler(
             return
         }
         showOrUpdateOverlay()
+    }
+
+    private fun updateCurrentSignal() {
+        mainHandler.post {
+            var level = -1
+
+            // 1. Check if connected to Wi-Fi
+            val activeNetwork = connectivityManager?.activeNetwork
+            val capabilities = activeNetwork?.let { connectivityManager?.getNetworkCapabilities(it) }
+            if (capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val transportInfo = capabilities.transportInfo
+                    if (transportInfo is WifiInfo) {
+                        val rssi = transportInfo.rssi
+                        if (rssi > -127) {
+                            level = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && wifiManager != null) {
+                                wifiManager?.calculateSignalLevel(rssi)?.coerceIn(0, 4) ?: 0
+                            } else {
+                                @Suppress("DEPRECATION")
+                                WifiManager.calculateSignalLevel(rssi, 5).coerceIn(0, 4)
+                            }
+                        }
+                    }
+                }
+                if (level == -1 && wifiManager != null) {
+                    @Suppress("DEPRECATION")
+                    val info = wifiManager?.connectionInfo
+                    if (info != null && info.rssi > -127) {
+                        level = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            wifiManager?.calculateSignalLevel(info.rssi)?.coerceIn(0, 4) ?: 0
+                        } else {
+                            @Suppress("DEPRECATION")
+                            WifiManager.calculateSignalLevel(info.rssi, 5).coerceIn(0, 4)
+                        }
+                    }
+                }
+            }
+
+            // 2. Cellular signal fallback / primary if on cellular
+            if (level == -1) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    try {
+                        val signalStrength = telephonyManager?.signalStrength
+                        if (signalStrength != null) {
+                            level = signalStrength.level.coerceIn(0, 4)
+                        }
+                    } catch (_: Exception) {}
+                }
+            }
+
+            if (level >= 0) {
+                overlayView?.signalLevel = level
+            }
+        }
     }
 
     private fun showOrUpdateOverlay() {
@@ -148,6 +226,8 @@ class DuoOverlayHandler(
             }
 
             registerBatteryReceiver()
+            registerSignalListeners()
+            updateCurrentSignal()
         }
     }
 
@@ -181,6 +261,79 @@ class DuoOverlayHandler(
         }
     }
 
+    private fun registerSignalListeners() {
+        if (!isNetworkCallbackRegistered) {
+            try {
+                connectivityManager?.registerDefaultNetworkCallback(networkCallback)
+                isNetworkCallbackRegistered = true
+            } catch (e: Exception) {
+                android.util.Log.e("DuoOverlayHandler", "Failed to register network callback", e)
+            }
+        }
+
+        if (!isTelephonyRegistered && telephonyManager != null) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val callback = object : TelephonyCallback(), TelephonyCallback.SignalStrengthsListener {
+                        override fun onSignalStrengthsChanged(signalStrength: SignalStrength) {
+                            val lvl = signalStrength.level.coerceIn(0, 4)
+                            overlayView?.signalLevel = lvl
+                        }
+                    }
+                    telephonyManager?.registerTelephonyCallback(service.mainExecutor, callback)
+                    telephonyCallback = callback
+                    isTelephonyRegistered = true
+                } else {
+                    @Suppress("DEPRECATION")
+                    val listener = object : PhoneStateListener() {
+                        @Deprecated("Deprecated in Java")
+                        override fun onSignalStrengthsChanged(signalStrength: SignalStrength?) {
+                            if (signalStrength != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                val lvl = signalStrength.level.coerceIn(0, 4)
+                                overlayView?.signalLevel = lvl
+                            }
+                        }
+                    }
+                    @Suppress("DEPRECATION")
+                    telephonyManager?.listen(listener, PhoneStateListener.LISTEN_SIGNAL_STRENGTHS)
+                    telephonyCallback = listener
+                    isTelephonyRegistered = true
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("DuoOverlayHandler", "Failed to register telephony listener", e)
+            }
+        }
+    }
+
+    private fun unregisterSignalListeners() {
+        if (isNetworkCallbackRegistered) {
+            try {
+                connectivityManager?.unregisterNetworkCallback(networkCallback)
+            } catch (_: Exception) {}
+            isNetworkCallbackRegistered = false
+        }
+
+        if (isTelephonyRegistered && telephonyCallback != null) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val callback = telephonyCallback as? TelephonyCallback
+                    if (callback != null) {
+                        telephonyManager?.unregisterTelephonyCallback(callback)
+                    }
+                } else {
+                    @Suppress("DEPRECATION")
+                    val listener = telephonyCallback as? PhoneStateListener
+                    if (listener != null) {
+                        @Suppress("DEPRECATION")
+                        telephonyManager?.listen(listener, PhoneStateListener.LISTEN_NONE)
+                    }
+                }
+            } catch (_: Exception) {}
+            telephonyCallback = null
+            isTelephonyRegistered = false
+        }
+    }
+
     fun removeOverlay() {
         mainHandler.post {
             if (isOverlayAdded && overlayView != null) {
@@ -190,6 +343,7 @@ class DuoOverlayHandler(
                 isOverlayAdded = false
             }
             unregisterBatteryReceiver()
+            unregisterSignalListeners()
         }
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -125,6 +125,7 @@ class DuoOverlayHandler(
                 this.dotRadiusPx = settingsRepository.getDuoDotSize() * density
                 this.isDarkTheme = isNightMode
                 this.isScreenOff = this@DuoOverlayHandler.isScreenOff
+                this.showNetworks = settingsRepository.isDuoShowNetworksEnabled()
             }
 
             if (!isOverlayAdded) {

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Background Services & Handlers
+ * File: DuoOverlayHandler.kt
+ * Description: Background handler managing the Duo ambient camera overlay.
+ */
+
+package com.sameerasw.essentials.services.handlers
+
+import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.Configuration
+import android.graphics.PixelFormat
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.DisplayMetrics
+import android.view.WindowManager
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.utils.DuoOverlayView
+import com.sameerasw.essentials.utils.OverlayHelper
+
+class DuoOverlayHandler(
+    private val service: AccessibilityService,
+) {
+    private var windowManager: WindowManager? = null
+    private var overlayView: DuoOverlayView? = null
+    private var isOverlayAdded = false
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private val settingsRepository by lazy { SettingsRepository(service) }
+
+    private val batteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_BATTERY_CHANGED) {
+                val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
+                if (level >= 0 && scale > 0) {
+                    val batteryPct = (level * 100) / scale
+                    overlayView?.batteryLevel = batteryPct
+                }
+            }
+        }
+    }
+    private var isBatteryReceiverRegistered = false
+
+    fun init() {
+        windowManager = service.getSystemService(AccessibilityService.WINDOW_SERVICE) as? WindowManager
+        updateState()
+    }
+
+    fun onScreenOn() {
+        updateState()
+    }
+
+    fun onScreenOff() {
+        removeOverlay()
+    }
+
+    fun updateState() {
+        if (!settingsRepository.isDuoEnabled()) {
+            removeOverlay()
+            return
+        }
+        showOrUpdateOverlay()
+    }
+
+    private fun showOrUpdateOverlay() {
+        mainHandler.post {
+            val wm = windowManager ?: return@post
+
+            val displayMetrics = DisplayMetrics()
+            @Suppress("DEPRECATION")
+            wm.defaultDisplay.getRealMetrics(displayMetrics)
+            val screenWidth = displayMetrics.widthPixels.toFloat()
+            val screenHeight = displayMetrics.heightPixels.toFloat()
+            val density = displayMetrics.density
+
+            var centerX = screenWidth * (settingsRepository.getDuoCameraOffsetX() / 100f)
+            var centerY = screenHeight * (settingsRepository.getDuoCameraOffsetY() / 100f)
+            var cameraRadiusPx = 18f * density * settingsRepository.getDuoCameraSize()
+
+            if (settingsRepository.isDuoAutoDetectEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                @Suppress("DEPRECATION")
+                val cutout = wm.defaultDisplay.cutout
+                if (cutout != null && cutout.boundingRects.isNotEmpty()) {
+                    // Find cutout rect closest to top center of screen
+                    val topCutouts = cutout.boundingRects.filter { it.top < screenHeight / 4 }
+                    val targetRect = topCutouts.minByOrNull { kotlin.math.abs(it.centerX() - screenWidth / 2f) }
+                    if (targetRect != null) {
+                        centerX = targetRect.centerX().toFloat()
+                        centerY = targetRect.centerY().toFloat()
+                        val computedRadius = (targetRect.width().coerceAtLeast(targetRect.height()) / 2f) * settingsRepository.getDuoCameraSize()
+                        if (computedRadius > 0) {
+                            cameraRadiusPx = computedRadius
+                        }
+                    }
+                }
+            }
+
+            val isNightMode = (service.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+
+            if (overlayView == null) {
+                overlayView = DuoOverlayView(service)
+            }
+
+            overlayView?.apply {
+                this.cameraCenterX = centerX
+                this.cameraCenterY = centerY
+                this.cameraRadiusPx = cameraRadiusPx
+                this.ringRadiusScale = settingsRepository.getDuoRingRadius()
+                this.arcThicknessPx = settingsRepository.getDuoArcThickness() * density
+                this.dotRadiusPx = settingsRepository.getDuoDotSize() * density
+                this.isDarkTheme = isNightMode
+            }
+
+            if (!isOverlayAdded) {
+                val params = OverlayHelper.createOverlayLayoutParams(
+                    WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+                    WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                    isTouchable = false
+                )
+                try {
+                    wm.addView(overlayView, params)
+                    isOverlayAdded = true
+                } catch (e: Exception) {
+                    android.util.Log.e("DuoOverlayHandler", "Failed to add Duo overlay", e)
+                }
+            } else {
+                overlayView?.invalidate()
+            }
+
+            registerBatteryReceiver()
+        }
+    }
+
+    private fun registerBatteryReceiver() {
+        if (!isBatteryReceiverRegistered) {
+            try {
+                val intent = service.registerReceiver(
+                    batteryReceiver,
+                    IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+                )
+                isBatteryReceiverRegistered = true
+                intent?.let {
+                    val level = it.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                    val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
+                    if (level >= 0 && scale > 0) {
+                        overlayView?.batteryLevel = (level * 100) / scale
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("DuoOverlayHandler", "Failed to register battery receiver", e)
+            }
+        }
+    }
+
+    private fun unregisterBatteryReceiver() {
+        if (isBatteryReceiverRegistered) {
+            try {
+                service.unregisterReceiver(batteryReceiver)
+            } catch (_: Exception) {}
+            isBatteryReceiverRegistered = false
+        }
+    }
+
+    fun removeOverlay() {
+        mainHandler.post {
+            if (isOverlayAdded && overlayView != null) {
+                try {
+                    windowManager?.removeView(overlayView)
+                } catch (_: Exception) {}
+                isOverlayAdded = false
+            }
+            unregisterBatteryReceiver()
+        }
+    }
+
+    fun destroy() {
+        removeOverlay()
+        overlayView = null
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -75,6 +75,15 @@ class DuoOverlayHandler(
     private var isBatteryReceiverRegistered = false
 
     private var isScreenOff: Boolean = false
+    var isFullscreen: Boolean = false
+        private set
+
+    fun setFullscreen(fullscreen: Boolean) {
+        if (isFullscreen != fullscreen) {
+            isFullscreen = fullscreen
+            overlayView?.isFullscreen = fullscreen
+        }
+    }
 
     fun init() {
         windowManager = service.getSystemService(AccessibilityService.WINDOW_SERVICE) as? WindowManager
@@ -96,6 +105,7 @@ class DuoOverlayHandler(
     fun onConfigurationChanged(newConfig: Configuration) {
         val isNightMode = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
         overlayView?.isDarkTheme = isNightMode
+        updateState()
     }
 
     fun updateState() {
@@ -171,17 +181,41 @@ class DuoOverlayHandler(
             val screenHeight = displayMetrics.heightPixels.toFloat()
             val density = displayMetrics.density
 
+            var isFullscreenState = false
             var centerX = screenWidth * (settingsRepository.getDuoCameraOffsetX() / 100f)
             var centerY = screenHeight * (settingsRepository.getDuoCameraOffsetY() / 100f)
             var cameraRadiusPx = 18f * density * settingsRepository.getDuoCameraSize()
+
+            @Suppress("DEPRECATION")
+            val rotation = wm.defaultDisplay.rotation
 
             if (settingsRepository.isDuoAutoDetectEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 @Suppress("DEPRECATION")
                 val cutout = wm.defaultDisplay.cutout
                 if (cutout != null && cutout.boundingRects.isNotEmpty()) {
-                    // Find cutout rect closest to top center of screen
-                    val topCutouts = cutout.boundingRects.filter { it.top < screenHeight / 4 }
-                    val targetRect = topCutouts.minByOrNull { kotlin.math.abs(it.centerX() - screenWidth / 2f) }
+                    val targetRect = when (rotation) {
+                        android.view.Surface.ROTATION_90 -> {
+                            cutout.boundingRects.filter { it.left < screenWidth / 4 }
+                                .minByOrNull { kotlin.math.abs(it.centerY() - screenHeight / 2f) }
+                                ?: cutout.boundingRects.firstOrNull()
+                        }
+                        android.view.Surface.ROTATION_270 -> {
+                            cutout.boundingRects.filter { it.right > screenWidth * 0.75f }
+                                .minByOrNull { kotlin.math.abs(it.centerY() - screenHeight / 2f) }
+                                ?: cutout.boundingRects.firstOrNull()
+                        }
+                        android.view.Surface.ROTATION_180 -> {
+                            cutout.boundingRects.filter { it.bottom > screenHeight * 0.75f }
+                                .minByOrNull { kotlin.math.abs(it.centerX() - screenWidth / 2f) }
+                                ?: cutout.boundingRects.firstOrNull()
+                        }
+                        else -> {
+                            cutout.boundingRects.filter { it.top < screenHeight / 4 }
+                                .minByOrNull { kotlin.math.abs(it.centerX() - screenWidth / 2f) }
+                                ?: cutout.boundingRects.firstOrNull()
+                        }
+                    }
+
                     if (targetRect != null) {
                         centerX = targetRect.centerX().toFloat()
                         centerY = targetRect.centerY().toFloat()
@@ -189,6 +223,27 @@ class DuoOverlayHandler(
                         if (computedRadius > 0) {
                             cameraRadiusPx = computedRadius
                         }
+                    }
+                }
+            } else if (!settingsRepository.isDuoAutoDetectEnabled()) {
+                val rawXRatio = settingsRepository.getDuoCameraOffsetX() / 100f
+                val rawYRatio = settingsRepository.getDuoCameraOffsetY() / 100f
+                when (rotation) {
+                    android.view.Surface.ROTATION_90 -> {
+                        centerX = screenWidth * rawYRatio
+                        centerY = screenHeight * (1f - rawXRatio)
+                    }
+                    android.view.Surface.ROTATION_270 -> {
+                        centerX = screenWidth * (1f - rawYRatio)
+                        centerY = screenHeight * rawXRatio
+                    }
+                    android.view.Surface.ROTATION_180 -> {
+                        centerX = screenWidth * (1f - rawXRatio)
+                        centerY = screenHeight * (1f - rawYRatio)
+                    }
+                    else -> {
+                        centerX = screenWidth * rawXRatio
+                        centerY = screenHeight * rawYRatio
                     }
                 }
             }
@@ -208,6 +263,7 @@ class DuoOverlayHandler(
                 this.dotRadiusPx = settingsRepository.getDuoDotSize() * density
                 this.isDarkTheme = isNightMode
                 this.isScreenOff = this@DuoOverlayHandler.isScreenOff
+                this.isFullscreen = this@DuoOverlayHandler.isFullscreen
                 this.hideWhenScreenOff = settingsRepository.isDuoHideWhenScreenOffEnabled()
                 this.useMaterialYouColors = settingsRepository.isDuoUseMaterialYouEnabled()
                 this.showNetworks = settingsRepository.isDuoShowNetworksEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -208,6 +208,8 @@ class DuoOverlayHandler(
                 this.dotRadiusPx = settingsRepository.getDuoDotSize() * density
                 this.isDarkTheme = isNightMode
                 this.isScreenOff = this@DuoOverlayHandler.isScreenOff
+                this.hideWhenScreenOff = settingsRepository.isDuoHideWhenScreenOffEnabled()
+                this.useMaterialYouColors = settingsRepository.isDuoUseMaterialYouEnabled()
                 this.showNetworks = settingsRepository.isDuoShowNetworksEnabled()
             }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -109,7 +109,8 @@ class DuoOverlayHandler(
     }
 
     fun updateState() {
-        if (!settingsRepository.isDuoEnabled()) {
+        val isDevMode = settingsRepository.getBoolean(SettingsRepository.KEY_DEVELOPER_MODE_ENABLED, false)
+        if (!isDevMode || !settingsRepository.isDuoEnabled()) {
             removeOverlay()
             return
         }

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -93,6 +93,11 @@ class DuoOverlayHandler(
         updateState()
     }
 
+    fun onConfigurationChanged(newConfig: Configuration) {
+        val isNightMode = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        overlayView?.isDarkTheme = isNightMode
+    }
+
     fun updateState() {
         if (!settingsRepository.isDuoEnabled()) {
             removeOverlay()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -50,17 +50,23 @@ class DuoOverlayHandler(
     }
     private var isBatteryReceiverRegistered = false
 
+    private var isScreenOff: Boolean = false
+
     fun init() {
         windowManager = service.getSystemService(AccessibilityService.WINDOW_SERVICE) as? WindowManager
         updateState()
     }
 
     fun onScreenOn() {
+        isScreenOff = false
+        overlayView?.isScreenOff = false
         updateState()
     }
 
     fun onScreenOff() {
-        removeOverlay()
+        isScreenOff = true
+        overlayView?.isScreenOff = true
+        updateState()
     }
 
     fun updateState() {
@@ -118,6 +124,7 @@ class DuoOverlayHandler(
                 this.arcThicknessPx = settingsRepository.getDuoArcThickness() * density
                 this.dotRadiusPx = settingsRepository.getDuoDotSize() * density
                 this.isDarkTheme = isNightMode
+                this.isScreenOff = this@DuoOverlayHandler.isScreenOff
             }
 
             if (!isOverlayAdded) {

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -244,6 +244,7 @@ class ScreenOffAccessibilityService :
                 }
                 aodWallpaperOverlayHandler.updateState()
             } else if (key == SettingsRepository.KEY_DUO_ENABLED ||
+                key == SettingsRepository.KEY_DEVELOPER_MODE_ENABLED ||
                 key == SettingsRepository.KEY_DUO_USE_AUTO_DETECT ||
                 key == SettingsRepository.KEY_DUO_CAMERA_OFFSET_X ||
                 key == SettingsRepository.KEY_DUO_CAMERA_OFFSET_Y ||

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -251,7 +251,9 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_DUO_ARC_THICKNESS ||
                 key == SettingsRepository.KEY_DUO_DOT_SIZE ||
                 key == SettingsRepository.KEY_DUO_RING_RADIUS ||
-                key == SettingsRepository.KEY_DUO_SHOW_NETWORKS
+                key == SettingsRepository.KEY_DUO_SHOW_NETWORKS ||
+                key == SettingsRepository.KEY_DUO_HIDE_WHEN_SCREEN_OFF ||
+                key == SettingsRepository.KEY_DUO_USE_MATERIAL_YOU
             ) {
                 duoOverlayHandler.updateState()
             }

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -595,6 +595,7 @@ class ScreenOffAccessibilityService :
     override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
         super.onConfigurationChanged(newConfig)
         updateOmniOverlay() // Force refresh overlay on rotation
+        duoOverlayHandler.onConfigurationChanged(newConfig)
     }
 
     override fun onKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -36,6 +36,7 @@ import com.sameerasw.essentials.services.handlers.AodForceTurnOffHandler
 import com.sameerasw.essentials.services.handlers.AodWallpaperOverlayHandler
 import com.sameerasw.essentials.services.handlers.AppFlowHandler
 import com.sameerasw.essentials.services.handlers.ButtonRemapHandler
+import com.sameerasw.essentials.services.handlers.DuoOverlayHandler
 import com.sameerasw.essentials.services.handlers.FlashlightHandler
 import com.sameerasw.essentials.services.handlers.NotificationLightingHandler
 import com.sameerasw.essentials.services.handlers.OmniGestureOverlayHandler
@@ -69,6 +70,7 @@ class ScreenOffAccessibilityService :
     private lateinit var statusBarIconHandler: StatusBarIconHandler
     private lateinit var pocketModeHandler: PocketModeHandler
     private lateinit var smartPixelsHandler: com.sameerasw.essentials.services.handlers.SmartPixelsHandler
+    private lateinit var duoOverlayHandler: DuoOverlayHandler
 
     private var lightSensor: Sensor? = null
     private var lightSensorLux: Float = 100f
@@ -241,6 +243,16 @@ class ScreenOffAccessibilityService :
                     aodWallpaperOverlayHandler.invalidateWallpaperCache()
                 }
                 aodWallpaperOverlayHandler.updateState()
+            } else if (key == SettingsRepository.KEY_DUO_ENABLED ||
+                key == SettingsRepository.KEY_DUO_USE_AUTO_DETECT ||
+                key == SettingsRepository.KEY_DUO_CAMERA_OFFSET_X ||
+                key == SettingsRepository.KEY_DUO_CAMERA_OFFSET_Y ||
+                key == SettingsRepository.KEY_DUO_CAMERA_SIZE ||
+                key == SettingsRepository.KEY_DUO_ARC_THICKNESS ||
+                key == SettingsRepository.KEY_DUO_DOT_SIZE ||
+                key == SettingsRepository.KEY_DUO_RING_RADIUS
+            ) {
+                duoOverlayHandler.updateState()
             }
         }
 
@@ -262,10 +274,12 @@ class ScreenOffAccessibilityService :
         smartPixelsHandler =
             com.sameerasw.essentials.services.handlers
                 .SmartPixelsHandler(this)
+        duoOverlayHandler = DuoOverlayHandler(this)
 
         flashlightHandler.register()
         statusBarIconHandler.register()
         smartPixelsHandler.init()
+        duoOverlayHandler.init()
 
         // Screen Receiver
         screenReceiver =
@@ -281,6 +295,7 @@ class ScreenOffAccessibilityService :
                             ambientGlanceHandler.dismissImmediately()
                             aodForceTurnOffHandler.removeOverlay()
                             aodWallpaperOverlayHandler.onScreenOn()
+                            duoOverlayHandler.onScreenOn()
                             freezeHandler.removeCallbacks(freezeRunnable)
                             stopInputEventListener()
                             updateOmniOverlay()
@@ -294,6 +309,7 @@ class ScreenOffAccessibilityService :
                             startInputEventListenerIfEnabled()
                             ambientGlanceHandler.checkAndShowOnScreenOff()
                             aodWallpaperOverlayHandler.onScreenOff()
+                            duoOverlayHandler.onScreenOff()
                             omniGestureOverlayHandler.updateOverlay(false) // Always hide when screen is off
                             pocketModeHandler.onScreenOff()
                             updatePocketModeSensors()
@@ -389,6 +405,7 @@ class ScreenOffAccessibilityService :
                 flags = flags or AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS
             }
         updateOmniOverlay()
+        duoOverlayHandler.updateState()
     }
 
     private fun updateOmniOverlay() {
@@ -424,6 +441,7 @@ class ScreenOffAccessibilityService :
         pocketModeHandler.removeOverlay()
         omniGestureOverlayHandler.removeOverlay()
         smartPixelsHandler.destroy()
+        duoOverlayHandler.destroy()
         statusBarIconHandler.unregister()
         stopInputEventListener()
         cancelPocketFlashlightTurnOff()

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -471,8 +471,40 @@ class ScreenOffAccessibilityService :
         if (event == null) return
 
         if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-            val packageName = event.packageName?.toString() ?: return
-            appFlowHandler.onPackageChanged(packageName)
+            val packageName = event.packageName?.toString()
+            if (packageName != null) {
+                appFlowHandler.onPackageChanged(packageName)
+            }
+        }
+
+        if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
+            event.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED
+        ) {
+            checkFullscreenState()
+        }
+    }
+
+    private fun checkFullscreenState() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                val currentWindows = windows
+                if (!currentWindows.isNullOrEmpty()) {
+                    val hasStatusBar = currentWindows.any { it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_SYSTEM }
+                    val appWindow = currentWindows.firstOrNull { it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_APPLICATION && it.isFocused }
+                        ?: currentWindows.firstOrNull { it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_APPLICATION }
+
+                    if (appWindow != null) {
+                        val outBounds = android.graphics.Rect()
+                        appWindow.getBoundsInScreen(outBounds)
+                        val displayMetrics = resources.displayMetrics
+                        val isCoveringFullDisplay = outBounds.width() >= displayMetrics.widthPixels &&
+                            outBounds.height() >= displayMetrics.heightPixels
+
+                        val isFullscreen = isCoveringFullDisplay && !hasStatusBar
+                        duoOverlayHandler.setFullscreen(isFullscreen)
+                    }
+                }
+            } catch (_: Exception) {}
         }
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -250,7 +250,8 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_DUO_CAMERA_SIZE ||
                 key == SettingsRepository.KEY_DUO_ARC_THICKNESS ||
                 key == SettingsRepository.KEY_DUO_DOT_SIZE ||
-                key == SettingsRepository.KEY_DUO_RING_RADIUS
+                key == SettingsRepository.KEY_DUO_RING_RADIUS ||
+                key == SettingsRepository.KEY_DUO_SHOW_NETWORKS
             ) {
                 duoOverlayHandler.updateState()
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/FeatureSettingsActivity.kt
@@ -70,6 +70,7 @@ import com.sameerasw.essentials.ui.features.system.BatteryNotificationSettingsUI
 import com.sameerasw.essentials.ui.features.system.ButtonRemapSettingsUI
 import com.sameerasw.essentials.ui.features.system.CaffeinateSettingsUI
 import com.sameerasw.essentials.ui.features.system.CalendarSyncSettingsUI
+import com.sameerasw.essentials.ui.features.display.DuoSettingsUI
 import com.sameerasw.essentials.ui.features.system.DynamicNightLightSettingsUI
 import com.sameerasw.essentials.ui.features.system.EssentialsOnDisplaySettingsUI
 import com.sameerasw.essentials.ui.features.system.FlashlightPulseSettingsUI
@@ -603,7 +604,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                         viewModel.isEnableUnsupportedFeatures.value,
                                     ).filter { it.parentFeatureId == featureId }
                             if (children.isNotEmpty() && featureId != "Networks") {
-                                val sectionChildLists =
+                        val sectionChildLists =
                                     run {
                                         val childMap = children.associateBy { it.id }
                                         val definedSections =
@@ -611,6 +612,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                                 "Display" ->
                                                     listOf(
                                                         listOf(
+                                                            "Duo",
                                                             "Essentials On Display",
                                                             "Always on Display",
                                                             "Statusbar icons",
@@ -1140,6 +1142,14 @@ class FeatureSettingsActivity : AppCompatActivity() {
 
                                     "Maps power saving mode" -> {
                                         MapsPowerSavingSettingsUI(
+                                            viewModel = viewModel,
+                                            modifier = Modifier.padding(top = 16.dp),
+                                            highlightSetting = highlightSetting,
+                                        )
+                                    }
+
+                                    "Duo" -> {
+                                        DuoSettingsUI(
                                             viewModel = viewModel,
                                             modifier = Modifier.padding(top = 16.dp),
                                             highlightSetting = highlightSetting,

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
@@ -240,5 +240,40 @@ fun DuoSettingsUI(
                 modifier = Modifier.highlight(highlightSetting == "duo_show_networks"),
             )
         }
+
+        Text(
+            text = stringResource(R.string.duo_section_behavior),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_palette_24,
+                title = stringResource(R.string.duo_material_you_title),
+                description = stringResource(R.string.duo_material_you_desc),
+                isChecked = viewModel.isDuoUseMaterialYou.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    viewModel.setDuoUseMaterialYou(checked)
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_use_material_you"),
+            )
+            IconToggleItem(
+                iconRes = R.drawable.rounded_mobile_off_24,
+                title = stringResource(R.string.duo_hide_when_screen_off_title),
+                description = stringResource(R.string.duo_hide_when_screen_off_desc),
+                isChecked = viewModel.isDuoHideWhenScreenOff.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    viewModel.setDuoHideWhenScreenOff(checked)
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_hide_when_screen_off"),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Feature - Display
+ * File: DuoSettingsUI.kt
+ * Description: UI settings composable for Duo ambient camera indicator feature.
+ */
+
+package com.sameerasw.essentials.ui.features.display
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
+import com.sameerasw.essentials.ui.core.cards.IconToggleItem
+import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
+import com.sameerasw.essentials.ui.modifiers.highlight
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.utils.PermissionUIHelper
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun DuoSettingsUI(
+    viewModel: MainViewModel,
+    modifier: Modifier = Modifier,
+    highlightSetting: String? = null,
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.check(context)
+    }
+
+    if (requestingPermissionsFor != null) {
+        val (featureTitle, permKeys) = requestingPermissionsFor!!
+        val permissionItems = PermissionUIHelper.getPermissionItems(permKeys, context, viewModel)
+        PermissionsBottomSheet(
+            onDismissRequest = {
+                requestingPermissionsFor = null
+                viewModel.check(context)
+            },
+            featureTitle = featureTitle,
+            permissions = permissionItems,
+        )
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_motion_play_24,
+                title = stringResource(R.string.duo_enable_title),
+                description = stringResource(R.string.duo_enable_desc),
+                isChecked = viewModel.isDuoEnabled.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    if (checked && !viewModel.isAccessibilityEnabled.value) {
+                        requestingPermissionsFor = Pair(R.string.duo_title, listOf("ACCESSIBILITY"))
+                    } else {
+                        viewModel.setDuoEnabled(checked)
+                    }
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_enabled"),
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.duo_section_position),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_center_focus_strong_24,
+                title = stringResource(R.string.duo_auto_detect_title),
+                description = stringResource(R.string.duo_auto_detect_desc),
+                isChecked = viewModel.isDuoAutoDetect.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    viewModel.setDuoAutoDetect(checked)
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_use_auto_detect"),
+            )
+
+            AnimatedVisibility(
+                visible = !viewModel.isDuoAutoDetect.value,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically(),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    ConfigSliderItem(
+                        title = stringResource(R.string.duo_camera_offset_x_title),
+                        value = viewModel.duoCameraOffsetX.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setDuoCameraOffsetX(it)
+                        },
+                        valueRange = 0f..100f,
+                        increment = 1f,
+                        iconRes = R.drawable.rounded_border_left_24,
+                        valueFormatter = { "${it.toInt()}%" },
+                    )
+                    ConfigSliderItem(
+                        title = stringResource(R.string.duo_camera_offset_y_title),
+                        value = viewModel.duoCameraOffsetY.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setDuoCameraOffsetY(it)
+                        },
+                        valueRange = 0f..20f,
+                        increment = 0.5f,
+                        iconRes = R.drawable.rounded_border_top_24,
+                        valueFormatter = { "%.1f%%".format(it) },
+                    )
+                }
+            }
+
+            ConfigSliderItem(
+                title = stringResource(R.string.duo_camera_size_title),
+                value = viewModel.duoCameraSize.floatValue,
+                onValueChange = {
+                    HapticUtil.performUIHaptic(view)
+                    viewModel.setDuoCameraSize(it)
+                },
+                valueRange = 0.2f..2.0f,
+                increment = 0.05f,
+                iconRes = R.drawable.rounded_arrows_outward_24,
+                valueFormatter = { "%.2fx".format(it) },
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.duo_section_style),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            ConfigSliderItem(
+                title = stringResource(R.string.duo_ring_radius_title),
+                value = viewModel.duoRingRadius.floatValue,
+                onValueChange = {
+                    HapticUtil.performUIHaptic(view)
+                    viewModel.setDuoRingRadius(it)
+                },
+                valueRange = 0.4f..1.6f,
+                increment = 0.05f,
+                iconRes = R.drawable.rounded_circle_24,
+                valueFormatter = { "%.2fx".format(it) },
+            )
+            ConfigSliderItem(
+                title = stringResource(R.string.duo_arc_thickness_title),
+                value = viewModel.duoArcThickness.floatValue,
+                onValueChange = {
+                    HapticUtil.performUIHaptic(view)
+                    viewModel.setDuoArcThickness(it)
+                },
+                valueRange = 2f..10f,
+                increment = 0.5f,
+                iconRes = R.drawable.rounded_line_weight_24,
+                valueFormatter = { "${it.toInt()} dp" },
+            )
+            ConfigSliderItem(
+                title = stringResource(R.string.duo_dot_size_title),
+                value = viewModel.duoDotSize.floatValue,
+                onValueChange = {
+                    HapticUtil.performUIHaptic(view)
+                    viewModel.setDuoDotSize(it)
+                },
+                valueRange = 2f..8f,
+                increment = 0.5f,
+                iconRes = R.drawable.rounded_circles_24,
+                valueFormatter = { "${it.toInt()} dp" },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
@@ -216,5 +216,29 @@ fun DuoSettingsUI(
                 valueFormatter = { "${it.toInt()} dp" },
             )
         }
+
+        Text(
+            text = stringResource(R.string.duo_section_what_to_show),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            IconToggleItem(
+                iconRes = R.drawable.rounded_signal_cellular_alt_24,
+                title = stringResource(R.string.duo_show_networks_title),
+                description = stringResource(R.string.duo_show_networks_desc),
+                isChecked = viewModel.isDuoShowNetworks.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    viewModel.setDuoShowNetworks(checked)
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_show_networks"),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -67,16 +67,18 @@ class DuoOverlayView(context: Context) : View(context) {
 
     var isDarkTheme: Boolean = true
         set(value) {
-            field = value
-            updateColors()
-            invalidate()
+            if (field != value) {
+                field = value
+                animateThemeChange()
+            }
         }
 
     var isScreenOff: Boolean = false
         set(value) {
-            field = value
-            updateColors()
-            invalidate()
+            if (field != value) {
+                field = value
+                animateThemeChange()
+            }
         }
 
     var showNetworks: Boolean = true
@@ -108,6 +110,57 @@ class DuoOverlayView(context: Context) : View(context) {
     private var animatedScaleBounce: Float = 1.0f
     private var layoutAnimator: android.animation.ValueAnimator? = null
     private var scaleAnimator: android.animation.ValueAnimator? = null
+
+    private var currentTrackColor: Int = Color.argb(60, 255, 255, 255)
+    private var currentProgressColor: Int = Color.WHITE
+    private var currentDotBaseColor: Int = Color.WHITE
+    private var themeAnimator: android.animation.ValueAnimator? = null
+
+    private fun getTargetColors(): Triple<Int, Int, Int> {
+        return if (isScreenOff) {
+            Triple(
+                Color.argb(40, 255, 255, 255),
+                Color.argb(128, 255, 255, 255),
+                Color.argb(128, 255, 255, 255)
+            )
+        } else if (isDarkTheme) {
+            Triple(
+                Color.argb(60, 255, 255, 255),
+                Color.WHITE,
+                Color.WHITE
+            )
+        } else {
+            Triple(
+                Color.argb(60, 0, 0, 0),
+                Color.BLACK,
+                Color.BLACK
+            )
+        }
+    }
+
+    private fun animateThemeChange() {
+        themeAnimator?.cancel()
+        val (targetTrack, targetProgress, targetDot) = getTargetColors()
+        val startTrack = currentTrackColor
+        val startProgress = currentProgressColor
+        val startDot = currentDotBaseColor
+        val evaluator = android.animation.ArgbEvaluator()
+
+        themeAnimator = android.animation.ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 600
+            interpolator = android.view.animation.DecelerateInterpolator()
+            addUpdateListener { animation ->
+                val fraction = animation.animatedFraction
+                currentTrackColor = evaluator.evaluate(fraction, startTrack, targetTrack) as Int
+                currentProgressColor = evaluator.evaluate(fraction, startProgress, targetProgress) as Int
+                currentDotBaseColor = evaluator.evaluate(fraction, startDot, targetDot) as Int
+                trackPaint.color = currentTrackColor
+                progressPaint.color = currentProgressColor
+                invalidate()
+            }
+            start()
+        }
+    }
 
     private fun animateSignalLevelChange(targetLevel: Float) {
         signalAnimator?.cancel()
@@ -189,23 +242,12 @@ class DuoOverlayView(context: Context) : View(context) {
 
     init {
         setLayerType(LAYER_TYPE_SOFTWARE, null)
-        updateColors()
-    }
-
-    private fun updateColors() {
-        if (isScreenOff) {
-            trackPaint.color = Color.argb(40, 255, 255, 255)
-            progressPaint.color = Color.argb(128, 255, 255, 255)
-            dotPaint.color = Color.argb((128 * animatedDotAlpha).toInt(), 255, 255, 255)
-        } else if (isDarkTheme) {
-            trackPaint.color = Color.argb(60, 255, 255, 255)
-            progressPaint.color = Color.WHITE
-            dotPaint.color = Color.argb((255 * animatedDotAlpha).toInt(), 255, 255, 255)
-        } else {
-            trackPaint.color = Color.argb(60, 0, 0, 0)
-            progressPaint.color = Color.BLACK
-            dotPaint.color = Color.argb((255 * animatedDotAlpha).toInt(), 0, 0, 0)
-        }
+        val (track, progress, dot) = getTargetColors()
+        currentTrackColor = track
+        currentProgressColor = progress
+        currentDotBaseColor = dot
+        trackPaint.color = currentTrackColor
+        progressPaint.color = currentProgressColor
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -221,8 +263,6 @@ class DuoOverlayView(context: Context) : View(context) {
             cameraCenterY + baseRadius
         )
 
-        updateColors()
-
         canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, trackPaint)
 
         val progressSweep = (animatedBatteryProgress / 100f) * animatedTotalSweep
@@ -232,17 +272,10 @@ class DuoOverlayView(context: Context) : View(context) {
 
         if (animatedDotAlpha > 0.01f) {
             val dotAngles = floatArrayOf(120f, 100f, 80f, 60f)
-            val baseDotColor = if (isScreenOff) {
-                Color.argb(128, 255, 255, 255)
-            } else if (isDarkTheme) {
-                Color.WHITE
-            } else {
-                Color.BLACK
-            }
-            val baseAlpha = Color.alpha(baseDotColor)
-            val red = Color.red(baseDotColor)
-            val green = Color.green(baseDotColor)
-            val blue = Color.blue(baseDotColor)
+            val baseAlpha = Color.alpha(currentDotBaseColor)
+            val red = Color.red(currentDotBaseColor)
+            val green = Color.green(currentDotBaseColor)
+            val blue = Color.blue(currentDotBaseColor)
 
             for (i in dotAngles.indices) {
                 val angleDeg = dotAngles[i]
@@ -266,6 +299,7 @@ class DuoOverlayView(context: Context) : View(context) {
         signalAnimator?.cancel()
         layoutAnimator?.cancel()
         scaleAnimator?.cancel()
+        themeAnimator?.cancel()
     }
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -79,8 +79,21 @@ class DuoOverlayView(context: Context) : View(context) {
             invalidate()
         }
 
+    var showNetworks: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                animateLayoutChange(value)
+            }
+        }
+
     private var animatedBatteryProgress: Float = 100f
     private var batteryAnimator: android.animation.ValueAnimator? = null
+
+    private var animatedStartAngle: Float = 140f
+    private var animatedTotalSweep: Float = 260f
+    private var animatedDotAlpha: Float = 1.0f
+    private var layoutAnimator: android.animation.ValueAnimator? = null
 
     private fun animateBatteryChange(targetLevel: Float) {
         batteryAnimator?.cancel()
@@ -89,6 +102,30 @@ class DuoOverlayView(context: Context) : View(context) {
             interpolator = android.view.animation.DecelerateInterpolator()
             addUpdateListener { animation ->
                 animatedBatteryProgress = animation.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    private fun animateLayoutChange(showingNetworks: Boolean) {
+        layoutAnimator?.cancel()
+        val targetStartAngle = if (showingNetworks) 140f else -90f
+        val targetTotalSweep = if (showingNetworks) 260f else 360f
+        val targetDotAlpha = if (showingNetworks) 1.0f else 0.0f
+
+        val startStartAngle = animatedStartAngle
+        val startTotalSweep = animatedTotalSweep
+        val startDotAlpha = animatedDotAlpha
+
+        layoutAnimator = android.animation.ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 500
+            interpolator = android.view.animation.DecelerateInterpolator()
+            addUpdateListener { animation ->
+                val fraction = animation.animatedFraction
+                animatedStartAngle = startStartAngle + (targetStartAngle - startStartAngle) * fraction
+                animatedTotalSweep = startTotalSweep + (targetTotalSweep - startTotalSweep) * fraction
+                animatedDotAlpha = startDotAlpha + (targetDotAlpha - startDotAlpha) * fraction
                 invalidate()
             }
             start()
@@ -120,15 +157,15 @@ class DuoOverlayView(context: Context) : View(context) {
         if (isScreenOff) {
             trackPaint.color = Color.argb(40, 255, 255, 255)
             progressPaint.color = Color.argb(128, 255, 255, 255)
-            dotPaint.color = Color.argb(128, 255, 255, 255)
+            dotPaint.color = Color.argb((128 * animatedDotAlpha).toInt(), 255, 255, 255)
         } else if (isDarkTheme) {
             trackPaint.color = Color.argb(60, 255, 255, 255)
             progressPaint.color = Color.WHITE
-            dotPaint.color = Color.WHITE
+            dotPaint.color = Color.argb((255 * animatedDotAlpha).toInt(), 255, 255, 255)
         } else {
             trackPaint.color = Color.argb(60, 0, 0, 0)
             progressPaint.color = Color.BLACK
-            dotPaint.color = Color.BLACK
+            dotPaint.color = Color.argb((255 * animatedDotAlpha).toInt(), 0, 0, 0)
         }
     }
 
@@ -145,28 +182,30 @@ class DuoOverlayView(context: Context) : View(context) {
             cameraCenterY + baseRadius
         )
 
-        val startAngle = 140f
-        val totalSweep = 260f
+        updateColors()
 
-        canvas.drawArc(arcBounds, startAngle, totalSweep, false, trackPaint)
+        canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, trackPaint)
 
-        val progressSweep = (animatedBatteryProgress / 100f) * totalSweep
+        val progressSweep = (animatedBatteryProgress / 100f) * animatedTotalSweep
         if (progressSweep > 0.5f) {
-            canvas.drawArc(arcBounds, startAngle, progressSweep, false, progressPaint)
+            canvas.drawArc(arcBounds, animatedStartAngle, progressSweep, false, progressPaint)
         }
 
-        val dotAngles = floatArrayOf(60f, 80f, 100f, 120f)
-        for (angleDeg in dotAngles) {
-            val angleRad = Math.toRadians(angleDeg.toDouble())
-            val dotX = (cameraCenterX + baseRadius * cos(angleRad)).toFloat()
-            val dotY = (cameraCenterY + baseRadius * sin(angleRad)).toFloat()
-            canvas.drawCircle(dotX, dotY, dotRadiusPx, dotPaint)
+        if (animatedDotAlpha > 0.01f) {
+            val dotAngles = floatArrayOf(60f, 80f, 100f, 120f)
+            for (angleDeg in dotAngles) {
+                val angleRad = Math.toRadians(angleDeg.toDouble())
+                val dotX = (cameraCenterX + baseRadius * cos(angleRad)).toFloat()
+                val dotY = (cameraCenterY + baseRadius * sin(angleRad)).toFloat()
+                canvas.drawCircle(dotX, dotY, dotRadiusPx, dotPaint)
+            }
         }
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         batteryAnimator?.cancel()
+        layoutAnimator?.cancel()
     }
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -79,11 +79,15 @@ class DuoOverlayView(context: Context) : View(context) {
         set(value) {
             if (field != value) {
                 field = value
-                if (hideWhenScreenOff) {
-                    animateScreenOffVisibility(!value)
-                } else {
-                    animateThemeChange()
-                }
+                updateVisibilityAnimation()
+            }
+        }
+
+    var isFullscreen: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityAnimation()
             }
         }
 
@@ -91,11 +95,19 @@ class DuoOverlayView(context: Context) : View(context) {
         set(value) {
             if (field != value) {
                 field = value
-                if (isScreenOff) {
-                    animateScreenOffVisibility(!value)
-                }
+                updateVisibilityAnimation()
             }
         }
+
+    private fun updateVisibilityAnimation() {
+        val shouldHide = isFullscreen || (isScreenOff && hideWhenScreenOff)
+        if (shouldHide) {
+            animateScreenOffVisibility(false)
+        } else {
+            animateScreenOffVisibility(true)
+            animateThemeChange()
+        }
+    }
 
     var useMaterialYouColors: Boolean = true
         set(value) {

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -93,13 +93,15 @@ class DuoOverlayView(context: Context) : View(context) {
     private var animatedStartAngle: Float = 140f
     private var animatedTotalSweep: Float = 260f
     private var animatedDotAlpha: Float = 1.0f
+    private var animatedScaleBounce: Float = 1.0f
     private var layoutAnimator: android.animation.ValueAnimator? = null
+    private var scaleAnimator: android.animation.ValueAnimator? = null
 
     private fun animateBatteryChange(targetLevel: Float) {
         batteryAnimator?.cancel()
         batteryAnimator = android.animation.ValueAnimator.ofFloat(animatedBatteryProgress, targetLevel).apply {
-            duration = 600
-            interpolator = android.view.animation.DecelerateInterpolator()
+            duration = 900
+            interpolator = android.view.animation.OvershootInterpolator(1.1f)
             addUpdateListener { animation ->
                 animatedBatteryProgress = animation.animatedValue as Float
                 invalidate()
@@ -110,6 +112,8 @@ class DuoOverlayView(context: Context) : View(context) {
 
     private fun animateLayoutChange(showingNetworks: Boolean) {
         layoutAnimator?.cancel()
+        scaleAnimator?.cancel()
+
         val targetStartAngle = if (showingNetworks) 140f else -90f
         val targetTotalSweep = if (showingNetworks) 260f else 360f
         val targetDotAlpha = if (showingNetworks) 1.0f else 0.0f
@@ -119,13 +123,23 @@ class DuoOverlayView(context: Context) : View(context) {
         val startDotAlpha = animatedDotAlpha
 
         layoutAnimator = android.animation.ValueAnimator.ofFloat(0f, 1f).apply {
-            duration = 500
-            interpolator = android.view.animation.DecelerateInterpolator()
+            duration = 850
+            interpolator = android.view.animation.OvershootInterpolator(1.15f)
             addUpdateListener { animation ->
                 val fraction = animation.animatedFraction
                 animatedStartAngle = startStartAngle + (targetStartAngle - startStartAngle) * fraction
                 animatedTotalSweep = startTotalSweep + (targetTotalSweep - startTotalSweep) * fraction
-                animatedDotAlpha = startDotAlpha + (targetDotAlpha - startDotAlpha) * fraction
+                animatedDotAlpha = (startDotAlpha + (targetDotAlpha - startDotAlpha) * fraction).coerceIn(0f, 1f)
+                invalidate()
+            }
+            start()
+        }
+
+        scaleAnimator = android.animation.ValueAnimator.ofFloat(1.0f, 1.04f, 1.0f).apply {
+            duration = 850
+            interpolator = android.view.animation.OvershootInterpolator(1.1f)
+            addUpdateListener { animation ->
+                animatedScaleBounce = animation.animatedValue as Float
                 invalidate()
             }
             start()
@@ -173,7 +187,7 @@ class DuoOverlayView(context: Context) : View(context) {
         super.onDraw(canvas)
         if (cameraCenterX <= 0 && cameraCenterY <= 0) return
 
-        val baseRadius = (cameraRadiusPx + 14f * resources.displayMetrics.density) * ringRadiusScale
+        val baseRadius = (cameraRadiusPx + 14f * resources.displayMetrics.density) * ringRadiusScale * animatedScaleBounce
         val strokeHalf = arcThicknessPx / 2f
         arcBounds.set(
             cameraCenterX - baseRadius,
@@ -197,7 +211,7 @@ class DuoOverlayView(context: Context) : View(context) {
                 val angleRad = Math.toRadians(angleDeg.toDouble())
                 val dotX = (cameraCenterX + baseRadius * cos(angleRad)).toFloat()
                 val dotY = (cameraCenterY + baseRadius * sin(angleRad)).toFloat()
-                canvas.drawCircle(dotX, dotY, dotRadiusPx, dotPaint)
+                canvas.drawCircle(dotX, dotY, dotRadiusPx * animatedDotAlpha, dotPaint)
             }
         }
     }
@@ -206,6 +220,7 @@ class DuoOverlayView(context: Context) : View(context) {
         super.onDetachedFromWindow()
         batteryAnimator?.cancel()
         layoutAnimator?.cancel()
+        scaleAnimator?.cancel()
     }
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -14,7 +14,9 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
+import android.os.Build
 import android.view.View
+import androidx.core.content.ContextCompat
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -77,6 +79,28 @@ class DuoOverlayView(context: Context) : View(context) {
         set(value) {
             if (field != value) {
                 field = value
+                if (hideWhenScreenOff) {
+                    animateScreenOffVisibility(!value)
+                } else {
+                    animateThemeChange()
+                }
+            }
+        }
+
+    var hideWhenScreenOff: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                if (isScreenOff) {
+                    animateScreenOffVisibility(!value)
+                }
+            }
+        }
+
+    var useMaterialYouColors: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
                 animateThemeChange()
             }
         }
@@ -111,19 +135,69 @@ class DuoOverlayView(context: Context) : View(context) {
     private var layoutAnimator: android.animation.ValueAnimator? = null
     private var scaleAnimator: android.animation.ValueAnimator? = null
 
+    private var animatedVisibilityAlpha: Float = 1.0f
+    private var animatedVisibilityScale: Float = 1.0f
+    private var animatedVisibilityRotation: Float = 0f
+    private var visibilityAnimator: android.animation.ValueAnimator? = null
+
     private var currentTrackColor: Int = Color.argb(60, 255, 255, 255)
     private var currentProgressColor: Int = Color.WHITE
     private var currentDotBaseColor: Int = Color.WHITE
     private var themeAnimator: android.animation.ValueAnimator? = null
 
+    private fun animateScreenOffVisibility(visible: Boolean) {
+        visibilityAnimator?.cancel()
+        val startAlpha = animatedVisibilityAlpha
+        val targetAlpha = if (visible) 1.0f else 0.0f
+
+        val startScale = animatedVisibilityScale
+        val targetScale = if (visible) 1.0f else 0.35f
+
+        val startRotation = animatedVisibilityRotation
+        val targetRotation = if (visible) 0f else -65f
+
+        visibilityAnimator = android.animation.ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 750
+            interpolator = if (visible) {
+                android.view.animation.OvershootInterpolator(1.15f)
+            } else {
+                android.view.animation.DecelerateInterpolator()
+            }
+            addUpdateListener { animation ->
+                val fraction = animation.animatedFraction
+                animatedVisibilityAlpha = (startAlpha + (targetAlpha - startAlpha) * fraction).coerceIn(0f, 1f)
+                animatedVisibilityScale = (startScale + (targetScale - startScale) * fraction).coerceAtLeast(0.01f)
+                animatedVisibilityRotation = startRotation + (targetRotation - startRotation) * fraction
+                invalidate()
+            }
+            start()
+        }
+    }
+
     private fun getTargetColors(): Triple<Int, Int, Int> {
-        return if (isScreenOff) {
-            Triple(
+        if (isScreenOff) {
+            return Triple(
                 Color.argb(40, 255, 255, 255),
                 Color.argb(128, 255, 255, 255),
                 Color.argb(128, 255, 255, 255)
             )
-        } else if (isDarkTheme) {
+        }
+
+        if (useMaterialYouColors && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return if (isDarkTheme) {
+                val accent = ContextCompat.getColor(context, android.R.color.system_accent1_200)
+                val track = ContextCompat.getColor(context, android.R.color.system_neutral1_800)
+                val trackWithAlpha = Color.argb(90, Color.red(track), Color.green(track), Color.blue(track))
+                Triple(trackWithAlpha, accent, accent)
+            } else {
+                val accent = ContextCompat.getColor(context, android.R.color.system_accent1_600)
+                val track = ContextCompat.getColor(context, android.R.color.system_neutral1_200)
+                val trackWithAlpha = Color.argb(110, Color.red(track), Color.green(track), Color.blue(track))
+                Triple(trackWithAlpha, accent, accent)
+            }
+        }
+
+        return if (isDarkTheme) {
             Triple(
                 Color.argb(60, 255, 255, 255),
                 Color.WHITE,
@@ -253,9 +327,9 @@ class DuoOverlayView(context: Context) : View(context) {
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         if (cameraCenterX <= 0 && cameraCenterY <= 0) return
+        if (animatedVisibilityAlpha <= 0.005f) return
 
         val baseRadius = (cameraRadiusPx + 14f * resources.displayMetrics.density) * ringRadiusScale * animatedScaleBounce
-        val strokeHalf = arcThicknessPx / 2f
         arcBounds.set(
             cameraCenterX - baseRadius,
             cameraCenterY - baseRadius,
@@ -263,10 +337,30 @@ class DuoOverlayView(context: Context) : View(context) {
             cameraCenterY + baseRadius
         )
 
+        canvas.save()
+        canvas.translate(cameraCenterX, cameraCenterY)
+        canvas.rotate(animatedVisibilityRotation)
+        canvas.scale(animatedVisibilityScale, animatedVisibilityScale)
+        canvas.translate(-cameraCenterX, -cameraCenterY)
+
+        val trackAlpha = (Color.alpha(currentTrackColor) * animatedVisibilityAlpha).toInt()
+        trackPaint.color = Color.argb(
+            trackAlpha,
+            Color.red(currentTrackColor),
+            Color.green(currentTrackColor),
+            Color.blue(currentTrackColor)
+        )
         canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, trackPaint)
 
         val progressSweep = (animatedBatteryProgress / 100f) * animatedTotalSweep
         if (progressSweep > 0.5f) {
+            val progAlpha = (Color.alpha(currentProgressColor) * animatedVisibilityAlpha).toInt()
+            progressPaint.color = Color.argb(
+                progAlpha,
+                Color.red(currentProgressColor),
+                Color.green(currentProgressColor),
+                Color.blue(currentProgressColor)
+            )
             canvas.drawArc(arcBounds, animatedStartAngle, progressSweep, false, progressPaint)
         }
 
@@ -285,12 +379,14 @@ class DuoOverlayView(context: Context) : View(context) {
 
                 // Signal level from 0..4 smoothly determines opacity of each dot (dot 0: 0..1, dot 1: 1..2, etc.)
                 val dotActiveFraction = (animatedSignalLevel - i).coerceIn(0f, 1f)
-                val dotOpacity = (0.22f + 0.78f * dotActiveFraction) * animatedDotAlpha
+                val dotOpacity = (0.22f + 0.78f * dotActiveFraction) * animatedDotAlpha * animatedVisibilityAlpha
                 dotPaint.color = Color.argb((baseAlpha * dotOpacity).toInt(), red, green, blue)
 
                 canvas.drawCircle(dotX, dotY, dotRadiusPx * animatedDotAlpha, dotPaint)
             }
         }
+
+        canvas.restore()
     }
 
     override fun onDetachedFromWindow() {
@@ -300,6 +396,7 @@ class DuoOverlayView(context: Context) : View(context) {
         layoutAnimator?.cancel()
         scaleAnimator?.cancel()
         themeAnimator?.cancel()
+        visibilityAnimator?.cancel()
     }
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -60,8 +60,9 @@ class DuoOverlayView(context: Context) : View(context) {
 
     var batteryLevel: Int = 100
         set(value) {
-            field = value.coerceIn(0, 100)
-            invalidate()
+            val clamped = value.coerceIn(0, 100)
+            field = clamped
+            animateBatteryChange(clamped.toFloat())
         }
 
     var isDarkTheme: Boolean = true
@@ -70,6 +71,29 @@ class DuoOverlayView(context: Context) : View(context) {
             updateColors()
             invalidate()
         }
+
+    var isScreenOff: Boolean = false
+        set(value) {
+            field = value
+            updateColors()
+            invalidate()
+        }
+
+    private var animatedBatteryProgress: Float = 100f
+    private var batteryAnimator: android.animation.ValueAnimator? = null
+
+    private fun animateBatteryChange(targetLevel: Float) {
+        batteryAnimator?.cancel()
+        batteryAnimator = android.animation.ValueAnimator.ofFloat(animatedBatteryProgress, targetLevel).apply {
+            duration = 600
+            interpolator = android.view.animation.DecelerateInterpolator()
+            addUpdateListener { animation ->
+                animatedBatteryProgress = animation.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
 
     private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
@@ -93,7 +117,11 @@ class DuoOverlayView(context: Context) : View(context) {
     }
 
     private fun updateColors() {
-        if (isDarkTheme) {
+        if (isScreenOff) {
+            trackPaint.color = Color.argb(40, 255, 255, 255)
+            progressPaint.color = Color.argb(128, 255, 255, 255)
+            dotPaint.color = Color.argb(128, 255, 255, 255)
+        } else if (isDarkTheme) {
             trackPaint.color = Color.argb(60, 255, 255, 255)
             progressPaint.color = Color.WHITE
             dotPaint.color = Color.WHITE
@@ -122,7 +150,7 @@ class DuoOverlayView(context: Context) : View(context) {
 
         canvas.drawArc(arcBounds, startAngle, totalSweep, false, trackPaint)
 
-        val progressSweep = (batteryLevel / 100f) * totalSweep
+        val progressSweep = (animatedBatteryProgress / 100f) * totalSweep
         if (progressSweep > 0.5f) {
             canvas.drawArc(arcBounds, startAngle, progressSweep, false, progressPaint)
         }
@@ -135,4 +163,10 @@ class DuoOverlayView(context: Context) : View(context) {
             canvas.drawCircle(dotX, dotY, dotRadiusPx, dotPaint)
         }
     }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        batteryAnimator?.cancel()
+    }
 }
+

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -87,7 +87,7 @@ class DuoOverlayView(context: Context) : View(context) {
             }
         }
 
-    var hideWhenScreenOff: Boolean = false
+    var hideWhenScreenOff: Boolean = true
         set(value) {
             if (field != value) {
                 field = value

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Utilities - Overlays
+ * File: DuoOverlayView.kt
+ * Description: Ambient camera ring and dots overlay view.
+ */
+
+package com.sameerasw.essentials.utils
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.view.View
+import kotlin.math.cos
+import kotlin.math.sin
+
+class DuoOverlayView(context: Context) : View(context) {
+
+    var cameraCenterX: Float = 0f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var cameraCenterY: Float = 0f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var cameraRadiusPx: Float = 36f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var ringRadiusScale: Float = 1.0f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var arcThicknessPx: Float = 10f
+        set(value) {
+            field = value
+            trackPaint.strokeWidth = value
+            progressPaint.strokeWidth = value
+            invalidate()
+        }
+
+    var dotRadiusPx: Float = 5f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var batteryLevel: Int = 100
+        set(value) {
+            field = value.coerceIn(0, 100)
+            invalidate()
+        }
+
+    var isDarkTheme: Boolean = true
+        set(value) {
+            field = value
+            updateColors()
+            invalidate()
+        }
+
+    private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+    }
+
+    private val progressPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+    }
+
+    private val dotPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val arcBounds = RectF()
+
+    init {
+        setLayerType(LAYER_TYPE_SOFTWARE, null)
+        updateColors()
+    }
+
+    private fun updateColors() {
+        if (isDarkTheme) {
+            trackPaint.color = Color.argb(60, 255, 255, 255)
+            progressPaint.color = Color.WHITE
+            dotPaint.color = Color.WHITE
+        } else {
+            trackPaint.color = Color.argb(60, 0, 0, 0)
+            progressPaint.color = Color.BLACK
+            dotPaint.color = Color.BLACK
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (cameraCenterX <= 0 && cameraCenterY <= 0) return
+
+        val baseRadius = (cameraRadiusPx + 14f * resources.displayMetrics.density) * ringRadiusScale
+        val strokeHalf = arcThicknessPx / 2f
+        arcBounds.set(
+            cameraCenterX - baseRadius,
+            cameraCenterY - baseRadius,
+            cameraCenterX + baseRadius,
+            cameraCenterY + baseRadius
+        )
+
+        val startAngle = 140f
+        val totalSweep = 260f
+
+        canvas.drawArc(arcBounds, startAngle, totalSweep, false, trackPaint)
+
+        val progressSweep = (batteryLevel / 100f) * totalSweep
+        if (progressSweep > 0.5f) {
+            canvas.drawArc(arcBounds, startAngle, progressSweep, false, progressPaint)
+        }
+
+        val dotAngles = floatArrayOf(60f, 80f, 100f, 120f)
+        for (angleDeg in dotAngles) {
+            val angleRad = Math.toRadians(angleDeg.toDouble())
+            val dotX = (cameraCenterX + baseRadius * cos(angleRad)).toFloat()
+            val dotY = (cameraCenterY + baseRadius * sin(angleRad)).toFloat()
+            canvas.drawCircle(dotX, dotY, dotRadiusPx, dotPaint)
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -87,8 +87,20 @@ class DuoOverlayView(context: Context) : View(context) {
             }
         }
 
+    var signalLevel: Int = 4
+        set(value) {
+            val clamped = value.coerceIn(0, 4)
+            if (field != clamped) {
+                field = clamped
+                animateSignalLevelChange(clamped.toFloat())
+            }
+        }
+
     private var animatedBatteryProgress: Float = 100f
     private var batteryAnimator: android.animation.ValueAnimator? = null
+
+    private var animatedSignalLevel: Float = 4f
+    private var signalAnimator: android.animation.ValueAnimator? = null
 
     private var animatedStartAngle: Float = 140f
     private var animatedTotalSweep: Float = 260f
@@ -96,6 +108,19 @@ class DuoOverlayView(context: Context) : View(context) {
     private var animatedScaleBounce: Float = 1.0f
     private var layoutAnimator: android.animation.ValueAnimator? = null
     private var scaleAnimator: android.animation.ValueAnimator? = null
+
+    private fun animateSignalLevelChange(targetLevel: Float) {
+        signalAnimator?.cancel()
+        signalAnimator = android.animation.ValueAnimator.ofFloat(animatedSignalLevel, targetLevel).apply {
+            duration = 750
+            interpolator = android.view.animation.OvershootInterpolator(1.1f)
+            addUpdateListener { animation ->
+                animatedSignalLevel = animation.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
 
     private fun animateBatteryChange(targetLevel: Float) {
         batteryAnimator?.cancel()
@@ -206,11 +231,30 @@ class DuoOverlayView(context: Context) : View(context) {
         }
 
         if (animatedDotAlpha > 0.01f) {
-            val dotAngles = floatArrayOf(60f, 80f, 100f, 120f)
-            for (angleDeg in dotAngles) {
+            val dotAngles = floatArrayOf(120f, 100f, 80f, 60f)
+            val baseDotColor = if (isScreenOff) {
+                Color.argb(128, 255, 255, 255)
+            } else if (isDarkTheme) {
+                Color.WHITE
+            } else {
+                Color.BLACK
+            }
+            val baseAlpha = Color.alpha(baseDotColor)
+            val red = Color.red(baseDotColor)
+            val green = Color.green(baseDotColor)
+            val blue = Color.blue(baseDotColor)
+
+            for (i in dotAngles.indices) {
+                val angleDeg = dotAngles[i]
                 val angleRad = Math.toRadians(angleDeg.toDouble())
                 val dotX = (cameraCenterX + baseRadius * cos(angleRad)).toFloat()
                 val dotY = (cameraCenterY + baseRadius * sin(angleRad)).toFloat()
+
+                // Signal level from 0..4 smoothly determines opacity of each dot (dot 0: 0..1, dot 1: 1..2, etc.)
+                val dotActiveFraction = (animatedSignalLevel - i).coerceIn(0f, 1f)
+                val dotOpacity = (0.22f + 0.78f * dotActiveFraction) * animatedDotAlpha
+                dotPaint.color = Color.argb((baseAlpha * dotOpacity).toInt(), red, green, blue)
+
                 canvas.drawCircle(dotX, dotY, dotRadiusPx * animatedDotAlpha, dotPaint)
             }
         }
@@ -219,6 +263,7 @@ class DuoOverlayView(context: Context) : View(context) {
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         batteryAnimator?.cancel()
+        signalAnimator?.cancel()
         layoutAnimator?.cancel()
         scaleAnimator?.cancel()
     }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -131,6 +131,7 @@ class MainViewModel : ViewModel() {
     val duoArcThickness = mutableFloatStateOf(4f)
     val duoDotSize = mutableFloatStateOf(4f)
     val duoRingRadius = mutableFloatStateOf(1.0f)
+    val isDuoShowNetworks = mutableStateOf(true)
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
     val mapsChannels =
@@ -533,6 +534,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_DUO_RING_RADIUS ->
                         duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
+
+                    SettingsRepository.KEY_DUO_SHOW_NETWORKS ->
+                        isDuoShowNetworks.value = settingsRepository.isDuoShowNetworksEnabled()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1763,6 +1767,7 @@ class MainViewModel : ViewModel() {
         duoArcThickness.floatValue = settingsRepository.getDuoArcThickness()
         duoDotSize.floatValue = settingsRepository.getDuoDotSize()
         duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
+        isDuoShowNetworks.value = settingsRepository.isDuoShowNetworksEnabled()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4348,6 +4353,11 @@ class MainViewModel : ViewModel() {
     fun setDuoRingRadius(value: Float) {
         duoRingRadius.floatValue = value
         settingsRepository.setDuoRingRadius(value)
+    }
+
+    fun setDuoShowNetworks(enabled: Boolean) {
+        isDuoShowNetworks.value = enabled
+        settingsRepository.setDuoShowNetworksEnabled(enabled)
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -2305,6 +2305,9 @@ class MainViewModel : ViewModel() {
         // Enabling pre-releases automatically enables Developer Mode; disabling turns it off
         isDeveloperModeEnabled.value = enabled
         settingsRepository.putBooleanSync(SettingsRepository.KEY_DEVELOPER_MODE_ENABLED, enabled)
+        if (!enabled) {
+            setDuoEnabled(false)
+        }
     }
 
     /**
@@ -2319,6 +2322,9 @@ class MainViewModel : ViewModel() {
     ) {
         isDeveloperModeEnabled.value = enabled
         settingsRepository.putBoolean(SettingsRepository.KEY_DEVELOPER_MODE_ENABLED, enabled)
+        if (!enabled) {
+            setDuoEnabled(false)
+        }
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -132,6 +132,8 @@ class MainViewModel : ViewModel() {
     val duoDotSize = mutableFloatStateOf(4f)
     val duoRingRadius = mutableFloatStateOf(1.0f)
     val isDuoShowNetworks = mutableStateOf(true)
+    val isDuoHideWhenScreenOff = mutableStateOf(false)
+    val isDuoUseMaterialYou = mutableStateOf(true)
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
     val mapsChannels =
@@ -537,6 +539,12 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_DUO_SHOW_NETWORKS ->
                         isDuoShowNetworks.value = settingsRepository.isDuoShowNetworksEnabled()
+
+                    SettingsRepository.KEY_DUO_HIDE_WHEN_SCREEN_OFF ->
+                        isDuoHideWhenScreenOff.value = settingsRepository.isDuoHideWhenScreenOffEnabled()
+
+                    SettingsRepository.KEY_DUO_USE_MATERIAL_YOU ->
+                        isDuoUseMaterialYou.value = settingsRepository.isDuoUseMaterialYouEnabled()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1768,6 +1776,8 @@ class MainViewModel : ViewModel() {
         duoDotSize.floatValue = settingsRepository.getDuoDotSize()
         duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
         isDuoShowNetworks.value = settingsRepository.isDuoShowNetworksEnabled()
+        isDuoHideWhenScreenOff.value = settingsRepository.isDuoHideWhenScreenOffEnabled()
+        isDuoUseMaterialYou.value = settingsRepository.isDuoUseMaterialYouEnabled()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4358,6 +4368,16 @@ class MainViewModel : ViewModel() {
     fun setDuoShowNetworks(enabled: Boolean) {
         isDuoShowNetworks.value = enabled
         settingsRepository.setDuoShowNetworksEnabled(enabled)
+    }
+
+    fun setDuoHideWhenScreenOff(enabled: Boolean) {
+        isDuoHideWhenScreenOff.value = enabled
+        settingsRepository.setDuoHideWhenScreenOffEnabled(enabled)
+    }
+
+    fun setDuoUseMaterialYou(enabled: Boolean) {
+        isDuoUseMaterialYou.value = enabled
+        settingsRepository.setDuoUseMaterialYouEnabled(enabled)
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -122,6 +122,15 @@ class MainViewModel : ViewModel() {
     val isSmartPixelsEnabled = mutableStateOf(false)
     val smartPixelsIntensity = mutableFloatStateOf(50f)
     val isSmartPixelsDisableOnCastEnabled = mutableStateOf(true)
+
+    val isDuoEnabled = mutableStateOf(false)
+    val isDuoAutoDetect = mutableStateOf(true)
+    val duoCameraOffsetX = mutableFloatStateOf(50f)
+    val duoCameraOffsetY = mutableFloatStateOf(3f)
+    val duoCameraSize = mutableFloatStateOf(1.0f)
+    val duoArcThickness = mutableFloatStateOf(4f)
+    val duoDotSize = mutableFloatStateOf(4f)
+    val duoRingRadius = mutableFloatStateOf(1.0f)
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
     val mapsChannels =
@@ -500,6 +509,30 @@ class MainViewModel : ViewModel() {
                     SettingsRepository.KEY_SMART_PIXELS_DISABLE_ON_CAST ->
                         isSmartPixelsDisableOnCastEnabled.value =
                             settingsRepository.getBoolean(key, true)
+
+                    SettingsRepository.KEY_DUO_ENABLED ->
+                        isDuoEnabled.value = settingsRepository.isDuoEnabled()
+
+                    SettingsRepository.KEY_DUO_USE_AUTO_DETECT ->
+                        isDuoAutoDetect.value = settingsRepository.isDuoAutoDetectEnabled()
+
+                    SettingsRepository.KEY_DUO_CAMERA_OFFSET_X ->
+                        duoCameraOffsetX.floatValue = settingsRepository.getDuoCameraOffsetX()
+
+                    SettingsRepository.KEY_DUO_CAMERA_OFFSET_Y ->
+                        duoCameraOffsetY.floatValue = settingsRepository.getDuoCameraOffsetY()
+
+                    SettingsRepository.KEY_DUO_CAMERA_SIZE ->
+                        duoCameraSize.floatValue = settingsRepository.getDuoCameraSize()
+
+                    SettingsRepository.KEY_DUO_ARC_THICKNESS ->
+                        duoArcThickness.floatValue = settingsRepository.getDuoArcThickness()
+
+                    SettingsRepository.KEY_DUO_DOT_SIZE ->
+                        duoDotSize.floatValue = settingsRepository.getDuoDotSize()
+
+                    SettingsRepository.KEY_DUO_RING_RADIUS ->
+                        duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1722,6 +1755,14 @@ class MainViewModel : ViewModel() {
             settingsRepository.getFloat(SettingsRepository.KEY_SMART_PIXELS_INTENSITY, 50f)
         isSmartPixelsDisableOnCastEnabled.value =
             settingsRepository.getBoolean(SettingsRepository.KEY_SMART_PIXELS_DISABLE_ON_CAST, true)
+        isDuoEnabled.value = settingsRepository.isDuoEnabled()
+        isDuoAutoDetect.value = settingsRepository.isDuoAutoDetectEnabled()
+        duoCameraOffsetX.floatValue = settingsRepository.getDuoCameraOffsetX()
+        duoCameraOffsetY.floatValue = settingsRepository.getDuoCameraOffsetY()
+        duoCameraSize.floatValue = settingsRepository.getDuoCameraSize()
+        duoArcThickness.floatValue = settingsRepository.getDuoArcThickness()
+        duoDotSize.floatValue = settingsRepository.getDuoDotSize()
+        duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4267,6 +4308,46 @@ class MainViewModel : ViewModel() {
     ) {
         isSmartPixelsDisableOnCastEnabled.value = enabled
         settingsRepository.putBoolean(SettingsRepository.KEY_SMART_PIXELS_DISABLE_ON_CAST, enabled)
+    }
+
+    fun setDuoEnabled(enabled: Boolean) {
+        isDuoEnabled.value = enabled
+        settingsRepository.setDuoEnabled(enabled)
+    }
+
+    fun setDuoAutoDetect(enabled: Boolean) {
+        isDuoAutoDetect.value = enabled
+        settingsRepository.setDuoAutoDetectEnabled(enabled)
+    }
+
+    fun setDuoCameraOffsetX(value: Float) {
+        duoCameraOffsetX.floatValue = value
+        settingsRepository.setDuoCameraOffsetX(value)
+    }
+
+    fun setDuoCameraOffsetY(value: Float) {
+        duoCameraOffsetY.floatValue = value
+        settingsRepository.setDuoCameraOffsetY(value)
+    }
+
+    fun setDuoCameraSize(value: Float) {
+        duoCameraSize.floatValue = value
+        settingsRepository.setDuoCameraSize(value)
+    }
+
+    fun setDuoArcThickness(value: Float) {
+        duoArcThickness.floatValue = value
+        settingsRepository.setDuoArcThickness(value)
+    }
+
+    fun setDuoDotSize(value: Float) {
+        duoDotSize.floatValue = value
+        settingsRepository.setDuoDotSize(value)
+    }
+
+    fun setDuoRingRadius(value: Float) {
+        duoRingRadius.floatValue = value
+        settingsRepository.setDuoRingRadius(value)
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -132,7 +132,7 @@ class MainViewModel : ViewModel() {
     val duoDotSize = mutableFloatStateOf(4f)
     val duoRingRadius = mutableFloatStateOf(1.0f)
     val isDuoShowNetworks = mutableStateOf(true)
-    val isDuoHideWhenScreenOff = mutableStateOf(false)
+    val isDuoHideWhenScreenOff = mutableStateOf(true)
     val isDuoUseMaterialYou = mutableStateOf(true)
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2449,4 +2449,20 @@
     <string name="action_show_granted">Show granted</string>
     <string name="action_hide_granted">Hide granted</string>
     <string name="label_frozen_apps">Frozen Apps</string>
+
+    <!-- Duo -->
+    <string name="duo_title">Duo</string>
+    <string name="duo_desc">Ambient camera ring indicator with battery level and status dots</string>
+    <string name="duo_enable_title">Enable Duo</string>
+    <string name="duo_enable_desc">Display ambient ring and status indicators around camera cutout</string>
+    <string name="duo_auto_detect_title">Auto-detect camera</string>
+    <string name="duo_auto_detect_desc">Automatically locate the front camera cutout using display metrics</string>
+    <string name="duo_camera_offset_x_title">Horizontal position</string>
+    <string name="duo_camera_offset_y_title">Vertical position</string>
+    <string name="duo_camera_size_title">Camera size</string>
+    <string name="duo_arc_thickness_title">Ring thickness</string>
+    <string name="duo_ring_radius_title">Ring radius</string>
+    <string name="duo_dot_size_title">Status dot size</string>
+    <string name="duo_section_position">Position and dimensions</string>
+    <string name="duo_section_style">Style</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2468,4 +2468,9 @@
     <string name="duo_section_what_to_show">What to show</string>
     <string name="duo_show_networks_title">Networks</string>
     <string name="duo_show_networks_desc">Show mobile network status indicator dots</string>
+    <string name="duo_section_behavior">Behavior</string>
+    <string name="duo_material_you_title">Use Material You colors</string>
+    <string name="duo_material_you_desc">Adapt colors dynamically from system wallpaper palette</string>
+    <string name="duo_hide_when_screen_off_title">Hide when screen off</string>
+    <string name="duo_hide_when_screen_off_desc">Hide the overlay completely when the display is turned off or on AOD</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -831,6 +831,7 @@
     <string name="update_download_failed">Download failed</string>
     <string name="perm_accessibility_desc_remap">Required to intercept hardware button events</string>
     <string name="perm_accessibility_desc_essentials_on_display">Required to intercept volume key events while the screen is off to trigger the Essentials On Display overlay.</string>
+    <string name="perm_accessibility_desc_duo">Required to display the ambient indicator overlay around the camera cutout.</string>
     <string name="perm_accessibility_desc_night_light">Needed to monitor foreground applications.</string>
     <string name="perm_write_secure_title">Write Secure Settings</string>
     <string name="perm_write_secure_desc_common">Required for Statusbar icons and Screen Locked Security</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2465,4 +2465,7 @@
     <string name="duo_dot_size_title">Status dot size</string>
     <string name="duo_section_position">Position and dimensions</string>
     <string name="duo_section_style">Style</string>
+    <string name="duo_section_what_to_show">What to show</string>
+    <string name="duo_show_networks_title">Networks</string>
+    <string name="duo_show_networks_desc">Show mobile network status indicator dots</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowStateChanged|typeViewClicked"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowsChanged|typeViewClicked"
     android:accessibilityFeedbackType=""
-    android:accessibilityFlags="flagRequestFilterKeyEvents"
+    android:accessibilityFlags="flagRequestFilterKeyEvents|flagRetrieveInteractiveWindows"
     android:canRequestFilterKeyEvents="true"
     android:canRetrieveWindowContent="true"
     android:description="@string/accessibility_service_description"


### PR DESCRIPTION
This pull request introduces a new feature called "Duo" to the project, including its settings, UI integration, accessibility service handling, and developer-only availability. The main changes add support for enabling and configuring the Duo feature, updating the accessibility service to manage its overlay, and registering Duo in the feature and permission registries.

**Duo Feature Integration:**

- Added a new `Duo` feature to the `FeatureRegistry`, making it available only when developer mode is enabled and requiring accessibility permissions. The feature is categorized under "Display" and includes toggle logic and descriptive resources.
- Registered the Duo feature for accessibility permissions in the `PermissionRegistry`.

**Settings and Configuration:**

- Introduced multiple new keys and getter/setter methods to `SettingsRepository` for storing Duo-related settings (such as enabled state, camera offset, size, arc thickness, dot size, ring radius, network display, hide-on-screen-off, and Material You support). [[1]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R358-R370) [[2]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R3070-R3102)

**Accessibility Service and Overlay Handling:**

- Integrated `DuoOverlayHandler` into `ScreenOffAccessibilityService`, including initialization, lifecycle management, state updates on relevant setting changes, and handling configuration changes (like screen rotation). [[1]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R39) [[2]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R73) [[3]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R281-R286) [[4]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R448) [[5]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R633)
- Updated the service to notify `DuoOverlayHandler` on screen on/off events and when settings change, and to update overlay state as needed. [[1]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R246-R259) [[2]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R302) [[3]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R316) [[4]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R412)
- Added logic to detect fullscreen state in the accessibility service and inform the Duo overlay handler accordingly.

**UI Integration:**

- Added `DuoSettingsUI` to the list of display features in `FeatureSettingsActivity`, allowing users to configure Duo settings via the app's UI. [[1]](diffhunk://#diff-856f0b915c43743b0f12d82114ba2e46d1d7bdd0979b9236a36c79a426e95538R73) [[2]](diffhunk://#diff-856f0b915c43743b0f12d82114ba2e46d1d7bdd0979b9236a36c79a426e95538R615) [[3]](diffhunk://#diff-856f0b915c43743b0f12d82114ba2e46d1d7bdd0979b9236a36c79a426e95538R1151-R1158)

**Supporting Types:**

- Introduced a new enum `DuoColorMode` (currently with a single value) in the domain model for future color mode support.