### PR TITLE
feat: add adaptive charging speed color option in Duo battery options

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -3123,7 +3123,7 @@ class SettingsRepository(
     fun isDuoBatteryChargingColorEnabled(): Boolean = getBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, true)
     fun setDuoBatteryChargingColorEnabled(enabled: Boolean) = putBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, enabled)
 
-    fun getDuoBatteryChargingColor(): String = getString(KEY_DUO_BATTERY_CHARGING_COLOR, "#00E676") ?: "#00E676"
+    fun getDuoBatteryChargingColor(): String = getString(KEY_DUO_BATTERY_CHARGING_COLOR, "auto") ?: "auto"
     fun setDuoBatteryChargingColor(colorHex: String) = putString(KEY_DUO_BATTERY_CHARGING_COLOR, colorHex)
 
     fun isDuoBatteryPowerSaveColorEnabled(): Boolean = getBoolean(KEY_DUO_BATTERY_POWER_SAVE_COLOR_ENABLED, true)

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -178,6 +178,45 @@ class DuoOverlayHandler(
     }
 
     private var isChargingState = false
+    private var isFastChargingState = false
+
+    private fun isFastCharging(intent: Intent?, plugged: Int): Boolean {
+        if (intent == null) return plugged == BatteryManager.BATTERY_PLUGGED_AC
+
+        try {
+            // 1. Samsung One UI specific charging extras (guarded against ClassCastException on non-Samsung OEMs)
+            val chargerType = try { intent.getIntExtra("charger_type", -1) } catch (_: Exception) { -1 }
+            if (chargerType >= 2) return true
+
+            val chargeType = try { intent.getIntExtra("charge_type", -1) } catch (_: Exception) { -1 }
+            if (chargeType >= 3) return true
+
+            val isFastExtra = try {
+                intent.getBooleanExtra("fast_charge", false) || intent.getBooleanExtra("is_fast_charge", false)
+            } catch (_: Exception) { false }
+            if (isFastExtra) return true
+
+            // 2. Standard Android / AOSP charging wattage check (Pixel, Motorola, Xiaomi, Sony, etc.)
+            val maxCurrent = try { intent.getIntExtra("max_charging_current", -1) } catch (_: Exception) { -1 }
+            val maxVoltage = try { intent.getIntExtra("max_charging_voltage", -1) } catch (_: Exception) { -1 }
+            if (maxCurrent > 0 && maxVoltage > 0) {
+                val watts = (maxCurrent.toDouble() / 1_000_000.0) * (maxVoltage.toDouble() / 1_000_000.0)
+                if (watts >= 10.0) return true
+                if (watts > 0 && watts < 7.5) return false
+            } else if (maxCurrent >= 2_000_000) {
+                return true
+            }
+
+            // 3. Fallback based on power source
+            // USB port charging (PC/laptop) is standard/slow charging (green)
+            if (plugged == BatteryManager.BATTERY_PLUGGED_USB) return false
+
+            // AC wall chargers are predominantly fast charging on modern devices (cyan)
+            return plugged == BatteryManager.BATTERY_PLUGGED_AC
+        } catch (_: Exception) {
+            return plugged == BatteryManager.BATTERY_PLUGGED_AC
+        }
+    }
 
     private val batteryReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -217,7 +256,8 @@ class DuoOverlayHandler(
                     else -> isChargingStatus || isPlugged
                 }
 
