### PR TITLE
feat: add battery percentage display in Duo camera ring apex

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -369,6 +369,7 @@ class SettingsRepository(
         const val KEY_DUO_RING_RADIUS = "duo_ring_radius"
         const val KEY_DUO_SHOW_BATTERY = "duo_show_battery"
         const val KEY_DUO_SHOW_BATTERY_PERCENTAGE = "duo_show_battery_percentage"
+        const val KEY_DUO_BATTERY_PERCENTAGE_ONLY_COLORED = "duo_battery_percentage_only_colored"
         const val KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED = "duo_battery_charging_color_enabled"
         const val KEY_DUO_BATTERY_CHARGING_COLOR = "duo_battery_charging_color"
         const val KEY_DUO_BATTERY_POWER_SAVE_COLOR_ENABLED = "duo_battery_power_save_color_enabled"
@@ -3123,6 +3124,9 @@ class SettingsRepository(
 
     fun isDuoShowBatteryPercentageEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_BATTERY_PERCENTAGE, false)
     fun setDuoShowBatteryPercentageEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_BATTERY_PERCENTAGE, enabled)
+
+    fun isDuoBatteryPercentageOnlyColoredEnabled(): Boolean = getBoolean(KEY_DUO_BATTERY_PERCENTAGE_ONLY_COLORED, false)
+    fun setDuoBatteryPercentageOnlyColoredEnabled(enabled: Boolean) = putBoolean(KEY_DUO_BATTERY_PERCENTAGE_ONLY_COLORED, enabled)
 
     fun isDuoBatteryChargingColorEnabled(): Boolean = getBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, true)
     fun setDuoBatteryChargingColorEnabled(enabled: Boolean) = putBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -368,6 +368,7 @@ class SettingsRepository(
         const val KEY_DUO_DOT_SIZE = "duo_dot_size"
         const val KEY_DUO_RING_RADIUS = "duo_ring_radius"
         const val KEY_DUO_SHOW_BATTERY = "duo_show_battery"
+        const val KEY_DUO_SHOW_BATTERY_PERCENTAGE = "duo_show_battery_percentage"
         const val KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED = "duo_battery_charging_color_enabled"
         const val KEY_DUO_BATTERY_CHARGING_COLOR = "duo_battery_charging_color"
         const val KEY_DUO_BATTERY_POWER_SAVE_COLOR_ENABLED = "duo_battery_power_save_color_enabled"
@@ -3119,6 +3120,9 @@ class SettingsRepository(
 
     fun isDuoShowBatteryEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_BATTERY, true)
     fun setDuoShowBatteryEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_BATTERY, enabled)
