### PR TITLE
fix: prevent right-side status bar icons unhiding on unlock and reboot

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/services/receivers/SecurityReceiver.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/receivers/SecurityReceiver.kt
@@ -75,6 +75,7 @@ class SecurityReceiver : BroadcastReceiver() {
                     context,
                     "StatusBarIconAdvancedLocked",
                 )
+                StatusBarManager.reassertFlags(context)
             }
         }
     }

--- a/app/src/main/java/com/sameerasw/essentials/utils/ServiceUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/ServiceUtils.kt
@@ -45,7 +45,7 @@ object ServiceUtils {
         applyPostRebootSettings(context, settingsRepository)
     }
 
-    private fun applyPostRebootSettings(
+    fun applyPostRebootSettings(
         context: Context,
         settingsRepository: SettingsRepository,
     ) {
@@ -54,6 +54,8 @@ object ServiceUtils {
         }
 
         CoroutineScope(Dispatchers.IO).launch {
+            StatusBarManager.update(context)
+
             if (settingsRepository.isSimNamesApplyOnBootEnabled()) {
                 SimCarrierUtil.applySavedCarrierNames(context)
             }

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusBarManager.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusBarManager.kt
@@ -12,6 +12,10 @@ package com.sameerasw.essentials.utils
 
 import android.content.Context
 import com.sameerasw.essentials.data.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 object StatusBarManager {
     // Disable request flags (Official flags from 'cmd statusbar' help)
@@ -61,33 +65,66 @@ object StatusBarManager {
     /**
      * Aggregate all active disable requests along with persistent settings and apply the final status bar state.
      */
-     private fun update(context: Context) {
-         val allFlags = disableRequests.values.flatten().toMutableSet()
+    fun update(context: Context) {
+        val allFlags = disableRequests.values.flatten().toMutableSet()
 
-         val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
-         val isHideSystemIcons = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS, false)
-         val isHideSystemIconsLockedOnly = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS_LOCKED_ONLY, false)
-         val isHideClock = prefs.getBoolean(SettingsRepository.KEY_HIDE_CLOCK, false)
-         val isHideNotificationIcons = prefs.getBoolean(SettingsRepository.KEY_HIDE_NOTIFICATION_ICONS, false)
+        val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
+        val isHideSystemIcons = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS, false)
+        val isHideSystemIconsLockedOnly = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS_LOCKED_ONLY, false)
+        val isHideClock = prefs.getBoolean(SettingsRepository.KEY_HIDE_CLOCK, false)
+        val isHideNotificationIcons = prefs.getBoolean(SettingsRepository.KEY_HIDE_NOTIFICATION_ICONS, false)
 
-         if (isHideSystemIcons && !isHideSystemIconsLockedOnly) {
-             allFlags.add(FLAG_SYSTEM_ICONS)
-         }
-         if (isHideClock) {
-             allFlags.add(FLAG_CLOCK)
-         }
-         if (isHideNotificationIcons) {
-             allFlags.add(FLAG_NOTIFICATION_ICONS)
-         }
+        if (isHideSystemIcons && !isHideSystemIconsLockedOnly) {
+            allFlags.add(FLAG_SYSTEM_ICONS)
+        }
+        if (isHideClock) {
+            allFlags.add(FLAG_CLOCK)
+        }
+        if (isHideNotificationIcons) {
+            allFlags.add(FLAG_NOTIFICATION_ICONS)
+        }
 
-         val command =
-             if (allFlags.isEmpty()) {
-                 "cmd statusbar send-disable-flag none"
-             } else {
-                 "cmd statusbar send-disable-flag ${allFlags.joinToString(" ")}"
-             }
-         ShellUtils.runCommand(context, command)
-     }
+        val command =
+            if (allFlags.isEmpty()) {
+                "cmd statusbar send-disable-flag none"
+            } else {
+                "cmd statusbar send-disable-flag ${allFlags.joinToString(" ")}"
+            }
+        ShellUtils.runCommand(context, command)
+    }
+
+    /**
+     * Re-assert status bar disable flags after keyguard unlock or transition.
+     * Forces a state delta in system_server so the disable event is dispatched
+     * to SystemUI to prevent system icons from unhiding.
+     */
+    fun reassertFlags(context: Context) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val prefs = context.getSharedPreferences(SettingsRepository.PREFS_NAME, Context.MODE_PRIVATE)
+            val isHideSystemIcons = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS, false)
+            val isHideSystemIconsLockedOnly = prefs.getBoolean(SettingsRepository.KEY_HIDE_SYSTEM_ICONS_LOCKED_ONLY, false)
+
+            if (isHideSystemIcons && !isHideSystemIconsLockedOnly) {
+                // Allow SystemUI keyguard dismissal animation to complete
+                delay(250)
+
+                val tempFlags = disableRequests.values.flatten().toMutableSet()
+                if (prefs.getBoolean(SettingsRepository.KEY_HIDE_CLOCK, false)) tempFlags.add(FLAG_CLOCK)
+                if (prefs.getBoolean(SettingsRepository.KEY_HIDE_NOTIFICATION_ICONS, false)) tempFlags.add(FLAG_NOTIFICATION_ICONS)
+
+                val tempCmd =
+                    if (tempFlags.isEmpty()) {
+                        "cmd statusbar send-disable-flag none"
+                    } else {
+                        "cmd statusbar send-disable-flag ${tempFlags.joinToString(" ")}"
+                    }
+
+                ShellUtils.runCommand(context, tempCmd)
+                delay(50)
+            }
+            update(context)
+        }
+    }
 
     // --- Action Commands ---
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/security/ShizukuUtils.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/security/ShizukuUtils.kt
@@ -21,6 +21,13 @@ object ShizukuUtils {
     private val binderReceivedListener =
         Shizuku.OnBinderReceivedListener {
             binder = Shizuku.getBinder()
+            try {
+                if (hasPermission()) {
+                    val appCtx = com.sameerasw.essentials.EssentialsApp.context
+                    StatusBarManager.update(appCtx)
+                }
+            } catch (_: Throwable) {
+            }
         }
 
     private val binderDeadListener =


### PR DESCRIPTION
## Summary

I investigated why the right-side status bar icons unhide on unlock & reboot while the clock stays hidden:

- **On Unlock**: SystemUI's keyguard dismiss resets `mSystemIconArea` to visible. Re-sending the flag fails because `system_server`'s `mDisabled1` already has the flag cached, so it drops the duplicate call.
- **The fix**: Toggling a brief state delta (clear `none` ➔ re-apply `system-icons`) right after unlock forces `system_server` to dispatch the disable event to SystemUI.
- **On Reboot**: The in-memory flag resets on restart. Re-asserting it via Shizuku binder once the token/service connects restores them automatically.

I pushed a draft implementation to this branch (`fix/statusbar-icons-unhiding`). Triggering this delta when keyguard finishes dismissing (e.g. inside `ScreenOffAccessibilityService` or `StatusBarIconHandler`) with Shizuku makes it work cleanly.