-                val isFastCharging = plugged == BatteryManager.BATTERY_PLUGGED_AC
+                val isFastCharging = isFastCharging(batteryIntent, plugged)
+                isFastChargingState = isFastCharging
 
                 if (action == Intent.ACTION_POWER_CONNECTED) {
                     isChargingState = true
@@ -759,9 +799,15 @@ class DuoOverlayHandler(
                     this.customColor = Color.parseColor(settingsRepository.getDuoCustomColor())
                 } catch (_: Exception) {}
                 this.isBatteryChargingColorEnabled = settingsRepository.isDuoBatteryChargingColorEnabled()
-                try {
-                    this.batteryChargingColor = Color.parseColor(settingsRepository.getDuoBatteryChargingColor())
-                } catch (_: Exception) {}
+                val chargingColorStr = settingsRepository.getDuoBatteryChargingColor()
+                if (chargingColorStr.equals("auto", ignoreCase = true)) {
+                    this.isChargingColorAuto = true
+                } else {
+                    this.isChargingColorAuto = false
+                    try {
+                        this.batteryChargingColor = Color.parseColor(chargingColorStr)
+                    } catch (_: Exception) {}
+                }
                 this.isBatteryPowerSaveColorEnabled = settingsRepository.isDuoBatteryPowerSaveColorEnabled()
                 try {
                     this.batteryPowerSaveColor = Color.parseColor(settingsRepository.getDuoBatteryPowerSaveColor())
@@ -781,7 +827,7 @@ class DuoOverlayHandler(
                 this.showMedia = settingsRepository.isDuoShowMediaEnabled()
                 this.showProgress = settingsRepository.isDuoShowProgressEnabled()
                 this.showFlashlight = settingsRepository.isDuoShowFlashlightEnabled()
-                this.setCharging(this@DuoOverlayHandler.isChargingState)
+                this.setCharging(this@DuoOverlayHandler.isChargingState, this@DuoOverlayHandler.isFastChargingState)
             }
 
             if (!isOverlayAdded) {
@@ -1054,7 +1100,8 @@ class DuoOverlayHandler(
                     val isPlugged = plugged > 0
                     if (isChargingStatus || isPlugged) {
                         isChargingState = true
-                        val isFast = plugged == BatteryManager.BATTERY_PLUGGED_AC
+                        val isFast = isFastCharging(it, plugged)
+                        isFastChargingState = isFast
                         overlayView?.setCharging(true, isFast)
                     }
                 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/core/pickers/ColorSwatchPicker.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/core/pickers/ColorSwatchPicker.kt
@@ -10,7 +10,6 @@
 package com.sameerasw.essentials.ui.core.pickers
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -23,18 +22,24 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
 import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.sameerasw.essentials.R
 import com.sameerasw.essentials.utils.HapticUtil
-import androidx.compose.ui.draw.clip
 
 val DUO_PRESET_COLORS =
     listOf(
@@ -62,9 +67,13 @@ fun ColorSwatchPicker(
     onColorSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
     colors: List<String> = DUO_PRESET_COLORS,
+    allowAuto: Boolean = false,
 ) {
+    val effectiveColors = remember(colors, allowAuto) {
+        if (allowAuto) listOf("auto") + colors else colors
+    }
     val view = LocalView.current
-    val carouselState = rememberCarouselState { colors.size }
+    val carouselState = rememberCarouselState { effectiveColors.size }
 
     Box(
         modifier =
@@ -86,45 +95,87 @@ fun ColorSwatchPicker(
                     .fillMaxWidth()
                     .height(48.dp),
         ) { index ->
-            val colorHex = colors[index]
+            val colorHex = effectiveColors[index]
+            val isAuto = colorHex.equals("auto", ignoreCase = true)
             val isSelected = colorHex.equals(selectedColorHex, ignoreCase = true)
-            val parsedColor =
-                try {
-                    Color(android.graphics.Color.parseColor(colorHex))
-                } catch (_: Exception) {
-                    MaterialTheme.colorScheme.primary
-                }
 
-            val isLightColor =
-                try {
-                    val c = android.graphics.Color.parseColor(colorHex)
-                    val r = android.graphics.Color.red(c) / 255.0
-                    val g = android.graphics.Color.green(c) / 255.0
-                    val b = android.graphics.Color.blue(c) / 255.0
-                    (0.299 * r + 0.587 * g + 0.114 * b) > 0.5
-                } catch (_: Exception) {
-                    false
-                }
-
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .maskClip(RoundedCornerShape(14.dp))
-                        .background(parsedColor)
-                        .clickable {
-                            HapticUtil.performVirtualKeyHaptic(view)
-                            onColorSelected(colorHex)
-                        },
-                contentAlignment = Alignment.Center,
-            ) {
-                if (isSelected) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.rounded_check_24),
-                        contentDescription = null,
-                        tint = if (isLightColor) Color.Black else Color.White,
-                        modifier = Modifier.size(18.dp),
+            if (isAuto) {
+                val autoGradient =
+                    Brush.linearGradient(
+                        colors =
+                            listOf(
+                                Color(0xFF00E676), // Vibrant Spring Green (Standard)
+                                Color(0xFF00E5FF), // Electric Cyan (Fast)
+                            ),
                     )
+
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .maskClip(RoundedCornerShape(14.dp))
+                            .background(autoGradient)
+                            .clickable {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                onColorSelected("auto")
+                            },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isSelected) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.rounded_check_24),
+                            contentDescription = stringResource(R.string.duo_battery_charging_color_auto),
+                            tint = Color(0xFF003822),
+                            modifier = Modifier.size(18.dp),
+                        )
+                    } else {
+                        Text(
+                            text = "A",
+                            color = Color(0xFF003822),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp,
+                        )
+                    }
+                }
+            } else {
+                val parsedColor =
+                    try {
+                        Color(android.graphics.Color.parseColor(colorHex))
+                    } catch (_: Exception) {
+                        MaterialTheme.colorScheme.primary
+                    }
+
+                val isLightColor =
+                    try {
+                        val c = android.graphics.Color.parseColor(colorHex)
+                        val r = android.graphics.Color.red(c) / 255.0
+                        val g = android.graphics.Color.green(c) / 255.0
+                        val b = android.graphics.Color.blue(c) / 255.0
+                        (0.299 * r + 0.587 * g + 0.114 * b) > 0.5
+                    } catch (_: Exception) {
+                        false
+                    }
+
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .maskClip(RoundedCornerShape(14.dp))
+                            .background(parsedColor)
+                            .clickable {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                onColorSelected(colorHex)
+                            },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isSelected) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.rounded_check_24),
+                            contentDescription = null,
+                            tint = if (isLightColor) Color.Black else Color.White,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/DuoBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/DuoBatteryOptionsBottomSheet.kt
@@ -168,6 +168,7 @@ fun DuoBatteryOptionsBottomSheet(
                         onColorSelected = { hex ->
                             viewModel.setDuoBatteryChargingColor(hex)
                         },
+                        allowAuto = true,
                     )
                 }
             }

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -231,6 +231,16 @@ class DuoOverlayView(context: Context) : View(context) {
             }
         }
 