+
+    fun isDuoShowBatteryPercentageEnabled(): Boolean = getBoolean(KEY_DUO_SHOW_BATTERY_PERCENTAGE, false)
+    fun setDuoShowBatteryPercentageEnabled(enabled: Boolean) = putBoolean(KEY_DUO_SHOW_BATTERY_PERCENTAGE, enabled)
 
     fun isDuoBatteryChargingColorEnabled(): Boolean = getBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, true)
     fun setDuoBatteryChargingColorEnabled(enabled: Boolean) = putBoolean(KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -823,6 +823,7 @@ class DuoOverlayHandler(
                 this.isPowerSaveMode = powerManager?.isPowerSaveMode ?: false
                 this.showBattery = settingsRepository.isDuoShowBatteryEnabled()
                 this.showBatteryPercentage = settingsRepository.isDuoShowBatteryPercentageEnabled()
+                this.isBatteryPercentageOnlyColored = settingsRepository.isDuoBatteryPercentageOnlyColoredEnabled()
                 this.showNetworks = settingsRepository.isDuoShowNetworksEnabled()
                 this.showTime = settingsRepository.isDuoShowTimeEnabled()
                 this.showMedia = settingsRepository.isDuoShowMediaEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/DuoOverlayHandler.kt
@@ -776,6 +776,7 @@ class DuoOverlayHandler(
                 } catch (_: Exception) {}
                 this.isPowerSaveMode = powerManager?.isPowerSaveMode ?: false
                 this.showBattery = settingsRepository.isDuoShowBatteryEnabled()
+                this.showBatteryPercentage = settingsRepository.isDuoShowBatteryPercentageEnabled()
                 this.showNetworks = settingsRepository.isDuoShowNetworksEnabled()
                 this.showTime = settingsRepository.isDuoShowTimeEnabled()
                 this.showMedia = settingsRepository.isDuoShowMediaEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -256,6 +256,7 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_DUO_RING_RADIUS ||
                 key == SettingsRepository.KEY_DUO_SHOW_BATTERY ||
                 key == SettingsRepository.KEY_DUO_SHOW_BATTERY_PERCENTAGE ||
+                key == SettingsRepository.KEY_DUO_BATTERY_PERCENTAGE_ONLY_COLORED ||
                 key == SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED ||
                 key == SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR ||
                 key == SettingsRepository.KEY_DUO_BATTERY_LOW_COLOR_ENABLED ||

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -255,6 +255,7 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_DUO_DOT_SIZE ||
                 key == SettingsRepository.KEY_DUO_RING_RADIUS ||
                 key == SettingsRepository.KEY_DUO_SHOW_BATTERY ||
+                key == SettingsRepository.KEY_DUO_SHOW_BATTERY_PERCENTAGE ||
                 key == SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED ||
                 key == SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR ||
                 key == SettingsRepository.KEY_DUO_BATTERY_LOW_COLOR_ENABLED ||

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
@@ -330,6 +330,17 @@ fun DuoSettingsUI(
                 modifier = Modifier.highlight(highlightSetting == "duo_show_battery"),
             )
             IconToggleItem(
+                iconRes = R.drawable.rounded_battery_android_frame_6_24,
+                title = stringResource(R.string.duo_show_battery_percentage_title),
+                isChecked = viewModel.isDuoShowBatteryPercentage.value,
+                enabled = viewModel.isDuoShowBattery.value,
+                onCheckedChange = { checked ->
+                    HapticUtil.performVirtualKeyHaptic(view)
+                    viewModel.setDuoShowBatteryPercentage(checked)
+                },
+                modifier = Modifier.highlight(highlightSetting == "duo_show_battery_percentage"),
+            )
+            IconToggleItem(
                 iconRes = R.drawable.rounded_signal_cellular_alt_24,
                 title = stringResource(R.string.duo_show_networks_title),
                 isChecked = viewModel.isDuoShowNetworks.value,

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/DuoSettingsUI.kt
@@ -64,6 +64,7 @@ import com.sameerasw.essentials.ui.core.sheets.SoundModeSettingsSheet
 import com.sameerasw.essentials.ui.features.apps.sheets.KeyboardSelectionSheet
 import com.sameerasw.essentials.ui.features.audio.sheets.SetVolumeSettingsSheet
 import com.sameerasw.essentials.ui.features.display.sheets.DuoBatteryOptionsBottomSheet
+import com.sameerasw.essentials.ui.features.display.sheets.DuoBatteryPercentageOptionsBottomSheet
 import com.sameerasw.essentials.ui.features.system.LikeSongSettingsSheet
 import com.sameerasw.essentials.ui.features.system.RemapActionItem
 import com.sameerasw.essentials.ui.modifiers.highlight
@@ -84,6 +85,7 @@ fun DuoSettingsUI(
 
     var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
     var showBatteryOptionsSheet by remember { mutableStateOf(false) }
+    var showBatteryPercentageOptionsSheet by remember { mutableStateOf(false) }
     var showMediaAppSelectionSheet by remember { mutableStateOf(false) }
 
     var pickingActionForGesture by remember { mutableStateOf<String?>(null) }
@@ -337,6 +339,9 @@ fun DuoSettingsUI(
                 onCheckedChange = { checked ->
                     HapticUtil.performVirtualKeyHaptic(view)
                     viewModel.setDuoShowBatteryPercentage(checked)
+                },
+                onSettingsClick = {
+                    showBatteryPercentageOptionsSheet = true
                 },
                 modifier = Modifier.highlight(highlightSetting == "duo_show_battery_percentage"),
             )
@@ -999,6 +1004,13 @@ fun DuoSettingsUI(
         DuoBatteryOptionsBottomSheet(
             viewModel = viewModel,
             onDismissRequest = { showBatteryOptionsSheet = false },
+        )
+    }
+
+    if (showBatteryPercentageOptionsSheet) {
+        DuoBatteryPercentageOptionsBottomSheet(
+            viewModel = viewModel,
+            onDismissRequest = { showBatteryPercentageOptionsSheet = false },
         )
     }
 

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/DuoBatteryPercentageOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/DuoBatteryPercentageOptionsBottomSheet.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Feature - Display
+ * File: DuoBatteryPercentageOptionsBottomSheet.kt
+ * Description: Bottom sheet for configuring Duo battery percentage display options.
+ */
+
+package com.sameerasw.essentials.ui.features.display.sheets
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.core.cards.IconToggleItem
+import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DuoBatteryPercentageOptionsBottomSheet(
+    viewModel: MainViewModel,
+    onDismissRequest: () -> Unit,
+) {
+    val view = LocalView.current
+
+    EssentialsBottomSheet(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.duo_battery_percentage_options_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 8.dp, bottom = 4.dp),
+            )
+
+            RoundedCardContainer(
+                spacing = 2.dp,
+                cornerRadius = 24.dp,
+            ) {
+                IconToggleItem(
+                    iconRes = R.drawable.rounded_palette_24,
+                    title = stringResource(R.string.duo_battery_percentage_only_colored_title),
+                    description = stringResource(R.string.duo_battery_percentage_only_colored_desc),
+                    isChecked = viewModel.isDuoBatteryPercentageOnlyColored.value,
+                    onCheckedChange = { checked ->
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        viewModel.setDuoBatteryPercentageOnlyColored(checked)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -99,6 +99,7 @@ class DuoOverlayView(context: Context) : View(context) {
                 if (oldColors != newColors) {
                     animateThemeChange()
                 }
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -160,17 +161,55 @@ class DuoOverlayView(context: Context) : View(context) {
         set(value) {
             if (field != value) {
                 field = value
-                animateBatteryPercentageTransition(value)
+                updateBatteryPercentageVisibility()
             }
         }
+
+    var isBatteryPercentageOnlyColored: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateBatteryPercentageVisibility()
+            }
+        }
+
+    fun isBatteryColoredInstanceActive(): Boolean {
+        if (isCharging && isBatteryChargingColorEnabled) return true
+        if (isPowerSaveMode && isBatteryPowerSaveColorEnabled) return true
+        if (batteryLevel <= 10 && isBatteryCriticalColorEnabled) return true
+        if (batteryLevel <= 20 && isBatteryLowColorEnabled) return true
+        return false
+    }
+
+    fun isBatteryPercentageActive(): Boolean {
+        if (!showBatteryPercentage) return false
+        if (isBatteryPercentageOnlyColored) {
+            return isBatteryColoredInstanceActive()
+        }
+        return true
+    }
+
+    private fun updateBatteryPercentageVisibility(animate: Boolean = true) {
+        val target = isBatteryPercentageActive()
+        if (animate) {
+            animateBatteryPercentageTransition(target)
+        } else {
+            batteryPercentageAnimator?.cancel()
+            animatedBatteryPercentageFraction = if (target) 1.0f else 0.0f
+            invalidate()
+        }
+    }
 
     private var animatedBatteryPercentageFraction: Float = 0f
     private var batteryPercentageAnimator: ValueAnimator? = null
 
     private fun animateBatteryPercentageTransition(visible: Boolean) {
-        batteryPercentageAnimator?.cancel()
-        val start = animatedBatteryPercentageFraction
         val target = if (visible) 1.0f else 0.0f
+        if (batteryPercentageAnimator?.isRunning == true) {
+            batteryPercentageAnimator?.cancel()
+        }
+        val start = animatedBatteryPercentageFraction
+        if (kotlin.math.abs(start - target) < 0.001f) return
         batteryPercentageAnimator = ValueAnimator.ofFloat(start, target).apply {
             duration = 300L
             interpolator = PathInterpolator(0.4f, 0.0f, 0.2f, 1.0f)
@@ -247,6 +286,7 @@ class DuoOverlayView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 animateThemeChange()
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -273,6 +313,7 @@ class DuoOverlayView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 animateThemeChange()
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -289,6 +330,7 @@ class DuoOverlayView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 animateThemeChange()
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -305,6 +347,7 @@ class DuoOverlayView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 animateThemeChange()
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -394,6 +437,7 @@ class DuoOverlayView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 animateThemeChange()
+                updateBatteryPercentageVisibility()
             }
         }
 
@@ -434,6 +478,7 @@ class DuoOverlayView(context: Context) : View(context) {
         if (isChargingAnnounce) {
             isChargingAnnounce = false
             updateActiveProgressMode()
+            updateBatteryPercentageVisibility()
         }
     }
 
@@ -602,13 +647,13 @@ class DuoOverlayView(context: Context) : View(context) {
         this.isFastCharging = isFastCharging
         this.isChargingAnnounce = true
         this.isChargingThemeActive = false
+        updateBatteryPercentageVisibility()
 
         removeCallbacks(revertChargingRunnable)
         postDelayed(revertChargingRunnable, 4000L)
 
         updateActiveProgressMode()
 
-        batteryPercentageAnimator?.cancel()
         tracerAnimator?.cancel()
         tracerAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = 800
@@ -662,11 +707,13 @@ class DuoOverlayView(context: Context) : View(context) {
             removeCallbacks(revertChargingRunnable)
             updateActiveProgressMode()
             animateThemeChange()
+            updateBatteryPercentageVisibility()
         } else if (wasCharging != isCharging) {
             if (!isChargingAnnounce) {
                 isChargingThemeActive = true
                 animateThemeChange()
             }
+            updateBatteryPercentageVisibility()
         }
     }
 
@@ -1230,7 +1277,7 @@ class DuoOverlayView(context: Context) : View(context) {
         val (track, progress, dot) = getTargetColors()
         currentTrackColor = track
         currentProgressColor = progress
-        animatedBatteryPercentageFraction = if (showBatteryPercentage) 1.0f else 0.0f
+        animatedBatteryPercentageFraction = if (isBatteryPercentageActive()) 1.0f else 0.0f
         currentDotBaseColor = dot
         trackPaint.color = currentTrackColor
         progressPaint.color = currentProgressColor
@@ -1292,7 +1339,7 @@ class DuoOverlayView(context: Context) : View(context) {
         val contrastAlpha = (baseContrastAlpha * animatedVisibilityAlpha).toInt()
 
         val bpFraction = animatedBatteryPercentageFraction
-        val isSplitBatteryActive = (bpFraction > 0.001f || showBatteryPercentage) && animatedCustomFraction < 0.5f && showBattery
+        val isSplitBatteryActive = (bpFraction > 0.001f || isBatteryPercentageActive()) && animatedCustomFraction < 0.5f && showBattery
 
         if (isSplitBatteryActive) {
             val batteryText = batteryLevel.toString()

--- a/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/DuoOverlayView.kt
@@ -26,6 +26,7 @@ import android.view.View
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.LinearInterpolator
 import android.view.animation.OvershootInterpolator
+import android.view.animation.PathInterpolator
 import androidx.core.content.ContextCompat
 import androidx.palette.graphics.Palette
 import com.sameerasw.essentials.R
@@ -154,6 +155,32 @@ class DuoOverlayView(context: Context) : View(context) {
                 updateVisibilityAnimation()
             }
         }
+
+    var showBatteryPercentage: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                animateBatteryPercentageTransition(value)
+            }
+        }
+
+    private var animatedBatteryPercentageFraction: Float = 0f
+    private var batteryPercentageAnimator: ValueAnimator? = null
+
+    private fun animateBatteryPercentageTransition(visible: Boolean) {
+        batteryPercentageAnimator?.cancel()
+        val start = animatedBatteryPercentageFraction
+        val target = if (visible) 1.0f else 0.0f
+        batteryPercentageAnimator = ValueAnimator.ofFloat(start, target).apply {
+            duration = 300L
+            interpolator = PathInterpolator(0.4f, 0.0f, 0.2f, 1.0f)
+            addUpdateListener { animation ->
+                animatedBatteryPercentageFraction = animation.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
 
     var showMedia: Boolean = true
         set(value) {
@@ -379,7 +406,8 @@ class DuoOverlayView(context: Context) : View(context) {
         resetInteractiveState(animate = true)
     }
 
-    private var isChargingAnnounce: Boolean = false
+    var isChargingAnnounce: Boolean = false
+        private set
     private var isChargingThemeActive: Boolean = false
     private var chargingBoltBitmap: Bitmap? = null
     private var tracerFraction: Float = -1f
@@ -563,6 +591,7 @@ class DuoOverlayView(context: Context) : View(context) {
 
         updateActiveProgressMode()
 
+        batteryPercentageAnimator?.cancel()
         tracerAnimator?.cancel()
         tracerAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = 800
@@ -602,6 +631,10 @@ class DuoOverlayView(context: Context) : View(context) {
     }
 
     fun setCharging(isCharging: Boolean, isFastCharging: Boolean = false) {
+        if (isChargingAnnounce && isCharging) {
+            this.isFastCharging = isFastCharging
+            return
+        }
         val wasCharging = this.isCharging
         this.isCharging = isCharging
         this.isFastCharging = isFastCharging
@@ -884,13 +917,13 @@ class DuoOverlayView(context: Context) : View(context) {
                 val dimTrack = Color.argb(50, Color.red(saveAccent), Color.green(saveAccent), Color.blue(saveAccent))
                 return Triple(dimTrack, dimProgress, dimProgress)
             }
-            if (showBattery && batteryLevel <= 10 && isBatteryCriticalColorEnabled) {
+            if ((showBattery || showBatteryPercentage) && batteryLevel <= 10 && isBatteryCriticalColorEnabled) {
                 val critAccent = getThemeAdjustedColor(batteryCriticalColor)
                 val dimProgress = Color.argb(160, Color.red(critAccent), Color.green(critAccent), Color.blue(critAccent))
                 val dimTrack = Color.argb(50, Color.red(critAccent), Color.green(critAccent), Color.blue(critAccent))
                 return Triple(dimTrack, dimProgress, dimProgress)
             }
-            if (showBattery && batteryLevel <= 20 && isBatteryLowColorEnabled) {
+            if ((showBattery || showBatteryPercentage) && batteryLevel <= 20 && isBatteryLowColorEnabled) {
                 val lowAccent = getThemeAdjustedColor(batteryLowColor)
                 val dimProgress = Color.argb(160, Color.red(lowAccent), Color.green(lowAccent), Color.blue(lowAccent))
                 val dimTrack = Color.argb(50, Color.red(lowAccent), Color.green(lowAccent), Color.blue(lowAccent))
@@ -910,8 +943,12 @@ class DuoOverlayView(context: Context) : View(context) {
 
         if (isCharging && isBatteryChargingColorEnabled) {
             val chargeAccent = getThemeAdjustedColor(batteryChargingColor)
-            val trackAlpha = if (isDarkTheme) 90 else 110
-            val track = Color.argb(trackAlpha, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
+            val track = if (isDarkTheme) {
+                val trackAlpha = 90
+                Color.argb(trackAlpha, Color.red(chargeAccent), Color.green(chargeAccent), Color.blue(chargeAccent))
+            } else {
+                Color.argb(42, 0, 70, 30)
+            }
             return Triple(track, chargeAccent, chargeAccent)
         }
 
@@ -922,14 +959,14 @@ class DuoOverlayView(context: Context) : View(context) {
             return Triple(track, saveAccent, saveAccent)
         }
 
-        if (showBattery && batteryLevel <= 10 && isBatteryCriticalColorEnabled) {
+        if ((showBattery || showBatteryPercentage) && batteryLevel <= 10 && isBatteryCriticalColorEnabled) {
             val critAccent = getThemeAdjustedColor(batteryCriticalColor)
             val trackAlpha = if (isDarkTheme) 90 else 110
             val track = Color.argb(trackAlpha, Color.red(critAccent), Color.green(critAccent), Color.blue(critAccent))
             return Triple(track, critAccent, critAccent)
         }
 
-        if (showBattery && batteryLevel <= 20 && isBatteryLowColorEnabled) {
+        if ((showBattery || showBatteryPercentage) && batteryLevel <= 20 && isBatteryLowColorEnabled) {
             val lowAccent = getThemeAdjustedColor(batteryLowColor)
             val trackAlpha = if (isDarkTheme) 90 else 110
             val track = Color.argb(trackAlpha, Color.red(lowAccent), Color.green(lowAccent), Color.blue(lowAccent))
@@ -1132,6 +1169,17 @@ class DuoOverlayView(context: Context) : View(context) {
         style = Paint.Style.STROKE
         strokeCap = Paint.Cap.ROUND
     }
+
+    private val batteryTextPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.create(android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
+        letterSpacing = -0.02f
+    }
+    private val contrastBatteryTextPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.create(android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
+        letterSpacing = -0.02f
+    }
     private val iconClipPath = Path()
     private val iconRect = RectF()
     private val arcBounds = RectF()
@@ -1149,6 +1197,7 @@ class DuoOverlayView(context: Context) : View(context) {
         val (track, progress, dot) = getTargetColors()
         currentTrackColor = track
         currentProgressColor = progress
+        animatedBatteryPercentageFraction = if (showBatteryPercentage) 1.0f else 0.0f
         currentDotBaseColor = dot
         trackPaint.color = currentTrackColor
         progressPaint.color = currentProgressColor
@@ -1209,35 +1258,175 @@ class DuoOverlayView(context: Context) : View(context) {
         val baseContrastAlpha = if (isProgressLight) 24 else 28
         val contrastAlpha = (baseContrastAlpha * animatedVisibilityAlpha).toInt()
 
-        if (useUniversalContrast && contrastAlpha > 0) {
-            contrastTrackPaint.color = Color.argb(
-                contrastAlpha,
-                Color.red(contrastColor),
-                Color.green(contrastColor),
-                Color.blue(contrastColor)
-            )
-            canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, contrastTrackPaint)
-        }
+        val bpFraction = animatedBatteryPercentageFraction
+        val isSplitBatteryActive = (bpFraction > 0.001f || showBatteryPercentage) && animatedCustomFraction < 0.5f && showBattery
 
-        val trackAlpha = (Color.alpha(currentTrackColor) * animatedVisibilityAlpha).toInt()
-        trackPaint.color = Color.argb(
-            trackAlpha,
-            Color.red(currentTrackColor),
-            Color.green(currentTrackColor),
-            Color.blue(currentTrackColor)
-        )
-        canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, trackPaint)
+        if (isSplitBatteryActive) {
+            val batteryText = batteryLevel.toString()
+            val dynamicTextSize = (baseRadius * 0.36f).coerceIn(9.5f * density, 15f * density)
+            batteryTextPaint.textSize = dynamicTextSize
+            contrastBatteryTextPaint.textSize = dynamicTextSize
 
-        val progressSweep = (animatedProgress.coerceIn(0f, 100f) / 100f) * animatedTotalSweep
-        if (progressSweep > 0.5f) {
-            val progAlpha = (Color.alpha(currentProgressColor) * animatedVisibilityAlpha).toInt()
-            progressPaint.color = Color.argb(
-                progAlpha,
-                Color.red(currentProgressColor),
-                Color.green(currentProgressColor),
-                Color.blue(currentProgressColor)
+            val textWidth = batteryTextPaint.measureText(batteryText)
+            val gapArcLength = textWidth + 8f * density
+            val fullGapAngleDeg = Math.toDegrees((gapArcLength / baseRadius).toDouble()).toFloat().coerceIn(44f, 66f)
+            val fullHalfGap = fullGapAngleDeg / 2f
+            val halfGap = fullHalfGap * bpFraction
+
+            if (showNetworks || showTime) {
+                val leftStart = 140f
+                val leftEnd = 270f - halfGap
+                val leftSweep = (leftEnd - leftStart).coerceAtLeast(0f)
+                val rightStart = 270f + halfGap
+                val rightEnd = 400f
+                val rightSweep = (rightEnd - rightStart).coerceAtLeast(0f)
+
+                if (useUniversalContrast && contrastAlpha > 0) {
+                    contrastTrackPaint.color = Color.argb(
+                        contrastAlpha,
+                        Color.red(contrastColor),
+                        Color.green(contrastColor),
+                        Color.blue(contrastColor)
+                    )
+                    if (leftSweep > 0.5f) canvas.drawArc(arcBounds, leftStart, leftSweep, false, contrastTrackPaint)
+                    if (rightSweep > 0.5f) canvas.drawArc(arcBounds, rightStart, rightSweep, false, contrastTrackPaint)
+                }
+
+                val trackAlpha = (Color.alpha(currentTrackColor) * animatedVisibilityAlpha).toInt()
+                trackPaint.color = Color.argb(
+                    trackAlpha,
+                    Color.red(currentTrackColor),
+                    Color.green(currentTrackColor),
+                    Color.blue(currentTrackColor)
+                )
+                if (leftSweep > 0.5f) canvas.drawArc(arcBounds, leftStart, leftSweep, false, trackPaint)
+                if (rightSweep > 0.5f) canvas.drawArc(arcBounds, rightStart, rightSweep, false, trackPaint)
+
+                val clampedProg = animatedProgress.coerceIn(0f, 100f)
+                val leftProgSweep = (clampedProg / 50f).coerceIn(0f, 1f) * leftSweep
+                val progAlpha = (Color.alpha(currentProgressColor) * animatedVisibilityAlpha).toInt()
+                progressPaint.color = Color.argb(
+                    progAlpha,
+                    Color.red(currentProgressColor),
+                    Color.green(currentProgressColor),
+                    Color.blue(currentProgressColor)
+                )
+
+                if (leftProgSweep > 0.5f) {
+                    canvas.drawArc(arcBounds, leftStart, leftProgSweep, false, progressPaint)
+                }
+                if (clampedProg > 50f) {
+                    val rightProgSweep = ((clampedProg - 50f) / 50f).coerceIn(0f, 1f) * rightSweep
+                    if (rightProgSweep > 0.5f) {
+                        canvas.drawArc(arcBounds, rightStart, rightProgSweep, false, progressPaint)
+                    }
+                }
+            } else {
+                val effectiveGap = fullGapAngleDeg * bpFraction
+                val trackStart = -90f + effectiveGap / 2f
+                val trackSweep = 360f - effectiveGap
+
+                if (useUniversalContrast && contrastAlpha > 0) {
+                    contrastTrackPaint.color = Color.argb(
+                        contrastAlpha,
+                        Color.red(contrastColor),
+                        Color.green(contrastColor),
+                        Color.blue(contrastColor)
+                    )
+                    canvas.drawArc(arcBounds, trackStart, trackSweep, false, contrastTrackPaint)
+                }
+
+                val trackAlpha = (Color.alpha(currentTrackColor) * animatedVisibilityAlpha).toInt()
+                trackPaint.color = Color.argb(
+                    trackAlpha,
+                    Color.red(currentTrackColor),
+                    Color.green(currentTrackColor),
+                    Color.blue(currentTrackColor)
+                )
+                canvas.drawArc(arcBounds, trackStart, trackSweep, false, trackPaint)
+
+                val clampedProg = animatedProgress.coerceIn(0f, 100f)
+                val progSweep = (clampedProg / 100f) * trackSweep
+                val progAlpha = (Color.alpha(currentProgressColor) * animatedVisibilityAlpha).toInt()
+                progressPaint.color = Color.argb(
+                    progAlpha,
+                    Color.red(currentProgressColor),
+                    Color.green(currentProgressColor),
+                    Color.blue(currentProgressColor)
+                )
+
+                if (progSweep > 0.5f) {
+                    canvas.drawArc(arcBounds, trackStart, progSweep, false, progressPaint)
+                }
+            }
+
+            val digitBounds = android.graphics.Rect()
+            batteryTextPaint.getTextBounds(batteryText, 0, batteryText.length, digitBounds)
+            val nominalCenterY = cameraCenterY - baseRadius - 1.5f * density
+            val minSafeCenterY = 1.5f * density + digitBounds.height() / 2f
+            val actualCenterY = nominalCenterY.coerceAtLeast(minSafeCenterY)
+            val baselineY = actualCenterY - digitBounds.exactCenterY()
+            val textAlpha = (bpFraction * (1f - animatedCustomFraction) * animatedVisibilityAlpha).coerceIn(0f, 1f)
+
+            if (textAlpha > 0.01f) {
+                val textScale = 0.85f + 0.15f * bpFraction
+                val saveText = canvas.save()
+                canvas.scale(textScale, textScale, cameraCenterX, actualCenterY)
+
+                if (useUniversalContrast && contrastAlpha > 0) {
+                    contrastBatteryTextPaint.color = Color.argb(
+                        (contrastAlpha * textAlpha).toInt().coerceIn(0, 255),
+                        Color.red(contrastColor),
+                        Color.green(contrastColor),
+                        Color.blue(contrastColor)
+                    )
+                    contrastBatteryTextPaint.style = Paint.Style.STROKE
+                    contrastBatteryTextPaint.strokeWidth = 2.4f * density
+                    canvas.drawText(batteryText, cameraCenterX, baselineY, contrastBatteryTextPaint)
+                }
+
+                val textColor = currentProgressColor
+                batteryTextPaint.style = Paint.Style.FILL
+                batteryTextPaint.color = Color.argb(
+                    (Color.alpha(textColor) * textAlpha).toInt().coerceIn(0, 255),
+                    Color.red(textColor),
+                    Color.green(textColor),
+                    Color.blue(textColor)
+                )
+                canvas.drawText(batteryText, cameraCenterX, baselineY, batteryTextPaint)
+                canvas.restoreToCount(saveText)
+            }
+        } else {
+            if (useUniversalContrast && contrastAlpha > 0) {
+                contrastTrackPaint.color = Color.argb(
+                    contrastAlpha,
+                    Color.red(contrastColor),
+                    Color.green(contrastColor),
+                    Color.blue(contrastColor)
+                )
+                canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, contrastTrackPaint)
+            }
+
+            val trackAlpha = (Color.alpha(currentTrackColor) * animatedVisibilityAlpha).toInt()
+            trackPaint.color = Color.argb(
+                trackAlpha,
+                Color.red(currentTrackColor),
+                Color.green(currentTrackColor),
+                Color.blue(currentTrackColor)
             )
-            canvas.drawArc(arcBounds, animatedStartAngle, progressSweep, false, progressPaint)
+            canvas.drawArc(arcBounds, animatedStartAngle, animatedTotalSweep, false, trackPaint)
+
+            val progressSweep = (animatedProgress.coerceIn(0f, 100f) / 100f) * animatedTotalSweep
+            if (progressSweep > 0.5f) {
+                val progAlpha = (Color.alpha(currentProgressColor) * animatedVisibilityAlpha).toInt()
+                progressPaint.color = Color.argb(
+                    progAlpha,
+                    Color.red(currentProgressColor),
+                    Color.green(currentProgressColor),
+                    Color.blue(currentProgressColor)
+                )
+                canvas.drawArc(arcBounds, animatedStartAngle, progressSweep, false, progressPaint)
+            }
         }
 
         if (tracerFraction in 0f..1f) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -134,6 +134,7 @@ class MainViewModel : ViewModel() {
     val duoRingRadius = mutableFloatStateOf(1.0f)
     val isDuoShowBattery = mutableStateOf(true)
     val isDuoShowBatteryPercentage = mutableStateOf(false)
+    val isDuoBatteryPercentageOnlyColored = mutableStateOf(false)
     val isDuoBatteryChargingColorEnabled = mutableStateOf(true)
     val duoBatteryChargingColor = mutableStateOf("auto")
     val isDuoBatteryPowerSaveColorEnabled = mutableStateOf(true)
@@ -568,6 +569,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_DUO_SHOW_BATTERY_PERCENTAGE ->
                         isDuoShowBatteryPercentage.value = settingsRepository.isDuoShowBatteryPercentageEnabled()
+
+                    SettingsRepository.KEY_DUO_BATTERY_PERCENTAGE_ONLY_COLORED ->
+                        isDuoBatteryPercentageOnlyColored.value = settingsRepository.isDuoBatteryPercentageOnlyColoredEnabled()
 
                     SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED ->
                         isDuoBatteryChargingColorEnabled.value = settingsRepository.isDuoBatteryChargingColorEnabled()
@@ -1875,6 +1879,7 @@ class MainViewModel : ViewModel() {
         duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
         isDuoShowBattery.value = settingsRepository.isDuoShowBatteryEnabled()
         isDuoShowBatteryPercentage.value = settingsRepository.isDuoShowBatteryPercentageEnabled()
+        isDuoBatteryPercentageOnlyColored.value = settingsRepository.isDuoBatteryPercentageOnlyColoredEnabled()
         isDuoBatteryChargingColorEnabled.value = settingsRepository.isDuoBatteryChargingColorEnabled()
         duoBatteryChargingColor.value = settingsRepository.getDuoBatteryChargingColor()
         isDuoBatteryPowerSaveColorEnabled.value = settingsRepository.isDuoBatteryPowerSaveColorEnabled()
@@ -4511,6 +4516,11 @@ class MainViewModel : ViewModel() {
     fun setDuoShowBatteryPercentage(enabled: Boolean) {
         isDuoShowBatteryPercentage.value = enabled
         settingsRepository.setDuoShowBatteryPercentageEnabled(enabled)
+    }
+
+    fun setDuoBatteryPercentageOnlyColored(enabled: Boolean) {
+        isDuoBatteryPercentageOnlyColored.value = enabled
+        settingsRepository.setDuoBatteryPercentageOnlyColoredEnabled(enabled)
     }
 
     fun setDuoBatteryChargingColorEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -133,6 +133,7 @@ class MainViewModel : ViewModel() {
     val duoDotSize = mutableFloatStateOf(4f)
     val duoRingRadius = mutableFloatStateOf(1.0f)
     val isDuoShowBattery = mutableStateOf(true)
+    val isDuoShowBatteryPercentage = mutableStateOf(false)
     val isDuoBatteryChargingColorEnabled = mutableStateOf(true)
     val duoBatteryChargingColor = mutableStateOf("#00E676")
     val isDuoBatteryPowerSaveColorEnabled = mutableStateOf(true)
@@ -564,6 +565,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_DUO_SHOW_BATTERY ->
                         isDuoShowBattery.value = settingsRepository.isDuoShowBatteryEnabled()
+
+                    SettingsRepository.KEY_DUO_SHOW_BATTERY_PERCENTAGE ->
+                        isDuoShowBatteryPercentage.value = settingsRepository.isDuoShowBatteryPercentageEnabled()
 
                     SettingsRepository.KEY_DUO_BATTERY_CHARGING_COLOR_ENABLED ->
                         isDuoBatteryChargingColorEnabled.value = settingsRepository.isDuoBatteryChargingColorEnabled()
@@ -1870,6 +1874,7 @@ class MainViewModel : ViewModel() {
         duoDotSize.floatValue = settingsRepository.getDuoDotSize()
         duoRingRadius.floatValue = settingsRepository.getDuoRingRadius()
         isDuoShowBattery.value = settingsRepository.isDuoShowBatteryEnabled()
+        isDuoShowBatteryPercentage.value = settingsRepository.isDuoShowBatteryPercentageEnabled()
         isDuoBatteryChargingColorEnabled.value = settingsRepository.isDuoBatteryChargingColorEnabled()
         duoBatteryChargingColor.value = settingsRepository.getDuoBatteryChargingColor()
         isDuoBatteryPowerSaveColorEnabled.value = settingsRepository.isDuoBatteryPowerSaveColorEnabled()
@@ -4494,11 +4499,18 @@ class MainViewModel : ViewModel() {
         isDuoShowBattery.value = enabled
         settingsRepository.setDuoShowBatteryEnabled(enabled)
         if (!enabled) {
+            isDuoShowBatteryPercentage.value = false
+            settingsRepository.setDuoShowBatteryPercentageEnabled(false)
             isDuoShowNetworks.value = false
             settingsRepository.setDuoShowNetworksEnabled(false)
             isDuoShowTime.value = false
             settingsRepository.setDuoShowTimeEnabled(false)
         }
+    }
+
+    fun setDuoShowBatteryPercentage(enabled: Boolean) {
+        isDuoShowBatteryPercentage.value = enabled
+        settingsRepository.setDuoShowBatteryPercentageEnabled(enabled)
     }
 
     fun setDuoBatteryChargingColorEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2472,6 +2472,7 @@
     <string name="duo_section_style">Style</string>
     <string name="duo_section_what_to_show">What to show</string>
     <string name="duo_show_battery_title">Battery</string>
+    <string name="duo_show_battery_percentage_title">Battery percentage</string>
     <string name="duo_battery_options_title">Battery options</string>
     <string name="duo_battery_charging_color_title">Charging</string>
     <string name="duo_battery_power_save_color_title">Battery saver</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2473,6 +2473,9 @@
     <string name="duo_section_what_to_show">What to show</string>
     <string name="duo_show_battery_title">Battery</string>
     <string name="duo_show_battery_percentage_title">Battery percentage</string>
+    <string name="duo_battery_percentage_options_title">Battery percentage options</string>
+    <string name="duo_battery_percentage_only_colored_title">Only for colored instances</string>
+    <string name="duo_battery_percentage_only_colored_desc">Show percentage only when charging, in battery saver, or at low battery levels</string>
     <string name="duo_battery_options_title">Battery options</string>
     <string name="duo_battery_charging_color_title">Charging</string>
     <string name="duo_battery_charging_color_auto">Auto charging speed</string>


### PR DESCRIPTION
People recently discovered that the iPhone version of Duo can actually show the battery percentage at the top of the ring, so I decided to bring that over here! 

When you toggle it on, the top of the circle smoothly opens up to fit the battery percentage numbers right above the camera cutout, with smooth trim animations and proper contrast.

### Preview

https://github.com/user-attachments/assets/919562a8-93ea-4931-951b-8fbbf7eb5f86

---

### What's included:

**Settings & UI:**
* Added a new **Battery percentage** toggle under the Battery section in Duo settings.
* Connected to `MainViewModel` and `SettingsRepository` (automatically turns off if master Battery is disabled so settings don't conflict).

**Appearance & Alignment:**
* Placed the numbers at the top apex with optical digit centering so it looks balanced above the camera cutout.
* Added safe-bound clamping so the text never clips off the top edge of the screen.
* Added universal contrast backing outline so the numbers stay easily readable even on bright/white wallpapers.
* Follows the low-battery color options (<20% yellow, <10% red) to match the dial.

**Smooth Path Animation:**
* Added a smooth 300ms cubic-bezier animation when toggling:
  * **Turning ON:** The top of the ring smoothly recedes downward to clear space as the percentage numbers fade in.
  * **Turning OFF:** The gap smoothly closes back up into a solid horseshoe arc.
* Handled broadcast lifecycle timing so charging animations don't interrupt the dial transition.