+    var isChargingColorAuto: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                if (isCharging) {
+                    animateThemeChange()
+                }
+            }
+        }
+
     var isBatteryPowerSaveColorEnabled: Boolean = true
         set(value) {
             if (field != value) {
@@ -343,7 +353,14 @@ class DuoOverlayView(context: Context) : View(context) {
         private set
 
     var isFastCharging: Boolean = false
-        private set
+        set(value) {
+            if (field != value) {
+                field = value
+                if (isCharging && isChargingColorAuto) {
+                    animateThemeChange()
+                }
+            }
+        }
 
     var isPowerSaveMode: Boolean = false
         set(value) {
@@ -379,7 +396,8 @@ class DuoOverlayView(context: Context) : View(context) {
         resetInteractiveState(animate = true)
     }
 
-    private var isChargingAnnounce: Boolean = false
+    var isChargingAnnounce: Boolean = false
+        private set
     private var isChargingThemeActive: Boolean = false
     private var chargingBoltBitmap: Bitmap? = null
     private var tracerFraction: Float = -1f
@@ -602,6 +620,10 @@ class DuoOverlayView(context: Context) : View(context) {
     }
 
     fun setCharging(isCharging: Boolean, isFastCharging: Boolean = false) {
+        if (isChargingAnnounce && isCharging) {
+            this.isFastCharging = isFastCharging
+            return
+        }
         val wasCharging = this.isCharging
         this.isCharging = isCharging
         this.isFastCharging = isFastCharging
@@ -873,7 +895,11 @@ class DuoOverlayView(context: Context) : View(context) {
                 return Triple(dimTrack, dimProgress, dimProgress)
             }
             if (isCharging && isBatteryChargingColorEnabled) {
-                val chargeAccent = getThemeAdjustedColor(batteryChargingColor)
+                val chargeAccent = if (isChargingColorAuto) {
+                    if (isFastCharging) Color.rgb(0, 229, 255) else Color.rgb(0, 230, 118)
+                } else {
+                    getThemeAdjustedColor(batteryChargingColor)
+                }
                 val dimProgress = Color.argb(160, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
                 val dimTrack = Color.argb(50, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
                 return Triple(dimTrack, dimProgress, dimProgress)
@@ -909,9 +935,25 @@ class DuoOverlayView(context: Context) : View(context) {
         }
 
         if (isCharging && isBatteryChargingColorEnabled) {
-            val chargeAccent = getThemeAdjustedColor(batteryChargingColor)
-            val trackAlpha = if (isDarkTheme) 90 else 110
-            val track = Color.argb(trackAlpha, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
+            val chargeAccent = if (isChargingColorAuto) {
+                if (isFastCharging) {
+                    if (isDarkTheme) Color.rgb(0, 229, 255) else Color.rgb(0, 151, 167)
+                } else {
+                    if (isDarkTheme) Color.rgb(0, 230, 118) else Color.rgb(10, 144, 66)
+                }
+            } else {
+                getThemeAdjustedColor(batteryChargingColor)
+            }
+            val track = if (isDarkTheme) {
+                val trackAlpha = 90
+                Color.argb(trackAlpha, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
+            } else {
+                if (isChargingColorAuto && isFastCharging) {
+                    Color.argb(42, 0, 70, 80)
+                } else {
+                    Color.argb(42, 0, 70, 30)
+                }
+            }
             return Triple(track, chargeAccent, chargeAccent)
         }
 
@@ -1263,7 +1305,15 @@ class DuoOverlayView(context: Context) : View(context) {
                     canvas.drawArc(arcBounds, tracerStartAngle, tailSpan, false, contrastTracerPaint)
                 }
 
-                val adjustedChargeColor = getThemeAdjustedColor(batteryChargingColor)
+                val adjustedChargeColor = if (isChargingColorAuto) {
+                    if (isFastCharging) {
+                        if (isDarkTheme) Color.rgb(0, 229, 255) else Color.rgb(0, 151, 167)
+                    } else {
+                        if (isDarkTheme) Color.rgb(0, 230, 118) else Color.rgb(10, 144, 66)
+                    }
+                } else {
+                    getThemeAdjustedColor(batteryChargingColor)
+                }
                 val beamAlpha = (245 * tracerAlpha).toInt().coerceIn(0, 255)
                 val beamColor = Color.argb(
                     beamAlpha,

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -134,7 +134,7 @@ class MainViewModel : ViewModel() {
     val duoRingRadius = mutableFloatStateOf(1.0f)
     val isDuoShowBattery = mutableStateOf(true)
     val isDuoBatteryChargingColorEnabled = mutableStateOf(true)
-    val duoBatteryChargingColor = mutableStateOf("#00E676")
+    val duoBatteryChargingColor = mutableStateOf("auto")
     val isDuoBatteryPowerSaveColorEnabled = mutableStateOf(true)
     val duoBatteryPowerSaveColor = mutableStateOf("#FF9800")
     val isDuoBatteryLowColorEnabled = mutableStateOf(true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2474,6 +2474,7 @@
     <string name="duo_show_battery_title">Battery</string>
     <string name="duo_battery_options_title">Battery options</string>
     <string name="duo_battery_charging_color_title">Charging</string>
+    <string name="duo_battery_charging_color_auto">Auto charging speed</string>
     <string name="duo_battery_power_save_color_title">Battery saver</string>
     <string name="duo_battery_low_color_title">Low battery (&lt;20%)</string>
     <string name="duo_battery_critical_color_title">Critically low battery (&lt;10%)</string>


### PR DESCRIPTION
This pull request restores and refines the adaptive charging speed color feature in Duo's battery options, which previously existed but was broken/removed following the recent color picker update. When enabled, Duo dynamically adjusts its charging ring and tracer animation colors based on the real-time charging wattage and protocol of the connected charger, distinguishing standard charging from fast and super-fast charging.

### Preview

#### On-Device Demo
https://github.com/user-attachments/assets/94084eec-67db-42de-8ddf-1585deb31617

#### Adaptive "A" Color Swatch in Battery Options
<img width="1439" height="402" alt="Screenshot_20260912_131045" src="https://github.com/user-attachments/assets/303f1349-6632-4ba4-ab94-daf8fd27fcb4" />

---

### Duo Adaptive Charging Enhancements

_Color picker and settings:_
* Restored the "Auto" option (`"auto"`) represented by a clean minimal "A" swatch with a gradient (`#00E676` → `#00E5FF`) in `ColorSwatchPicker` and `DuoBatteryOptionsBottomSheet`.
* Set `"auto"` as the default charging color in `SettingsRepository` and `MainViewModel`.
* Added string resource `duo_battery_charging_color_auto`.

_Multi-OEM fast charging detection:_
* Implemented guarded multi-OEM fast-charging detection in `DuoOverlayHandler`:
  * Samsung One UI specific charging extras (`charger_type`, `charge_type`, `fast_charge`, `is_fast_charge`) with safe exception boundaries for non-Samsung devices.
  * Standard Android / AOSP real-time charging power check (`max_charging_current` & `max_charging_voltage` for $\ge 10\text{W}$, or $\ge 2\text{A}$).
  * Safe fallback based on power source (standard USB port vs AC wall charger).

_Dynamic overlay color switching & animation stability:_
* Added `isChargingColorAuto` in `DuoOverlayView` to dynamically transition colors when charging state or charging speed changes:
  * Fast / Super-fast charging: Electric Cyan (`#00E5FF` in dark mode, `#0097A7` in light mode).
  * Standard charging: Vibrant Spring Green (`#00E676` in dark mode, `#0A9042` in light mode).
* Updated charging tracer animation and ambient dim mode colors to follow adaptive charging speeds.
* Guarded `setCharging()` against interrupting in-flight charging announcements (`isChargingAnnounce`), preventing layout animation cancellations and race conditions between back-to-back battery broadcasts.