### PR TITLE
Feature/status glance

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -409,6 +409,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_SHOW_TIME = "status_glance_show_time"
         const val KEY_STATUS_GLANCE_BACKGROUND_PILL = "status_glance_background_pill"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
+        const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
 
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
@@ -3254,5 +3255,8 @@ class SettingsRepository(
 
     fun isStatusGlanceHideWhenFullscreenEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, true)
     fun setStatusGlanceHideWhenFullscreenEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, enabled)
+
+    fun isStatusGlanceHideInQuickSettingsEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, true)
+    fun setStatusGlanceHideInQuickSettingsEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, enabled)
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -416,6 +416,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING = "status_glance_battery_show_charging"
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_FULL = "status_glance_battery_show_full"
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE = "status_glance_battery_show_otherwise"
+        const val KEY_STATUS_GLANCE_BATTERY_ICON_SIZE = "status_glance_battery_icon_size"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
         const val KEY_STATUS_GLANCE_TAP_ACTION = "status_glance_tap_action"
@@ -3308,6 +3309,9 @@ class SettingsRepository(
 
     fun isStatusGlanceBatteryShowOtherwiseEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, true)
     fun setStatusGlanceBatteryShowOtherwiseEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, enabled)
+
+    fun getStatusGlanceBatteryIconSize(): Float = getFloat(KEY_STATUS_GLANCE_BATTERY_ICON_SIZE, 16f)
+    fun setStatusGlanceBatteryIconSize(size: Float) = putFloat(KEY_STATUS_GLANCE_BATTERY_ICON_SIZE, size)
 
     fun getStatusGlanceTapAction(): Action? = getRemapAction(KEY_STATUS_GLANCE_TAP_ACTION)
     fun setStatusGlanceTapAction(action: Action?) = setRemapAction(KEY_STATUS_GLANCE_TAP_ACTION, action)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -410,6 +410,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_SHOW_MEDIA = "status_glance_show_media"
         const val KEY_STATUS_GLANCE_SHOW_TIME = "status_glance_show_time"
         const val KEY_STATUS_GLANCE_BACKGROUND_PILL = "status_glance_background_pill"
+        const val KEY_STATUS_GLANCE_ALBUM_ART_COLORS = "status_glance_album_art_colors"
         const val KEY_STATUS_GLANCE_SHOW_BATTERY = "status_glance_show_battery"
         const val KEY_STATUS_GLANCE_BATTERY_DISPLAY_MODE = "status_glance_battery_display_mode"
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_LOW = "status_glance_battery_show_low"
@@ -3286,6 +3287,9 @@ class SettingsRepository(
 
     fun isStatusGlanceBackgroundPillEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BACKGROUND_PILL, false)
     fun setStatusGlanceBackgroundPillEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BACKGROUND_PILL, enabled)
+
+    fun isStatusGlanceAlbumArtColorsEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_ALBUM_ART_COLORS, true)
+    fun setStatusGlanceAlbumArtColorsEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_ALBUM_ART_COLORS, enabled)
 
     fun isStatusGlanceHideWhenFullscreenEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, true)
     fun setStatusGlanceHideWhenFullscreenEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -419,6 +419,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_BATTERY_ICON_SIZE = "status_glance_battery_icon_size"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
+        const val KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED = "status_glance_hide_when_locked"
         const val KEY_STATUS_GLANCE_TAP_ACTION = "status_glance_tap_action"
         const val KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION = "status_glance_double_tap_action"
         const val KEY_STATUS_GLANCE_LONG_PRESS_ACTION = "status_glance_long_press_action"
@@ -3291,6 +3292,9 @@ class SettingsRepository(
 
     fun isStatusGlanceHideInQuickSettingsEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, true)
     fun setStatusGlanceHideInQuickSettingsEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, enabled)
+
+    fun isStatusGlanceHideWhenLockedEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED, true)
+    fun setStatusGlanceHideWhenLockedEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED, enabled)
 
     fun isStatusGlanceShowBatteryEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, false)
     fun setStatusGlanceShowBatteryEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -408,6 +408,12 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_SHOW_MEDIA = "status_glance_show_media"
         const val KEY_STATUS_GLANCE_SHOW_TIME = "status_glance_show_time"
         const val KEY_STATUS_GLANCE_BACKGROUND_PILL = "status_glance_background_pill"
+        const val KEY_STATUS_GLANCE_SHOW_BATTERY = "status_glance_show_battery"
+        const val KEY_STATUS_GLANCE_BATTERY_DISPLAY_MODE = "status_glance_battery_display_mode"
+        const val KEY_STATUS_GLANCE_BATTERY_SHOW_LOW = "status_glance_battery_show_low"
+        const val KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING = "status_glance_battery_show_charging"
+        const val KEY_STATUS_GLANCE_BATTERY_SHOW_FULL = "status_glance_battery_show_full"
+        const val KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE = "status_glance_battery_show_otherwise"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
 
@@ -3258,5 +3264,23 @@ class SettingsRepository(
 
     fun isStatusGlanceHideInQuickSettingsEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, true)
     fun setStatusGlanceHideInQuickSettingsEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, enabled)
+
+    fun isStatusGlanceShowBatteryEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, false)
+    fun setStatusGlanceShowBatteryEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, enabled)
+
+    fun getStatusGlanceBatteryDisplayMode(): String = getString(KEY_STATUS_GLANCE_BATTERY_DISPLAY_MODE, "icon") ?: "icon"
+    fun setStatusGlanceBatteryDisplayMode(mode: String) = putString(KEY_STATUS_GLANCE_BATTERY_DISPLAY_MODE, mode)
+
+    fun isStatusGlanceBatteryShowLowEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_LOW, true)
+    fun setStatusGlanceBatteryShowLowEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_LOW, enabled)
+
+    fun isStatusGlanceBatteryShowChargingEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING, true)
+    fun setStatusGlanceBatteryShowChargingEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING, enabled)
+
+    fun isStatusGlanceBatteryShowFullEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_FULL, true)
+    fun setStatusGlanceBatteryShowFullEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_FULL, enabled)
+
+    fun isStatusGlanceBatteryShowOtherwiseEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, true)
+    fun setStatusGlanceBatteryShowOtherwiseEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, enabled)
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -418,6 +418,9 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE = "status_glance_battery_show_otherwise"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
+        const val KEY_STATUS_GLANCE_TAP_ACTION = "status_glance_tap_action"
+        const val KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION = "status_glance_double_tap_action"
+        const val KEY_STATUS_GLANCE_LONG_PRESS_ACTION = "status_glance_long_press_action"
 
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
@@ -3305,5 +3308,14 @@ class SettingsRepository(
 
     fun isStatusGlanceBatteryShowOtherwiseEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, true)
     fun setStatusGlanceBatteryShowOtherwiseEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, enabled)
+
+    fun getStatusGlanceTapAction(): Action? = getRemapAction(KEY_STATUS_GLANCE_TAP_ACTION)
+    fun setStatusGlanceTapAction(action: Action?) = setRemapAction(KEY_STATUS_GLANCE_TAP_ACTION, action)
+
+    fun getStatusGlanceDoubleTapAction(): Action? = getRemapAction(KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION)
+    fun setStatusGlanceDoubleTapAction(action: Action?) = setRemapAction(KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION, action)
+
+    fun getStatusGlanceLongPressAction(): Action? = getRemapAction(KEY_STATUS_GLANCE_LONG_PRESS_ACTION)
+    fun setStatusGlanceLongPressAction(action: Action?) = setRemapAction(KEY_STATUS_GLANCE_LONG_PRESS_ACTION, action)
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -405,6 +405,8 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_FONT_SIZE = "status_glance_font_size"
         const val KEY_STATUS_GLANCE_SHOW_FLASHLIGHT = "status_glance_show_flashlight"
         const val KEY_STATUS_GLANCE_SHOW_CALENDAR = "status_glance_show_calendar"
+        const val KEY_STATUS_GLANCE_CALENDAR_TIMEFRAME = "status_glance_calendar_timeframe"
+        const val KEY_STATUS_GLANCE_CALENDAR_SELECTED_CALENDARS = "status_glance_calendar_selected_calendars"
         const val KEY_STATUS_GLANCE_SHOW_MEDIA = "status_glance_show_media"
         const val KEY_STATUS_GLANCE_SHOW_TIME = "status_glance_show_time"
         const val KEY_STATUS_GLANCE_BACKGROUND_PILL = "status_glance_background_pill"
@@ -3249,6 +3251,27 @@ class SettingsRepository(
 
     fun isStatusGlanceShowCalendarEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_CALENDAR, true)
     fun setStatusGlanceShowCalendarEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_CALENDAR, enabled)
+
+    fun getStatusGlanceCalendarTimeframe(): String = getString(KEY_STATUS_GLANCE_CALENDAR_TIMEFRAME, "today") ?: "today"
+    fun setStatusGlanceCalendarTimeframe(timeframe: String) = putString(KEY_STATUS_GLANCE_CALENDAR_TIMEFRAME, timeframe)
+
+    fun getStatusGlanceCalendarSelectedCalendars(): Set<String> {
+        val json = prefs.getString(KEY_STATUS_GLANCE_CALENDAR_SELECTED_CALENDARS, null)
+        return if (json != null) {
+            try {
+                gson.fromJson(json, Array<String>::class.java).toSet()
+            } catch (e: Exception) {
+                emptySet()
+            }
+        } else {
+            emptySet()
+        }
+    }
+
+    fun saveStatusGlanceCalendarSelectedCalendars(calendarIds: Set<String>) {
+        val json = gson.toJson(calendarIds)
+        putString(KEY_STATUS_GLANCE_CALENDAR_SELECTED_CALENDARS, json)
+    }
 
     fun isStatusGlanceShowMediaEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_MEDIA, true)
     fun setStatusGlanceShowMediaEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_MEDIA, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -396,6 +396,20 @@ class SettingsRepository(
         const val KEY_DUO_SLIDE_TRACK = "duo_slide_track"
         const val KEY_DUO_SLIDE_INVERT_DIRECTION = "duo_slide_invert_direction"
 
+        // Status Glance
+        const val KEY_STATUS_GLANCE_ENABLED = "status_glance_enabled"
+        const val KEY_STATUS_GLANCE_USE_AUTO_DETECT = "status_glance_use_auto_detect"
+        const val KEY_STATUS_GLANCE_OFFSET_X = "status_glance_offset_x"
+        const val KEY_STATUS_GLANCE_OFFSET_Y = "status_glance_offset_y"
+        const val KEY_STATUS_GLANCE_MAX_WIDTH = "status_glance_max_width"
+        const val KEY_STATUS_GLANCE_FONT_SIZE = "status_glance_font_size"
+        const val KEY_STATUS_GLANCE_SHOW_FLASHLIGHT = "status_glance_show_flashlight"
+        const val KEY_STATUS_GLANCE_SHOW_CALENDAR = "status_glance_show_calendar"
+        const val KEY_STATUS_GLANCE_SHOW_MEDIA = "status_glance_show_media"
+        const val KEY_STATUS_GLANCE_SHOW_TIME = "status_glance_show_time"
+        const val KEY_STATUS_GLANCE_BACKGROUND_PILL = "status_glance_background_pill"
+        const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
+
         // Live Wallpaper
         const val LIVE_WALLPAPER_PREFS_NAME = "live_wallpaper_prefs"
         const val KEY_LIVE_WALLPAPER_SELECTED_VIDEO = "selected_video"
@@ -3203,5 +3217,42 @@ class SettingsRepository(
 
     fun isDuoSlideInvertDirectionEnabled(): Boolean = getBoolean(KEY_DUO_SLIDE_INVERT_DIRECTION, false)
     fun setDuoSlideInvertDirection(enabled: Boolean) = putBoolean(KEY_DUO_SLIDE_INVERT_DIRECTION, enabled)
+
+    // Status Glance
+    fun isStatusGlanceEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_ENABLED, false)
+    fun setStatusGlanceEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_ENABLED, enabled)
+
+    fun isStatusGlanceAutoDetectEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_USE_AUTO_DETECT, true)
+    fun setStatusGlanceAutoDetectEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_USE_AUTO_DETECT, enabled)
+
+    fun getStatusGlanceOffsetX(): Float = getFloat(KEY_STATUS_GLANCE_OFFSET_X, 60f)
+    fun setStatusGlanceOffsetX(value: Float) = putFloat(KEY_STATUS_GLANCE_OFFSET_X, value)
+
+    fun getStatusGlanceOffsetY(): Float = getFloat(KEY_STATUS_GLANCE_OFFSET_Y, 2f)
+    fun setStatusGlanceOffsetY(value: Float) = putFloat(KEY_STATUS_GLANCE_OFFSET_Y, value)
+
+    fun getStatusGlanceMaxWidth(): Float = getFloat(KEY_STATUS_GLANCE_MAX_WIDTH, 180f)
+    fun setStatusGlanceMaxWidth(value: Float) = putFloat(KEY_STATUS_GLANCE_MAX_WIDTH, value)
+
+    fun getStatusGlanceFontSize(): Float = getFloat(KEY_STATUS_GLANCE_FONT_SIZE, 13f)
+    fun setStatusGlanceFontSize(value: Float) = putFloat(KEY_STATUS_GLANCE_FONT_SIZE, value)
+
+    fun isStatusGlanceShowFlashlightEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_FLASHLIGHT, true)
+    fun setStatusGlanceShowFlashlightEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_FLASHLIGHT, enabled)
+
+    fun isStatusGlanceShowCalendarEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_CALENDAR, true)
+    fun setStatusGlanceShowCalendarEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_CALENDAR, enabled)
+
+    fun isStatusGlanceShowMediaEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_MEDIA, true)
+    fun setStatusGlanceShowMediaEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_MEDIA, enabled)
+
+    fun isStatusGlanceShowTimeEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_TIME, true)
+    fun setStatusGlanceShowTimeEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_TIME, enabled)
+
+    fun isStatusGlanceBackgroundPillEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BACKGROUND_PILL, false)
+    fun setStatusGlanceBackgroundPillEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BACKGROUND_PILL, enabled)
+
+    fun isStatusGlanceHideWhenFullscreenEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, true)
+    fun setStatusGlanceHideWhenFullscreenEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN, enabled)
 }
 

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/FeatureRegistry.kt
@@ -648,6 +648,32 @@ object FeatureRegistry {
                 ) = viewModel.setStatusBarIconControlEnabled(enabled, context)
             },
             object : Feature(
+                id = "Status glance",
+                title = R.string.feat_status_glance_title,
+                iconRes = R.drawable.rounded_motion_play_24,
+                category = R.string.cat_interface,
+                description = R.string.feat_status_glance_desc,
+                aboutDescription = R.string.about_desc_status_glance,
+                permissionKeys = listOf("ACCESSIBILITY"),
+                hasMoreSettings = true,
+                showToggle = true,
+                isBeta = true,
+                parentFeatureId = "Display",
+            ) {
+                override fun isEnabled(viewModel: MainViewModel) = viewModel.isStatusGlanceEnabled.value
+
+                override fun isToggleEnabled(
+                    viewModel: MainViewModel,
+                    context: Context,
+                ) = viewModel.isAccessibilityEnabled.value
+
+                override fun onToggle(
+                    viewModel: MainViewModel,
+                    context: Context,
+                    enabled: Boolean,
+                ) = viewModel.setStatusGlanceEnabled(enabled)
+            },
+            object : Feature(
                 id = "Maps power saving mode",
                 title = R.string.feat_maps_power_saving_title,
                 iconRes = R.drawable.rounded_navigation_24,

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
@@ -56,6 +56,8 @@ fun initPermissionRegistry() {
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_essentials_on_display_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.feat_aod_wallpaper_title)
     PermissionRegistry.register("ACCESSIBILITY", R.string.duo_title)
+    PermissionRegistry.register("ACCESSIBILITY", R.string.feat_status_glance_title)
+    PermissionRegistry.register("READ_CALENDAR", R.string.feat_status_glance_title)
 
     // Write secure settings permission
     PermissionRegistry.register("WRITE_SECURE_SETTINGS", R.string.feat_statusbar_icons_title)

--- a/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
+++ b/app/src/main/java/com/sameerasw/essentials/domain/registry/PermissionRegistry.kt
@@ -114,6 +114,7 @@ fun initPermissionRegistry() {
     PermissionRegistry.register("NOTIFICATION_LISTENER", R.string.feat_essentials_on_display_title)
     PermissionRegistry.register("NOTIFICATION_LISTENER", R.string.feat_aod_wallpaper_use_album_art)
     PermissionRegistry.register("NOTIFICATION_LISTENER", R.string.duo_title)
+    PermissionRegistry.register("NOTIFICATION_LISTENER", R.string.feat_status_glance_title)
 
     // Bluetooth permissions
     PermissionRegistry.register("BLUETOOTH_CONNECT", R.string.feat_batteries_title)

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -76,6 +76,7 @@ class StatusGlanceHandler(
     private var isLocked = false
     private var isShadeExpanded = false
     private var isFullscreen = false
+    private var isLandscape = false
     private var lastUnlockTimestamp = 0L
 
     private var cachedIsMediaPlaying = false
@@ -244,6 +245,8 @@ class StatusGlanceHandler(
             v.mediaArtist = cachedMediaArtist
             v.mediaArtworkBitmap = cachedMediaArtwork
 
+            isLandscape = service.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            v.isLandscape = isLandscape
             v.isFullscreen = isFullscreen
             v.isShadeExpanded = isShadeExpanded
             v.isLocked = isLocked
@@ -882,6 +885,8 @@ class StatusGlanceHandler(
     fun onConfigurationChanged(newConfig: Configuration) {
         val isNightMode = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
         glanceView?.isDarkTheme = isNightMode
+        isLandscape = newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
+        glanceView?.isLandscape = isLandscape
         if (settingsRepository.isStatusGlanceEnabled()) {
             mainHandler.postDelayed({
                 updateGlancePosition()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -10,6 +10,7 @@
 package com.sameerasw.essentials.services.handlers
 
 import android.accessibilityservice.AccessibilityService
+import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
@@ -19,22 +20,24 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.database.ContentObserver
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.PixelFormat
 import android.graphics.Rect
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.media.MediaMetadata
 import android.media.session.MediaController
+import android.media.session.MediaSession
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
 import android.provider.CalendarContract
 import android.text.format.DateFormat
-import android.util.DisplayMetrics
 import android.view.Gravity
-import android.view.View
 import android.view.WindowManager
 import androidx.core.content.ContextCompat
 import com.google.gson.Gson
@@ -43,6 +46,7 @@ import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.domain.model.AppSelection
 import com.sameerasw.essentials.services.NotificationListener
 import com.sameerasw.essentials.utils.StatusGlanceView
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -62,8 +66,24 @@ class StatusGlanceHandler(
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val settingsRepository by lazy { SettingsRepository(service) }
+    private val keyguardManager by lazy { service.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager }
     private val cameraManager by lazy { service.getSystemService(Context.CAMERA_SERVICE) as CameraManager }
     private val mediaSessionManager by lazy { service.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager }
+
+    private var isScreenOff = false
+    private var isLocked = false
+    private var isShadeExpanded = false
+    private var isFullscreen = false
+    private var lastUnlockTimestamp = 0L
+
+    private var cachedIsMediaPlaying = false
+    private var cachedMediaTitle = ""
+    private var cachedMediaArtist = ""
+    private var cachedMediaArtwork: Bitmap? = null
+    private var cachedEventTitle = ""
+    private var cachedEventTimeMillis = 0L
+    private var cachedIsEventToday = false
+    private var cachedTimeString = ""
 
     private val handlerScope = CoroutineScope(Dispatchers.Main + Job())
     private var calendarObserver: ContentObserver? = null
@@ -82,39 +102,11 @@ class StatusGlanceHandler(
         }
     }
 
+    private val monitoredControllers = mutableListOf<MediaController>()
+    private val controllerCallbacks = mutableMapOf<MediaSession.Token, MediaController.Callback>()
     private var activeMediaController: MediaController? = null
     private var isMediaSessionRegistered = false
-
-    private val mediaCallback = object : MediaController.Callback() {
-        override fun onPlaybackStateChanged(state: PlaybackState?) {
-            updateMediaState(state, activeMediaController?.metadata)
-        }
-
-        override fun onMetadataChanged(metadata: MediaMetadata?) {
-            updateMediaState(activeMediaController?.playbackState, metadata)
-        }
-
-        override fun onSessionDestroyed() {
-            activeMediaController = null
-            findActiveMediaSession()
-        }
-    }
-
-    private val activeSessionsListener =
-        MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
-            val excludedPackages = getExcludedPackages()
-            val valid = controllers?.filter { !excludedPackages.contains(it.packageName) }
-            val active = valid?.firstOrNull {
-                it.playbackState?.state == PlaybackState.STATE_PLAYING
-            } ?: valid?.firstOrNull()
-
-            if (active?.sessionToken != activeMediaController?.sessionToken) {
-                activeMediaController?.unregisterCallback(mediaCallback)
-                activeMediaController = active
-                active?.registerCallback(mediaCallback, mainHandler)
-                updateMediaState(active?.playbackState, active?.metadata)
-            }
-        }
+    private var currentMediaKey: String? = null
 
     private val timeTickReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -126,6 +118,10 @@ class StatusGlanceHandler(
 
     fun init() {
         windowManager = service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+        val powerManager = service.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val isInteractive = powerManager?.isInteractive ?: true
+        isScreenOff = !isInteractive
+        isLocked = keyguardManager?.isKeyguardLocked ?: false
         updateState()
     }
 
@@ -146,14 +142,50 @@ class StatusGlanceHandler(
                 }
 
                 updateTime()
-                syncConfigToView()
                 queryUpcomingCalendarEvent()
+                reEvaluateAndApplyMedia(isInitial = true)
+                syncConfigToView()
             } else {
                 removeOverlay()
                 unregisterTorchCallback()
                 unregisterMediaListener()
                 unregisterCalendarObserver()
                 unregisterTimeReceiver()
+            }
+        }
+    }
+
+    fun setFullscreen(fullscreen: Boolean) {
+        if (isFullscreen != fullscreen) {
+            isFullscreen = fullscreen
+            mainHandler.post {
+                glanceView?.isFullscreen = fullscreen
+            }
+        }
+    }
+
+    fun setShadeExpanded(expanded: Boolean) {
+        if (isScreenOff || isLocked) {
+            if (isShadeExpanded) {
+                isShadeExpanded = false
+                mainHandler.post {
+                    glanceView?.isShadeExpanded = false
+                }
+            }
+            return
+        }
+
+        if (expanded) {
+            val elapsedSinceUnlock = SystemClock.elapsedRealtime() - lastUnlockTimestamp
+            if (elapsedSinceUnlock < 600L) {
+                return
+            }
+        }
+
+        if (isShadeExpanded != expanded) {
+            isShadeExpanded = expanded
+            mainHandler.post {
+                glanceView?.isShadeExpanded = expanded
             }
         }
     }
@@ -167,10 +199,29 @@ class StatusGlanceHandler(
             v.showMedia = settingsRepository.isStatusGlanceShowMediaEnabled()
             v.showTime = settingsRepository.isStatusGlanceShowTimeEnabled()
             v.useBackgroundPill = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+            v.hideWhenFullscreen = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
+            v.hideInQuickSettings = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
             v.maxWidthDp = settingsRepository.getStatusGlanceMaxWidth()
             v.fontSize = settingsRepository.getStatusGlanceFontSize()
             v.isFlashlightOn = isFlashlightOn
+
+            v.nextEventTitle = cachedEventTitle
+            v.nextEventTimeMillis = cachedEventTimeMillis
+            v.isEventToday = cachedIsEventToday
+            v.currentTimeString = cachedTimeString
+
+            v.isMediaPlaying = cachedIsMediaPlaying
+            v.mediaTitle = cachedMediaTitle
+            v.mediaArtist = cachedMediaArtist
+            v.mediaArtworkBitmap = cachedMediaArtwork
+
+            v.isFullscreen = isFullscreen
+            v.isShadeExpanded = isShadeExpanded
+            v.isLocked = isLocked
+            v.isScreenOff = isScreenOff
+
             updateGlancePosition()
+            v.reevaluateSlot()
         }
     }
 
@@ -233,37 +284,19 @@ class StatusGlanceHandler(
         view.glanceCenterY = dm.heightPixels * (offsetYPercent / 100f)
     }
 
-    private fun getCutoutBounds(): Rect? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val windowMetrics = windowManager?.currentWindowMetrics
-            val cutout = windowMetrics?.windowInsets?.displayCutout
-            val rects = cutout?.boundingRects
-            if (!rects.isNullOrEmpty()) {
-                return rects[0]
-            }
-        }
-        return null
-    }
-
-    private fun getStatusBarHeight(): Float {
-        val resourceId = service.resources.getIdentifier("status_bar_height", "dimen", "android")
-        return if (resourceId > 0) {
-            service.resources.getDimensionPixelSize(resourceId).toFloat()
-        } else {
-            24f * service.resources.displayMetrics.density
-        }
-    }
-
     private fun updateTime() {
         val is24Hour = DateFormat.is24HourFormat(service)
         val pattern = if (is24Hour) "HH:mm" else "h:mm"
         val timeFormat = SimpleDateFormat(pattern, Locale.getDefault())
         val formattedTime = timeFormat.format(Date())
+        cachedTimeString = formattedTime
         glanceView?.currentTimeString = formattedTime
     }
 
     private fun queryUpcomingCalendarEvent() {
         if (ContextCompat.checkSelfPermission(service, android.Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+            cachedEventTitle = ""
+            cachedIsEventToday = false
             glanceView?.nextEventTitle = ""
             glanceView?.isEventToday = false
             return
@@ -302,12 +335,17 @@ class StatusGlanceHandler(
                     if (it.moveToFirst()) {
                         val title = it.getString(0) ?: ""
                         val dtStart = it.getLong(1)
+                        cachedEventTitle = title
+                        cachedEventTimeMillis = dtStart
+                        cachedIsEventToday = true
                         withContext(Dispatchers.Main) {
                             glanceView?.nextEventTitle = title
                             glanceView?.nextEventTimeMillis = dtStart
                             glanceView?.isEventToday = true
                         }
                     } else {
+                        cachedEventTitle = ""
+                        cachedIsEventToday = false
                         withContext(Dispatchers.Main) {
                             glanceView?.nextEventTitle = ""
                             glanceView?.isEventToday = false
@@ -315,6 +353,8 @@ class StatusGlanceHandler(
                     }
                 }
             } catch (e: Exception) {
+                cachedEventTitle = ""
+                cachedIsEventToday = false
                 withContext(Dispatchers.Main) {
                     glanceView?.nextEventTitle = ""
                     glanceView?.isEventToday = false
@@ -389,34 +429,6 @@ class StatusGlanceHandler(
         isTorchCallbackRegistered = false
     }
 
-    private fun registerMediaListener() {
-        if (isMediaSessionRegistered) return
-        try {
-            val componentName = ComponentName(service, NotificationListener::class.java)
-            mediaSessionManager?.addOnActiveSessionsChangedListener(
-                activeSessionsListener,
-                componentName,
-                mainHandler
-            )
-            isMediaSessionRegistered = true
-            findActiveMediaSession()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    private fun unregisterMediaListener() {
-        if (!isMediaSessionRegistered) return
-        try {
-            mediaSessionManager?.removeOnActiveSessionsChangedListener(activeSessionsListener)
-            activeMediaController?.unregisterCallback(mediaCallback)
-            activeMediaController = null
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-        isMediaSessionRegistered = false
-    }
-
     private fun getExcludedPackages(): Set<String> {
         val excludedAppsJson = settingsRepository.getString(SettingsRepository.KEY_AOD_WALLPAPER_MEDIA_EXCLUDED_APPS, null)
         return if (!excludedAppsJson.isNullOrBlank()) {
@@ -432,44 +444,221 @@ class StatusGlanceHandler(
         }
     }
 
-    private fun findActiveMediaSession() {
-        try {
-            val componentName = ComponentName(service, NotificationListener::class.java)
-            val controllers = mediaSessionManager?.getActiveSessions(componentName)
-            val excludedPackages = getExcludedPackages()
-            val valid = controllers?.filter { !excludedPackages.contains(it.packageName) }
-            val active = valid?.firstOrNull {
-                it.playbackState?.state == PlaybackState.STATE_PLAYING
-            } ?: valid?.firstOrNull()
+    private var activeSessionsChangedListener: MediaSessionManager.OnActiveSessionsChangedListener? = null
 
-            activeMediaController?.unregisterCallback(mediaCallback)
-            activeMediaController = active
-            active?.registerCallback(mediaCallback, mainHandler)
-            updateMediaState(active?.playbackState, active?.metadata)
-        } catch (e: Exception) {
-            e.printStackTrace()
+    private fun registerMediaListener() {
+        if (!isMediaSessionRegistered && mediaSessionManager != null) {
+            try {
+                val componentName = ComponentName(service, NotificationListener::class.java)
+                val listener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+                    updateActiveMediaSessions(controllers)
+                }
+                activeSessionsChangedListener = listener
+                mediaSessionManager?.addOnActiveSessionsChangedListener(
+                    listener,
+                    componentName,
+                    mainHandler
+                )
+                isMediaSessionRegistered = true
+                val initialControllers = mediaSessionManager?.getActiveSessions(componentName)
+                updateActiveMediaSessions(initialControllers, isInitial = true)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
-    private fun updateMediaState(playbackState: PlaybackState?, metadata: MediaMetadata?) {
-        val excludedPackages = getExcludedPackages()
-        val isExcluded = activeMediaController != null && excludedPackages.contains(activeMediaController?.packageName)
-        val isPlaying = !isExcluded && playbackState?.state == PlaybackState.STATE_PLAYING
-        val title = if (!isExcluded) metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "" else ""
-        val artist = if (!isExcluded) metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: "" else ""
-        val artwork = if (!isExcluded) {
-            metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
-                ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
-        } else null
+    private fun unregisterMediaListener() {
+        if (!isMediaSessionRegistered) return
+        try {
+            activeSessionsChangedListener?.let {
+                mediaSessionManager?.removeOnActiveSessionsChangedListener(it)
+            }
+            activeSessionsChangedListener = null
+            val iterator = controllerCallbacks.entries.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                val controller = monitoredControllers.find { it.sessionToken == entry.key }
+                try {
+                    controller?.unregisterCallback(entry.value)
+                } catch (_: Exception) {}
+                iterator.remove()
+            }
+            monitoredControllers.clear()
+            activeMediaController = null
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        isMediaSessionRegistered = false
+    }
 
+    private fun updateActiveMediaSessions(controllers: List<MediaController>?, isInitial: Boolean = false) {
         mainHandler.post {
-            glanceView?.let { v ->
-                v.isMediaPlaying = isPlaying
-                v.mediaTitle = title
-                v.mediaArtist = artist
-                v.mediaArtworkBitmap = artwork
+            val excludedPackages = getExcludedPackages()
+            val validControllers = controllers?.filter { !excludedPackages.contains(it.packageName) } ?: emptyList()
+
+            val currentTokens = validControllers.map { it.sessionToken }.toSet()
+            val iterator = controllerCallbacks.entries.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (!currentTokens.contains(entry.key)) {
+                    val controller = monitoredControllers.find { it.sessionToken == entry.key }
+                    try {
+                        controller?.unregisterCallback(entry.value)
+                    } catch (_: Exception) {}
+                    iterator.remove()
+                }
+            }
+            monitoredControllers.removeAll { !currentTokens.contains(it.sessionToken) }
+
+            for (controller in validControllers) {
+                if (!controllerCallbacks.containsKey(controller.sessionToken)) {
+                    val callback = object : MediaController.Callback() {
+                        override fun onPlaybackStateChanged(state: PlaybackState?) {
+                            reEvaluateAndApplyMedia()
+                        }
+
+                        override fun onMetadataChanged(metadata: MediaMetadata?) {
+                            reEvaluateAndApplyMedia()
+                        }
+
+                        override fun onSessionDestroyed() {
+                            mainHandler.post {
+                                try {
+                                    controller.unregisterCallback(this)
+                                } catch (_: Exception) {}
+                                controllerCallbacks.remove(controller.sessionToken)
+                                monitoredControllers.removeAll { it.sessionToken == controller.sessionToken }
+                                reEvaluateAndApplyMedia()
+                            }
+                        }
+                    }
+                    try {
+                        controller.registerCallback(callback, mainHandler)
+                        controllerCallbacks[controller.sessionToken] = callback
+                        monitoredControllers.add(controller)
+                    } catch (_: Exception) {}
+                }
+            }
+
+            reEvaluateAndApplyMedia(isInitial = isInitial)
+        }
+    }
+
+    private fun reEvaluateAndApplyMedia(isInitial: Boolean = false) {
+        mainHandler.post {
+            val excludedPackages = getExcludedPackages()
+            val valid = monitoredControllers.filter { !excludedPackages.contains(it.packageName) }
+
+            val currentIsPlaying = activeMediaController?.let { current ->
+                valid.any { it.sessionToken == current.sessionToken } &&
+                    current.playbackState?.state == PlaybackState.STATE_PLAYING
+            } ?: false
+
+            val target = if (currentIsPlaying) {
+                activeMediaController
+            } else {
+                val playingController = valid.firstOrNull {
+                    it.playbackState?.state == PlaybackState.STATE_PLAYING
+                }
+                playingController
+                    ?: valid.firstOrNull { it.sessionToken == activeMediaController?.sessionToken }
+                    ?: valid.firstOrNull()
+            }
+
+            activeMediaController = target
+            checkAndApplyMediaState()
+        }
+    }
+
+    private fun checkAndApplyMediaState() {
+        val showMedia = settingsRepository.isStatusGlanceShowMediaEnabled()
+        val controller = activeMediaController
+        val excludedPackages = getExcludedPackages()
+
+        val isExcluded = controller != null && excludedPackages.contains(controller.packageName)
+        val state = controller?.playbackState
+        val isPlaying = showMedia && !isExcluded && state?.state == PlaybackState.STATE_PLAYING
+
+        val title = if (!isExcluded) controller?.metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "" else ""
+        val artist = if (!isExcluded) controller?.metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: "" else ""
+        val pkg = controller?.packageName ?: ""
+        val mediaKey = "${pkg}_${title}_$artist"
+
+        cachedIsMediaPlaying = isPlaying
+        cachedMediaTitle = title
+        cachedMediaArtist = artist
+
+        if (!isPlaying) {
+            currentMediaKey = null
+            cachedMediaArtwork = null
+            mainHandler.post {
+                glanceView?.let { v ->
+                    v.isMediaPlaying = false
+                    v.mediaTitle = ""
+                    v.mediaArtist = ""
+                    v.mediaArtworkBitmap = null
+                }
+            }
+            return
+        }
+
+        if (currentMediaKey != mediaKey || cachedMediaArtwork == null) {
+            currentMediaKey = mediaKey
+            handlerScope.launch(Dispatchers.IO) {
+                val art = extractMediaArtwork(controller.metadata, controller)
+                withContext(Dispatchers.Main) {
+                    if (currentMediaKey == mediaKey && cachedIsMediaPlaying) {
+                        cachedMediaArtwork = art
+                        glanceView?.let { v ->
+                            v.isMediaPlaying = true
+                            v.mediaTitle = title
+                            v.mediaArtist = artist
+                            v.mediaArtworkBitmap = art
+                        }
+                    }
+                }
+            }
+        } else {
+            mainHandler.post {
+                glanceView?.let { v ->
+                    v.isMediaPlaying = isPlaying
+                    v.mediaTitle = title
+                    v.mediaArtist = artist
+                    v.mediaArtworkBitmap = cachedMediaArtwork
+                }
             }
         }
+    }
+
+    private fun extractMediaArtwork(metadata: MediaMetadata?, controller: MediaController?): Bitmap? {
+        var bitmap = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
+        if (bitmap == null) {
+            bitmap = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+        }
+
+        if (bitmap == null) {
+            val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE)
+            val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST)
+            if (!title.isNullOrBlank()) {
+                val hashToUse = kotlin.math.abs("${title}_$artist".hashCode().toLong())
+                bitmap = NotificationListener.getCachedBitmap(hashToUse)
+                if (bitmap == null) {
+                    val artFile = File(service.cacheDir, "art_$hashToUse.png")
+                    if (artFile.exists()) {
+                        try {
+                            bitmap = BitmapFactory.decodeFile(artFile.absolutePath)
+                        } catch (_: Exception) {}
+                    }
+                }
+            }
+        }
+
+        if (bitmap == null) {
+            bitmap = NotificationListener.getLatestArtBitmap()
+        }
+
+        return bitmap
     }
 
     private fun getCameraId(): String? {
@@ -485,15 +674,42 @@ class StatusGlanceHandler(
     }
 
     fun onScreenOn() {
-        if (settingsRepository.isStatusGlanceEnabled()) {
+        isScreenOff = false
+        isLocked = keyguardManager?.isKeyguardLocked ?: false
+        mainHandler.post {
+            glanceView?.isScreenOff = false
+            glanceView?.isLocked = isLocked
             updateTime()
             queryUpcomingCalendarEvent()
-            updateGlancePosition()
+            reEvaluateAndApplyMedia(isInitial = true)
+            syncConfigToView()
         }
     }
 
     fun onScreenOff() {
-        // Overlay can remain or suspend updates
+        isScreenOff = true
+        isLocked = true
+        mainHandler.post {
+            glanceView?.isScreenOff = true
+            glanceView?.isLocked = true
+            glanceView?.updateVisibilityState(immediate = true)
+        }
+    }
+
+    fun onUserPresent() {
+        isScreenOff = false
+        isLocked = false
+        isShadeExpanded = false
+        lastUnlockTimestamp = SystemClock.elapsedRealtime()
+        mainHandler.post {
+            glanceView?.isScreenOff = false
+            glanceView?.isLocked = false
+            glanceView?.isShadeExpanded = false
+            updateTime()
+            queryUpcomingCalendarEvent()
+            reEvaluateAndApplyMedia(isInitial = true)
+            syncConfigToView()
+        }
     }
 
     fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -292,6 +292,7 @@ class StatusGlanceHandler(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun getOverlayLayoutParams(): WindowManager.LayoutParams {
         val type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
 
@@ -299,7 +300,8 @@ class StatusGlanceHandler(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                 WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
-                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
         )
 
         return WindowManager.LayoutParams(
@@ -326,8 +328,9 @@ class StatusGlanceHandler(
         updateTouchAnchor()
     }
 
+    @Suppress("DEPRECATION")
     private fun updateTouchAnchor() {
-        if (!settingsRepository.isStatusGlanceEnabled() || glanceView == null || windowManager == null || isScreenOff || isLocked || isLandscape || (isFullscreen && settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()) || (isShadeExpanded && settingsRepository.isStatusGlanceHideInQuickSettingsEnabled())) {
+        if (!settingsRepository.isStatusGlanceEnabled() || glanceView == null || windowManager == null || isScreenOff || (isLocked && settingsRepository.isStatusGlanceHideWhenLockedEnabled()) || isLandscape || (isFullscreen && settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()) || (isShadeExpanded && settingsRepository.isStatusGlanceHideInQuickSettingsEnabled())) {
             removeTouchAnchor()
             return
         }
@@ -365,7 +368,8 @@ class StatusGlanceHandler(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
-                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -43,6 +43,7 @@ import android.view.WindowManager
 import androidx.core.content.ContextCompat
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.sameerasw.essentials.R
 import com.sameerasw.essentials.data.repository.SettingsRepository
 import com.sameerasw.essentials.domain.model.AppSelection
 import com.sameerasw.essentials.services.NotificationListener
@@ -372,6 +373,27 @@ class StatusGlanceHandler(
         isBatteryReceiverRegistered = false
     }
 
+    private fun formatRelativeEventTime(eventTimeMillis: Long, now: Long): String {
+        val diffMillis = (eventTimeMillis - now).coerceAtLeast(0L)
+        val minutes = (diffMillis / (60 * 1000L)).toInt()
+        val hours = minutes / 60
+        val days = hours / 24
+
+        val timeStr = when {
+            minutes < 1 -> "1m"
+            minutes < 60 -> "${minutes}m"
+            hours < 24 -> {
+                val remMins = minutes % 60
+                if (remMins > 0) "${hours}h ${remMins}m" else "${hours}h"
+            }
+            else -> {
+                val remHours = hours % 24
+                if (remHours > 0) "${days}d ${remHours}h" else "${days}d"
+            }
+        }
+        return service.getString(R.string.status_glance_calendar_event_in_time, timeStr)
+    }
+
     private fun queryUpcomingCalendarEvent() {
         if (ContextCompat.checkSelfPermission(service, android.Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
             cachedEventTitle = ""
@@ -384,51 +406,110 @@ class StatusGlanceHandler(
         handlerScope.launch(Dispatchers.IO) {
             try {
                 val now = System.currentTimeMillis()
-                val calendar = Calendar.getInstance().apply {
-                    set(Calendar.HOUR_OF_DAY, 23)
-                    set(Calendar.MINUTE, 59)
-                    set(Calendar.SECOND, 59)
-                    set(Calendar.MILLISECOND, 999)
+                val timeframe = settingsRepository.getStatusGlanceCalendarTimeframe()
+                val selectedCalIds = settingsRepository.getStatusGlanceCalendarSelectedCalendars()
+                    .mapNotNull { it.toLongOrNull() }.toSet()
+
+                val maxTimeMillis: Long = when (timeframe) {
+                    "15m" -> now + (15 * 60 * 1000L)
+                    "30m" -> now + (30 * 60 * 1000L)
+                    "1h" -> now + (60 * 60 * 1000L)
+                    "2h" -> now + (2 * 60 * 60 * 1000L)
+                    "6h" -> now + (6 * 60 * 60 * 1000L)
+                    "24h" -> now + (24 * 60 * 60 * 1000L)
+                    "today" -> {
+                        val calendar = Calendar.getInstance().apply {
+                            set(Calendar.HOUR_OF_DAY, 23)
+                            set(Calendar.MINUTE, 59)
+                            set(Calendar.SECOND, 59)
+                            set(Calendar.MILLISECOND, 999)
+                        }
+                        calendar.timeInMillis
+                    }
+                    "next" -> now + (30 * 24 * 60 * 60 * 1000L)
+                    else -> {
+                        val calendar = Calendar.getInstance().apply {
+                            set(Calendar.HOUR_OF_DAY, 23)
+                            set(Calendar.MINUTE, 59)
+                            set(Calendar.SECOND, 59)
+                            set(Calendar.MILLISECOND, 999)
+                        }
+                        calendar.timeInMillis
+                    }
                 }
-                val endOfDay = calendar.timeInMillis
+
+                val builder = CalendarContract.Instances.CONTENT_URI.buildUpon()
+                android.content.ContentUris.appendId(builder, now)
+                android.content.ContentUris.appendId(builder, maxTimeMillis)
 
                 val projection = arrayOf(
-                    CalendarContract.Events.TITLE,
-                    CalendarContract.Events.DTSTART,
-                    CalendarContract.Events.ALL_DAY
+                    CalendarContract.Instances.EVENT_ID,
+                    CalendarContract.Instances.TITLE,
+                    CalendarContract.Instances.BEGIN,
+                    CalendarContract.Instances.END,
+                    CalendarContract.Instances.ALL_DAY,
+                    CalendarContract.Instances.SELF_ATTENDEE_STATUS,
+                    CalendarContract.Instances.CALENDAR_ID
                 )
-
-                val selection = "(${CalendarContract.Events.DTSTART} >= ?) AND (${CalendarContract.Events.DTSTART} <= ?) AND (${CalendarContract.Events.DELETED} = 0)"
-                val selectionArgs = arrayOf(now.toString(), endOfDay.toString())
-                val sortOrder = "${CalendarContract.Events.DTSTART} ASC LIMIT 1"
 
                 val cursor = service.contentResolver.query(
-                    CalendarContract.Events.CONTENT_URI,
+                    builder.build(),
                     projection,
-                    selection,
-                    selectionArgs,
-                    sortOrder
+                    null,
+                    null,
+                    "${CalendarContract.Instances.BEGIN} ASC"
                 )
 
+                var foundTitle: String? = null
+                var foundBegin: Long = 0L
+
                 cursor?.use {
-                    if (it.moveToFirst()) {
-                        val title = it.getString(0) ?: ""
-                        val dtStart = it.getLong(1)
-                        cachedEventTitle = title
-                        cachedEventTimeMillis = dtStart
-                        cachedIsEventToday = true
-                        withContext(Dispatchers.Main) {
-                            glanceView?.nextEventTitle = title
-                            glanceView?.nextEventTimeMillis = dtStart
-                            glanceView?.isEventToday = true
+                    val titleIndex = it.getColumnIndex(CalendarContract.Instances.TITLE)
+                    val beginIndex = it.getColumnIndex(CalendarContract.Instances.BEGIN)
+                    val statusIndex = it.getColumnIndex(CalendarContract.Instances.SELF_ATTENDEE_STATUS)
+                    val calIdIndex = it.getColumnIndex(CalendarContract.Instances.CALENDAR_ID)
+
+                    while (it.moveToNext()) {
+                        val calId = it.getLong(calIdIndex)
+                        if (selectedCalIds.isNotEmpty() && !selectedCalIds.contains(calId)) {
+                            continue
                         }
-                    } else {
-                        cachedEventTitle = ""
-                        cachedIsEventToday = false
-                        withContext(Dispatchers.Main) {
-                            glanceView?.nextEventTitle = ""
-                            glanceView?.isEventToday = false
+
+                        if (statusIndex != -1 && it.getInt(statusIndex) == CalendarContract.Attendees.ATTENDEE_STATUS_DECLINED) {
+                            continue
                         }
+
+                        val rawTitle = it.getString(titleIndex)
+                        if (rawTitle.isNullOrBlank()) {
+                            continue
+                        }
+
+                        val begin = it.getLong(beginIndex)
+                        if (begin >= now && begin <= maxTimeMillis) {
+                            foundTitle = rawTitle.trim()
+                            foundBegin = begin
+                            break
+                        }
+                    }
+                }
+
+                if (foundTitle != null) {
+                    val inTimeStr = formatRelativeEventTime(foundBegin, now)
+                    val fullTitle = "$foundTitle $inTimeStr"
+                    cachedEventTitle = fullTitle
+                    cachedEventTimeMillis = foundBegin
+                    cachedIsEventToday = true
+                    withContext(Dispatchers.Main) {
+                        glanceView?.nextEventTitle = fullTitle
+                        glanceView?.nextEventTimeMillis = foundBegin
+                        glanceView?.isEventToday = true
+                    }
+                } else {
+                    cachedEventTitle = ""
+                    cachedIsEventToday = false
+                    withContext(Dispatchers.Main) {
+                        glanceView?.nextEventTitle = ""
+                        glanceView?.isEventToday = false
                     }
                 }
             } catch (e: Exception) {
@@ -452,6 +533,11 @@ class StatusGlanceHandler(
             }
             service.contentResolver.registerContentObserver(
                 CalendarContract.Events.CONTENT_URI,
+                true,
+                calendarObserver!!
+            )
+            service.contentResolver.registerContentObserver(
+                CalendarContract.Instances.CONTENT_URI,
                 true,
                 calendarObserver!!
             )

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -226,6 +226,7 @@ class StatusGlanceHandler(
             v.useBackgroundPill = settingsRepository.isStatusGlanceBackgroundPillEnabled()
             v.hideWhenFullscreen = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
             v.hideInQuickSettings = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+            v.hideWhenLocked = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
             v.maxWidthDp = settingsRepository.getStatusGlanceMaxWidth()
             v.fontSize = settingsRepository.getStatusGlanceFontSize()
             v.isFlashlightOn = isFlashlightOn

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -1,0 +1,498 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Background Services & Handlers
+ * File: StatusGlanceHandler.kt
+ * Description: Background handler managing the Status Glance ambient overlay indicator.
+ */
+
+package com.sameerasw.essentials.services.handlers
+
+import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.database.ContentObserver
+import android.graphics.Bitmap
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.CalendarContract
+import android.text.format.DateFormat
+import android.util.DisplayMetrics
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import androidx.core.content.ContextCompat
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.services.NotificationListener
+import com.sameerasw.essentials.utils.StatusGlanceView
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class StatusGlanceHandler(
+    private val service: AccessibilityService,
+) {
+    private var windowManager: WindowManager? = null
+    private var glanceView: StatusGlanceView? = null
+    private var isOverlayAdded = false
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private val settingsRepository by lazy { SettingsRepository(service) }
+    private val cameraManager by lazy { service.getSystemService(Context.CAMERA_SERVICE) as CameraManager }
+    private val mediaSessionManager by lazy { service.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager }
+
+    private val handlerScope = CoroutineScope(Dispatchers.Main + Job())
+    private var calendarObserver: ContentObserver? = null
+
+    private var isFlashlightOn = false
+    private var isTorchCallbackRegistered = false
+
+    private val torchCallback = object : CameraManager.TorchCallback() {
+        override fun onTorchModeChanged(cameraId: String, enabled: Boolean) {
+            val primaryId = getCameraId()
+            if (cameraId != primaryId) return
+            mainHandler.post {
+                isFlashlightOn = enabled
+                glanceView?.isFlashlightOn = enabled
+            }
+        }
+    }
+
+    private var activeMediaController: MediaController? = null
+    private var isMediaSessionRegistered = false
+
+    private val mediaCallback = object : MediaController.Callback() {
+        override fun onPlaybackStateChanged(state: PlaybackState?) {
+            updateMediaState(state, activeMediaController?.metadata)
+        }
+
+        override fun onMetadataChanged(metadata: MediaMetadata?) {
+            updateMediaState(activeMediaController?.playbackState, metadata)
+        }
+
+        override fun onSessionDestroyed() {
+            activeMediaController = null
+            findActiveMediaSession()
+        }
+    }
+
+    private val activeSessionsListener =
+        MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+            val active = controllers?.firstOrNull {
+                it.playbackState?.state == PlaybackState.STATE_PLAYING
+            } ?: controllers?.firstOrNull()
+
+            if (active?.sessionToken != activeMediaController?.sessionToken) {
+                activeMediaController?.unregisterCallback(mediaCallback)
+                activeMediaController = active
+                active?.registerCallback(mediaCallback, mainHandler)
+                updateMediaState(active?.playbackState, active?.metadata)
+            }
+        }
+
+    private val timeTickReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            updateTime()
+            queryUpcomingCalendarEvent()
+        }
+    }
+    private var isTimeReceiverRegistered = false
+
+    fun init() {
+        windowManager = service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+        updateState()
+    }
+
+    fun updateState() {
+        mainHandler.post {
+            val isEnabled = settingsRepository.isStatusGlanceEnabled()
+
+            if (isEnabled) {
+                registerTorchCallback()
+                registerMediaListener()
+                registerCalendarObserver()
+                registerTimeReceiver()
+
+                if (!isOverlayAdded) {
+                    createOverlay()
+                } else {
+                    updateOverlayParams()
+                }
+
+                updateTime()
+                syncConfigToView()
+                queryUpcomingCalendarEvent()
+            } else {
+                removeOverlay()
+                unregisterTorchCallback()
+                unregisterMediaListener()
+                unregisterCalendarObserver()
+                unregisterTimeReceiver()
+            }
+        }
+    }
+
+    private fun syncConfigToView() {
+        glanceView?.let { v ->
+            v.showFlashlight = settingsRepository.isStatusGlanceShowFlashlightEnabled()
+            v.showCalendar = settingsRepository.isStatusGlanceShowCalendarEnabled()
+            v.showMedia = settingsRepository.isStatusGlanceShowMediaEnabled()
+            v.showTime = settingsRepository.isStatusGlanceShowTimeEnabled()
+            v.useBackgroundPill = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+            v.maxWidthDp = settingsRepository.getStatusGlanceMaxWidth()
+            v.fontSize = settingsRepository.getStatusGlanceFontSize()
+            v.isFlashlightOn = isFlashlightOn
+            updateGlancePosition()
+        }
+    }
+
+    private fun createOverlay() {
+        if (isOverlayAdded || windowManager == null) return
+
+        glanceView = StatusGlanceView(service)
+        val params = getOverlayLayoutParams()
+
+        try {
+            windowManager?.addView(glanceView, params)
+            isOverlayAdded = true
+            updateGlancePosition()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun updateOverlayParams() {
+        if (!isOverlayAdded || glanceView == null || windowManager == null) return
+        try {
+            val params = getOverlayLayoutParams()
+            windowManager?.updateViewLayout(glanceView, params)
+            updateGlancePosition()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun getOverlayLayoutParams(): WindowManager.LayoutParams {
+        val type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+
+        val flags = (
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+        )
+
+        return WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+            type,
+            flags,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            gravity = Gravity.TOP or Gravity.START
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+        }
+    }
+
+    private fun updateGlancePosition() {
+        val view = glanceView ?: return
+        val dm = service.resources.displayMetrics
+        val offsetXPercent = settingsRepository.getStatusGlanceOffsetX()
+        val offsetYPercent = settingsRepository.getStatusGlanceOffsetY()
+        view.glanceCenterX = dm.widthPixels * (offsetXPercent / 100f)
+        view.glanceCenterY = dm.heightPixels * (offsetYPercent / 100f)
+    }
+
+    private fun getCutoutBounds(): Rect? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val windowMetrics = windowManager?.currentWindowMetrics
+            val cutout = windowMetrics?.windowInsets?.displayCutout
+            val rects = cutout?.boundingRects
+            if (!rects.isNullOrEmpty()) {
+                return rects[0]
+            }
+        }
+        return null
+    }
+
+    private fun getStatusBarHeight(): Float {
+        val resourceId = service.resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resourceId > 0) {
+            service.resources.getDimensionPixelSize(resourceId).toFloat()
+        } else {
+            24f * service.resources.displayMetrics.density
+        }
+    }
+
+    private fun updateTime() {
+        val is24Hour = DateFormat.is24HourFormat(service)
+        val pattern = if (is24Hour) "HH:mm" else "h:mm"
+        val timeFormat = SimpleDateFormat(pattern, Locale.getDefault())
+        val formattedTime = timeFormat.format(Date())
+        glanceView?.currentTimeString = formattedTime
+    }
+
+    private fun queryUpcomingCalendarEvent() {
+        if (ContextCompat.checkSelfPermission(service, android.Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+            glanceView?.nextEventTitle = ""
+            glanceView?.isEventToday = false
+            return
+        }
+
+        handlerScope.launch(Dispatchers.IO) {
+            try {
+                val now = System.currentTimeMillis()
+                val calendar = Calendar.getInstance().apply {
+                    set(Calendar.HOUR_OF_DAY, 23)
+                    set(Calendar.MINUTE, 59)
+                    set(Calendar.SECOND, 59)
+                    set(Calendar.MILLISECOND, 999)
+                }
+                val endOfDay = calendar.timeInMillis
+
+                val projection = arrayOf(
+                    CalendarContract.Events.TITLE,
+                    CalendarContract.Events.DTSTART,
+                    CalendarContract.Events.ALL_DAY
+                )
+
+                val selection = "(${CalendarContract.Events.DTSTART} >= ?) AND (${CalendarContract.Events.DTSTART} <= ?) AND (${CalendarContract.Events.DELETED} = 0)"
+                val selectionArgs = arrayOf(now.toString(), endOfDay.toString())
+                val sortOrder = "${CalendarContract.Events.DTSTART} ASC LIMIT 1"
+
+                val cursor = service.contentResolver.query(
+                    CalendarContract.Events.CONTENT_URI,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    sortOrder
+                )
+
+                cursor?.use {
+                    if (it.moveToFirst()) {
+                        val title = it.getString(0) ?: ""
+                        val dtStart = it.getLong(1)
+                        withContext(Dispatchers.Main) {
+                            glanceView?.nextEventTitle = title
+                            glanceView?.nextEventTimeMillis = dtStart
+                            glanceView?.isEventToday = true
+                        }
+                    } else {
+                        withContext(Dispatchers.Main) {
+                            glanceView?.nextEventTitle = ""
+                            glanceView?.isEventToday = false
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    glanceView?.nextEventTitle = ""
+                    glanceView?.isEventToday = false
+                }
+            }
+        }
+    }
+
+    private fun registerCalendarObserver() {
+        if (calendarObserver != null) return
+        try {
+            calendarObserver = object : ContentObserver(mainHandler) {
+                override fun onChange(selfChange: Boolean) {
+                    queryUpcomingCalendarEvent()
+                }
+            }
+            service.contentResolver.registerContentObserver(
+                CalendarContract.Events.CONTENT_URI,
+                true,
+                calendarObserver!!
+            )
+        } catch (_: Exception) {}
+    }
+
+    private fun unregisterCalendarObserver() {
+        calendarObserver?.let {
+            try {
+                service.contentResolver.unregisterContentObserver(it)
+            } catch (_: Exception) {}
+        }
+        calendarObserver = null
+    }
+
+    private fun registerTimeReceiver() {
+        if (isTimeReceiverRegistered) return
+        try {
+            val filter = IntentFilter().apply {
+                addAction(Intent.ACTION_TIME_TICK)
+                addAction(Intent.ACTION_TIME_CHANGED)
+                addAction(Intent.ACTION_TIMEZONE_CHANGED)
+            }
+            service.registerReceiver(timeTickReceiver, filter)
+            isTimeReceiverRegistered = true
+        } catch (_: Exception) {}
+    }
+
+    private fun unregisterTimeReceiver() {
+        if (!isTimeReceiverRegistered) return
+        try {
+            service.unregisterReceiver(timeTickReceiver)
+        } catch (_: Exception) {}
+        isTimeReceiverRegistered = false
+    }
+
+    private fun registerTorchCallback() {
+        if (isTorchCallbackRegistered) return
+        try {
+            cameraManager.registerTorchCallback(torchCallback, mainHandler)
+            isTorchCallbackRegistered = true
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun unregisterTorchCallback() {
+        if (!isTorchCallbackRegistered) return
+        try {
+            cameraManager.unregisterTorchCallback(torchCallback)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        isTorchCallbackRegistered = false
+    }
+
+    private fun registerMediaListener() {
+        if (isMediaSessionRegistered) return
+        try {
+            val componentName = ComponentName(service, NotificationListener::class.java)
+            mediaSessionManager?.addOnActiveSessionsChangedListener(
+                activeSessionsListener,
+                componentName,
+                mainHandler
+            )
+            isMediaSessionRegistered = true
+            findActiveMediaSession()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun unregisterMediaListener() {
+        if (!isMediaSessionRegistered) return
+        try {
+            mediaSessionManager?.removeOnActiveSessionsChangedListener(activeSessionsListener)
+            activeMediaController?.unregisterCallback(mediaCallback)
+            activeMediaController = null
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        isMediaSessionRegistered = false
+    }
+
+    private fun findActiveMediaSession() {
+        try {
+            val componentName = ComponentName(service, NotificationListener::class.java)
+            val controllers = mediaSessionManager?.getActiveSessions(componentName)
+            val active = controllers?.firstOrNull {
+                it.playbackState?.state == PlaybackState.STATE_PLAYING
+            } ?: controllers?.firstOrNull()
+
+            activeMediaController?.unregisterCallback(mediaCallback)
+            activeMediaController = active
+            active?.registerCallback(mediaCallback, mainHandler)
+            updateMediaState(active?.playbackState, active?.metadata)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun updateMediaState(playbackState: PlaybackState?, metadata: MediaMetadata?) {
+        val isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING
+        val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
+        val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: ""
+        val artwork = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
+            ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+
+        mainHandler.post {
+            glanceView?.let { v ->
+                v.isMediaPlaying = isPlaying
+                v.mediaTitle = title
+                v.mediaArtist = artist
+                v.mediaArtworkBitmap = artwork
+            }
+        }
+    }
+
+    private fun getCameraId(): String? {
+        return try {
+            cameraManager.cameraIdList.firstOrNull { id ->
+                val chars = cameraManager.getCameraCharacteristics(id)
+                val facing = chars.get(CameraCharacteristics.LENS_FACING)
+                facing == CameraCharacteristics.LENS_FACING_BACK
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun onScreenOn() {
+        if (settingsRepository.isStatusGlanceEnabled()) {
+            updateTime()
+            queryUpcomingCalendarEvent()
+            updateGlancePosition()
+        }
+    }
+
+    fun onScreenOff() {
+        // Overlay can remain or suspend updates
+    }
+
+    fun onConfigurationChanged(newConfig: Configuration) {
+        if (settingsRepository.isStatusGlanceEnabled()) {
+            mainHandler.postDelayed({
+                updateGlancePosition()
+            }, 300)
+        }
+    }
+
+    private fun removeOverlay() {
+        if (isOverlayAdded && glanceView != null && windowManager != null) {
+            try {
+                windowManager?.removeView(glanceView)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+            isOverlayAdded = false
+            glanceView = null
+        }
+    }
+
+    fun destroy() {
+        removeOverlay()
+        unregisterTorchCallback()
+        unregisterMediaListener()
+        unregisterCalendarObserver()
+        unregisterTimeReceiver()
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -30,6 +30,7 @@ import android.media.session.MediaController
 import android.media.session.MediaSession
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
+import android.os.BatteryManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -85,6 +86,12 @@ class StatusGlanceHandler(
     private var cachedIsEventToday = false
     private var cachedTimeString = ""
 
+    private var cachedBatteryLevel = 100
+    private var cachedIsBatteryCharging = false
+    private var cachedIsBatteryFull = false
+    private var cachedIsPowerSaveMode = false
+    private var isBatteryReceiverRegistered = false
+
     private val handlerScope = CoroutineScope(Dispatchers.Main + Job())
     private var calendarObserver: ContentObserver? = null
 
@@ -116,6 +123,12 @@ class StatusGlanceHandler(
     }
     private var isTimeReceiverRegistered = false
 
+    private val batteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            updateBatteryStatus(intent)
+        }
+    }
+
     fun init() {
         windowManager = service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
         val powerManager = service.getSystemService(Context.POWER_SERVICE) as? PowerManager
@@ -134,6 +147,7 @@ class StatusGlanceHandler(
                 registerMediaListener()
                 registerCalendarObserver()
                 registerTimeReceiver()
+                registerBatteryReceiver()
 
                 if (!isOverlayAdded) {
                     createOverlay()
@@ -142,6 +156,7 @@ class StatusGlanceHandler(
                 }
 
                 updateTime()
+                updateBatteryStatus()
                 queryUpcomingCalendarEvent()
                 reEvaluateAndApplyMedia(isInitial = true)
                 syncConfigToView()
@@ -151,6 +166,7 @@ class StatusGlanceHandler(
                 unregisterMediaListener()
                 unregisterCalendarObserver()
                 unregisterTimeReceiver()
+                unregisterBatteryReceiver()
             }
         }
     }
@@ -204,6 +220,18 @@ class StatusGlanceHandler(
             v.maxWidthDp = settingsRepository.getStatusGlanceMaxWidth()
             v.fontSize = settingsRepository.getStatusGlanceFontSize()
             v.isFlashlightOn = isFlashlightOn
+
+            v.showBattery = settingsRepository.isStatusGlanceShowBatteryEnabled()
+            v.batteryDisplayMode = settingsRepository.getStatusGlanceBatteryDisplayMode()
+            v.showBatteryWhenLow = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
+            v.showBatteryWhileCharging = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
+            v.showBatteryWhileFull = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
+            v.showBatteryOtherwise = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+
+            v.batteryLevel = cachedBatteryLevel
+            v.isBatteryCharging = cachedIsBatteryCharging
+            v.isBatteryFull = cachedIsBatteryFull
+            v.isPowerSaveMode = cachedIsPowerSaveMode
 
             v.nextEventTitle = cachedEventTitle
             v.nextEventTimeMillis = cachedEventTimeMillis
@@ -291,6 +319,57 @@ class StatusGlanceHandler(
         val formattedTime = timeFormat.format(Date())
         cachedTimeString = formattedTime
         glanceView?.currentTimeString = formattedTime
+    }
+
+    private fun updateBatteryStatus(intent: Intent? = null) {
+        val batteryIntent = intent ?: service.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val level = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, 100) ?: 100
+        val batteryPct = if (level >= 0 && scale > 0) ((level.toFloat() / scale.toFloat()) * 100f).toInt() else 100
+
+        val status = batteryIntent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL
+        val isFull = status == BatteryManager.BATTERY_STATUS_FULL || batteryPct >= 100
+
+        val powerManager = service.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val isPowerSave = powerManager?.isPowerSaveMode ?: false
+
+        cachedBatteryLevel = batteryPct
+        cachedIsBatteryCharging = isCharging
+        cachedIsBatteryFull = isFull
+        cachedIsPowerSaveMode = isPowerSave
+
+        mainHandler.post {
+            glanceView?.let { v ->
+                v.batteryLevel = batteryPct
+                v.isBatteryCharging = isCharging
+                v.isBatteryFull = isFull
+                v.isPowerSaveMode = isPowerSave
+            }
+        }
+    }
+
+    private fun registerBatteryReceiver() {
+        if (isBatteryReceiverRegistered) return
+        try {
+            val filter = IntentFilter().apply {
+                addAction(Intent.ACTION_BATTERY_CHANGED)
+                addAction(Intent.ACTION_POWER_CONNECTED)
+                addAction(Intent.ACTION_POWER_DISCONNECTED)
+                addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+            }
+            service.registerReceiver(batteryReceiver, filter)
+            isBatteryReceiverRegistered = true
+            updateBatteryStatus()
+        } catch (_: Exception) {}
+    }
+
+    private fun unregisterBatteryReceiver() {
+        if (!isBatteryReceiverRegistered) return
+        try {
+            service.unregisterReceiver(batteryReceiver)
+        } catch (_: Exception) {}
+        isBatteryReceiverRegistered = false
     }
 
     private fun queryUpcomingCalendarEvent() {
@@ -680,6 +759,7 @@ class StatusGlanceHandler(
             glanceView?.isScreenOff = false
             glanceView?.isLocked = isLocked
             updateTime()
+            updateBatteryStatus()
             queryUpcomingCalendarEvent()
             reEvaluateAndApplyMedia(isInitial = true)
             syncConfigToView()
@@ -706,6 +786,7 @@ class StatusGlanceHandler(
             glanceView?.isLocked = false
             glanceView?.isShadeExpanded = false
             updateTime()
+            updateBatteryStatus()
             queryUpcomingCalendarEvent()
             reEvaluateAndApplyMedia(isInitial = true)
             syncConfigToView()
@@ -740,5 +821,6 @@ class StatusGlanceHandler(
         unregisterMediaListener()
         unregisterCalendarObserver()
         unregisterTimeReceiver()
+        unregisterBatteryReceiver()
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -39,6 +39,7 @@ import android.os.SystemClock
 import android.provider.CalendarContract
 import android.text.format.DateFormat
 import android.view.Gravity
+import android.view.View
 import android.view.WindowManager
 import androidx.core.content.ContextCompat
 import com.google.gson.Gson
@@ -65,6 +66,9 @@ class StatusGlanceHandler(
     private var windowManager: WindowManager? = null
     private var glanceView: StatusGlanceView? = null
     private var isOverlayAdded = false
+    private var touchAnchorView: View? = null
+    private var isTouchAnchorAdded = false
+    private var touchHandler: StatusGlanceTouchHandler? = null
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val settingsRepository by lazy { SettingsRepository(service) }
@@ -178,6 +182,7 @@ class StatusGlanceHandler(
             isFullscreen = fullscreen
             mainHandler.post {
                 glanceView?.isFullscreen = fullscreen
+                updateTouchAnchor()
             }
         }
     }
@@ -188,6 +193,7 @@ class StatusGlanceHandler(
                 isShadeExpanded = false
                 mainHandler.post {
                     glanceView?.isShadeExpanded = false
+                    updateTouchAnchor()
                 }
             }
             return
@@ -204,6 +210,7 @@ class StatusGlanceHandler(
             isShadeExpanded = expanded
             mainHandler.post {
                 glanceView?.isShadeExpanded = expanded
+                updateTouchAnchor()
             }
         }
     }
@@ -314,6 +321,82 @@ class StatusGlanceHandler(
         val offsetYPercent = settingsRepository.getStatusGlanceOffsetY()
         view.glanceCenterX = dm.widthPixels * (offsetXPercent / 100f)
         view.glanceCenterY = dm.heightPixels * (offsetYPercent / 100f)
+        updateTouchAnchor()
+    }
+
+    private fun updateTouchAnchor() {
+        if (!settingsRepository.isStatusGlanceEnabled() || glanceView == null || windowManager == null || isScreenOff || isLocked || isLandscape || (isFullscreen && settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()) || (isShadeExpanded && settingsRepository.isStatusGlanceHideInQuickSettingsEnabled())) {
+            removeTouchAnchor()
+            return
+        }
+
+        if (touchHandler == null) {
+            touchHandler = StatusGlanceTouchHandler(service)
+        }
+        touchHandler?.apply {
+            this.glanceView = this@StatusGlanceHandler.glanceView
+            this.activeMediaControllerProvider = { activeMediaController }
+        }
+
+        if (touchAnchorView == null) {
+            touchAnchorView = View(service).apply {
+                setOnTouchListener { _, event ->
+                    touchHandler?.onTouchEvent(event) ?: false
+                }
+            }
+        }
+
+        val dm = service.resources.displayMetrics
+        val density = dm.density
+        val maxWidth = settingsRepository.getStatusGlanceMaxWidth() * density
+        val height = 36f * density
+        val width = maxWidth.coerceAtLeast(48f * density).toInt()
+        val heightPx = height.toInt()
+
+        val glanceCenterX = glanceView?.glanceCenterX ?: (dm.widthPixels * (settingsRepository.getStatusGlanceOffsetX() / 100f))
+        val glanceCenterY = glanceView?.glanceCenterY ?: (dm.heightPixels * (settingsRepository.getStatusGlanceOffsetY() / 100f))
+
+        val touchParams = WindowManager.LayoutParams(
+            width,
+            heightPx,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            PixelFormat.TRANSLUCENT
+        ).apply {
+            gravity = Gravity.TOP or Gravity.START
+            x = (glanceCenterX - 8f * density).toInt().coerceAtLeast(0)
+            y = (glanceCenterY - heightPx / 2f).toInt()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+        }
+
+        if (!isTouchAnchorAdded) {
+            try {
+                windowManager?.addView(touchAnchorView, touchParams)
+                isTouchAnchorAdded = true
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        } else {
+            try {
+                windowManager?.updateViewLayout(touchAnchorView, touchParams)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun removeTouchAnchor() {
+        if (isTouchAnchorAdded && touchAnchorView != null && windowManager != null) {
+            try {
+                windowManager?.removeView(touchAnchorView)
+            } catch (_: Exception) {}
+            isTouchAnchorAdded = false
+        }
     }
 
     private fun updateTime() {
@@ -862,6 +945,7 @@ class StatusGlanceHandler(
             glanceView?.isScreenOff = true
             glanceView?.isLocked = true
             glanceView?.updateVisibilityState(immediate = true)
+            removeTouchAnchor()
         }
     }
 
@@ -904,10 +988,13 @@ class StatusGlanceHandler(
             isOverlayAdded = false
             glanceView = null
         }
+        removeTouchAnchor()
     }
 
     fun destroy() {
         removeOverlay()
+        touchAnchorView = null
+        touchHandler = null
         unregisterTorchCallback()
         unregisterMediaListener()
         unregisterCalendarObserver()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -160,6 +160,8 @@ class StatusGlanceHandler(
 
     private fun syncConfigToView() {
         glanceView?.let { v ->
+            val isNightMode = (service.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+            v.isDarkTheme = isNightMode
             v.showFlashlight = settingsRepository.isStatusGlanceShowFlashlightEnabled()
             v.showCalendar = settingsRepository.isStatusGlanceShowCalendarEnabled()
             v.showMedia = settingsRepository.isStatusGlanceShowMediaEnabled()
@@ -495,6 +497,8 @@ class StatusGlanceHandler(
     }
 
     fun onConfigurationChanged(newConfig: Configuration) {
+        val isNightMode = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        glanceView?.isDarkTheme = isNightMode
         if (settingsRepository.isStatusGlanceEnabled()) {
             mainHandler.postDelayed({
                 updateGlancePosition()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -232,6 +232,7 @@ class StatusGlanceHandler(
 
             v.showBattery = settingsRepository.isStatusGlanceShowBatteryEnabled()
             v.batteryDisplayMode = settingsRepository.getStatusGlanceBatteryDisplayMode()
+            v.batteryIconSizeDp = settingsRepository.getStatusGlanceBatteryIconSize()
             v.showBatteryWhenLow = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
             v.showBatteryWhileCharging = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
             v.showBatteryWhileFull = settingsRepository.isStatusGlanceBatteryShowFullEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -224,6 +224,7 @@ class StatusGlanceHandler(
             v.showMedia = settingsRepository.isStatusGlanceShowMediaEnabled()
             v.showTime = settingsRepository.isStatusGlanceShowTimeEnabled()
             v.useBackgroundPill = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+            v.useAlbumArtColors = settingsRepository.isStatusGlanceAlbumArtColorsEnabled()
             v.hideWhenFullscreen = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
             v.hideInQuickSettings = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
             v.hideWhenLocked = settingsRepository.isStatusGlanceHideWhenLockedEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -37,7 +37,10 @@ import android.view.Gravity
 import android.view.View
 import android.view.WindowManager
 import androidx.core.content.ContextCompat
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.domain.model.AppSelection
 import com.sameerasw.essentials.services.NotificationListener
 import com.sameerasw.essentials.utils.StatusGlanceView
 import java.text.SimpleDateFormat
@@ -99,9 +102,11 @@ class StatusGlanceHandler(
 
     private val activeSessionsListener =
         MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
-            val active = controllers?.firstOrNull {
+            val excludedPackages = getExcludedPackages()
+            val valid = controllers?.filter { !excludedPackages.contains(it.packageName) }
+            val active = valid?.firstOrNull {
                 it.playbackState?.state == PlaybackState.STATE_PLAYING
-            } ?: controllers?.firstOrNull()
+            } ?: valid?.firstOrNull()
 
             if (active?.sessionToken != activeMediaController?.sessionToken) {
                 activeMediaController?.unregisterCallback(mediaCallback)
@@ -410,13 +415,30 @@ class StatusGlanceHandler(
         isMediaSessionRegistered = false
     }
 
+    private fun getExcludedPackages(): Set<String> {
+        val excludedAppsJson = settingsRepository.getString(SettingsRepository.KEY_AOD_WALLPAPER_MEDIA_EXCLUDED_APPS, null)
+        return if (!excludedAppsJson.isNullOrBlank()) {
+            try {
+                val listType = object : TypeToken<List<AppSelection>>() {}.type
+                val apps: List<AppSelection> = Gson().fromJson(excludedAppsJson, listType) ?: emptyList()
+                apps.filter { it.isEnabled }.map { it.packageName }.toSet()
+            } catch (_: Exception) {
+                emptySet()
+            }
+        } else {
+            emptySet()
+        }
+    }
+
     private fun findActiveMediaSession() {
         try {
             val componentName = ComponentName(service, NotificationListener::class.java)
             val controllers = mediaSessionManager?.getActiveSessions(componentName)
-            val active = controllers?.firstOrNull {
+            val excludedPackages = getExcludedPackages()
+            val valid = controllers?.filter { !excludedPackages.contains(it.packageName) }
+            val active = valid?.firstOrNull {
                 it.playbackState?.state == PlaybackState.STATE_PLAYING
-            } ?: controllers?.firstOrNull()
+            } ?: valid?.firstOrNull()
 
             activeMediaController?.unregisterCallback(mediaCallback)
             activeMediaController = active
@@ -428,11 +450,15 @@ class StatusGlanceHandler(
     }
 
     private fun updateMediaState(playbackState: PlaybackState?, metadata: MediaMetadata?) {
-        val isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING
-        val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
-        val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: ""
-        val artwork = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
-            ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+        val excludedPackages = getExcludedPackages()
+        val isExcluded = activeMediaController != null && excludedPackages.contains(activeMediaController?.packageName)
+        val isPlaying = !isExcluded && playbackState?.state == PlaybackState.STATE_PLAYING
+        val title = if (!isExcluded) metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "" else ""
+        val artist = if (!isExcluded) metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: "" else ""
+        val artwork = if (!isExcluded) {
+            metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
+                ?: metadata?.getBitmap(MediaMetadata.METADATA_KEY_ART)
+        } else null
 
         mainHandler.post {
             glanceView?.let { v ->

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceTouchHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceTouchHandler.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Background Services & Handlers
+ * File: StatusGlanceTouchHandler.kt
+ * Description: Touch handler managing gestures on Status Glance ambient chip.
+ */
+
+package com.sameerasw.essentials.services.handlers
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.media.AudioManager
+import android.media.session.MediaController
+import android.media.session.PlaybackState
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.view.KeyEvent
+import android.view.MotionEvent
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.domain.HapticFeedbackType
+import com.sameerasw.essentials.domain.diy.Action
+import com.sameerasw.essentials.services.automation.executors.CombinedActionExecutor
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.utils.StatusGlanceView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.hypot
+
+class StatusGlanceTouchHandler(
+    private val service: AccessibilityService,
+) {
+    private val settingsRepository by lazy { SettingsRepository(service) }
+    private val audioManager by lazy { service.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+    private val handler = Handler(Looper.getMainLooper())
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    var glanceView: StatusGlanceView? = null
+    var activeMediaControllerProvider: (() -> MediaController?)? = null
+
+    private var downX: Float = 0f
+    private var downY: Float = 0f
+    private var downTime: Long = 0L
+
+    private var lastTapTime: Long = 0L
+    private var lastTapX: Float = 0f
+    private var lastTapY: Float = 0f
+    private var isDoubleTapPending: Boolean = false
+
+    private var isTouchActive: Boolean = false
+    private var isLongPressTriggered: Boolean = false
+    private var isSwipeThresholdReached: Boolean = false
+    private var isSwiping: Boolean = false
+
+    private val density: Float
+        get() = service.resources.displayMetrics.density
+
+    private val touchSlopPx: Float
+        get() = 10f * density
+
+    private val swipeTriggerPx: Float
+        get() = 36f * density
+
+    private val maxSwipeDistancePx: Float
+        get() = 80f * density
+
+    private val longPressTimeoutMs = 450L
+    private val doubleTapTimeoutMs = 260L
+
+    private var pendingSingleTapRunnable: Runnable? = null
+
+    private val longPressRunnable = Runnable {
+        isLongPressTriggered = true
+        val action = settingsRepository.getStatusGlanceLongPressAction()
+        if (action != null) {
+            HapticUtil.performHapticForService(service, HapticFeedbackType.DOUBLE)
+            glanceView?.triggerTapAnimation()
+            executeAction(action)
+        }
+    }
+
+    fun onTouchEvent(event: MotionEvent): Boolean {
+        val x = event.rawX
+        val y = event.rawY
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                isTouchActive = true
+                downX = x
+                downY = y
+                downTime = SystemClock.uptimeMillis()
+                isLongPressTriggered = false
+                isSwipeThresholdReached = false
+                isSwiping = false
+
+                val doubleTapAction = settingsRepository.getStatusGlanceDoubleTapAction()
+                val isSecondTapInWindow = (downTime - lastTapTime) < doubleTapTimeoutMs &&
+                    hypot(x - lastTapX, y - lastTapY) < touchSlopPx * 1.5f
+
+                if (doubleTapAction != null && isSecondTapInWindow) {
+                    pendingSingleTapRunnable?.let { handler.removeCallbacks(it) }
+                    pendingSingleTapRunnable = null
+                    isDoubleTapPending = true
+                } else {
+                    isDoubleTapPending = false
+                    if (pendingSingleTapRunnable != null) {
+                        pendingSingleTapRunnable?.let {
+                            handler.removeCallbacks(it)
+                            it.run()
+                        }
+                        pendingSingleTapRunnable = null
+                    }
+                }
+
+                if (settingsRepository.getStatusGlanceLongPressAction() != null) {
+                    handler.postDelayed(longPressRunnable, longPressTimeoutMs)
+                }
+                return true
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (!isTouchActive) return false
+
+                val dx = x - downX
+                val dy = y - downY
+                val totalDist = hypot(dx, dy)
+
+                if (totalDist > touchSlopPx) {
+                    handler.removeCallbacks(longPressRunnable)
+                    isDoubleTapPending = false
+                }
+
+                if (isLongPressTriggered) return true
+
+                val isMediaActive = isMediaCurrentlyActive()
+                val isHorizontalDominant = dx > 0f && dx > abs(dy) * 1.1f
+
+                if (isMediaActive && (isSwiping || isHorizontalDominant)) {
+                    isSwiping = true
+                    val clampedOffset = (dx * 0.75f).coerceIn(0f, maxSwipeDistancePx)
+                    glanceView?.setSwipeArtworkOffset(clampedOffset)
+
+                    val isPastThreshold = dx >= swipeTriggerPx
+                    if (isPastThreshold && !isSwipeThresholdReached) {
+                        isSwipeThresholdReached = true
+                        HapticUtil.performHapticForService(service, HapticFeedbackType.TICK)
+                    } else if (!isPastThreshold && isSwipeThresholdReached) {
+                        isSwipeThresholdReached = false
+                    }
+                    return true
+                }
+
+                return true
+            }
+
+            MotionEvent.ACTION_UP -> {
+                if (!isTouchActive) return false
+                isTouchActive = false
+                handler.removeCallbacks(longPressRunnable)
+                glanceView?.releaseSwipeArtwork()
+
+                val elapsed = SystemClock.uptimeMillis() - downTime
+                val dx = x - downX
+                val dy = y - downY
+                val totalDist = hypot(dx, dy)
+
+                if (isSwiping && isSwipeThresholdReached) {
+                    HapticUtil.performHapticForService(service, HapticFeedbackType.DOUBLE)
+                    skipToNextTrack()
+                    return true
+                }
+
+                val didPerformAnyGesture = isLongPressTriggered || (isSwiping && isSwipeThresholdReached)
+
+                if (!didPerformAnyGesture && totalDist < touchSlopPx && elapsed < 350L) {
+                    val doubleTapAction = settingsRepository.getStatusGlanceDoubleTapAction()
+                    val isMediaActive = isMediaCurrentlyActive()
+
+                    if (isDoubleTapPending && doubleTapAction != null) {
+                        isDoubleTapPending = false
+                        lastTapTime = 0L
+                        glanceView?.triggerTapAnimation()
+                        HapticUtil.performHapticForService(service, HapticFeedbackType.DOUBLE)
+                        executeAction(doubleTapAction)
+                    } else if (doubleTapAction != null) {
+                        lastTapTime = SystemClock.uptimeMillis()
+                        lastTapX = downX
+                        lastTapY = downY
+                        val runnable = Runnable {
+                            pendingSingleTapRunnable = null
+                            handleSingleTap(isMediaActive)
+                        }
+                        pendingSingleTapRunnable = runnable
+                        handler.postDelayed(runnable, doubleTapTimeoutMs)
+                    } else {
+                        lastTapTime = 0L
+                        handleSingleTap(isMediaActive)
+                    }
+                }
+
+                return true
+            }
+
+            MotionEvent.ACTION_CANCEL -> {
+                isTouchActive = false
+                handler.removeCallbacks(longPressRunnable)
+                glanceView?.releaseSwipeArtwork()
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun handleSingleTap(isMediaActive: Boolean) {
+        glanceView?.triggerTapAnimation()
+        HapticUtil.performHapticForService(service, HapticFeedbackType.CLICK)
+
+        if (isMediaActive) {
+            togglePlayPause()
+        } else {
+            val tapAction = settingsRepository.getStatusGlanceTapAction()
+            if (tapAction != null) {
+                executeAction(tapAction)
+            }
+        }
+    }
+
+    private fun isMediaCurrentlyActive(): Boolean {
+        return glanceView?.isMediaPlaying == true || audioManager.isMusicActive
+    }
+
+    private fun togglePlayPause() {
+        val controller = activeMediaControllerProvider?.invoke()
+        if (controller != null) {
+            val state = controller.playbackState?.state
+            if (state == PlaybackState.STATE_PLAYING) {
+                controller.transportControls?.pause()
+            } else {
+                controller.transportControls?.play()
+            }
+        } else {
+            dispatchMediaKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+        }
+    }
+
+    private fun skipToNextTrack() {
+        val controller = activeMediaControllerProvider?.invoke()
+        if (controller != null) {
+            controller.transportControls?.skipToNext()
+        } else {
+            dispatchMediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)
+        }
+    }
+
+    private fun dispatchMediaKey(keyCode: Int) {
+        try {
+            audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+            audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun executeAction(action: Action) {
+        scope.launch {
+            try {
+                CombinedActionExecutor.execute(service, action)
+            } catch (_: Exception) {
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -299,7 +299,8 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_MEDIA ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ||
-                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS
             ) {
                 statusGlanceHandler.updateState()
             }
@@ -370,6 +371,7 @@ class ScreenOffAccessibilityService :
 
                         Intent.ACTION_USER_PRESENT -> {
                             aodWallpaperOverlayHandler.onScreenOn()
+                            statusGlanceHandler.onUserPresent()
                             val prefs = getSharedPreferences("essentials_prefs", MODE_PRIVATE)
                             if (prefs.getBoolean("pocket_mode_lock_screen_only", false)) {
                                 pocketModeHandler.onScreenOff() // cancel pending timer + remove overlay
@@ -455,7 +457,9 @@ class ScreenOffAccessibilityService :
         super.onServiceConnected()
         serviceInfo =
             serviceInfo.apply {
-                flags = flags or AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS
+                flags = flags or
+                    AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS or
+                    AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
             }
         updateOmniOverlay()
         duoOverlayHandler.updateState()
@@ -533,6 +537,31 @@ class ScreenOffAccessibilityService :
             event.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED
         ) {
             checkFullscreenState()
+            checkStatusBarExpansion()
+        }
+    }
+
+    private fun checkStatusBarExpansion() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                if (keyguardManager.isKeyguardLocked || !isScreenOn) {
+                    statusGlanceHandler.setShadeExpanded(false)
+                    return
+                }
+                val currentWindows = windows
+                if (currentWindows.isNullOrEmpty()) {
+                    statusGlanceHandler.setShadeExpanded(false)
+                    return
+                }
+
+                val isShadeExpanded = currentWindows.any { window ->
+                    window.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_SYSTEM &&
+                        window.title?.contains("NotificationShade", ignoreCase = true) == true
+                }
+                statusGlanceHandler.setShadeExpanded(isShadeExpanded)
+            } catch (_: Exception) {
+                statusGlanceHandler.setShadeExpanded(false)
+            }
         }
     }
 
@@ -554,6 +583,7 @@ class ScreenOffAccessibilityService :
 
                         val isFullscreen = isCoveringFullDisplay && !hasStatusBar
                         duoOverlayHandler.setFullscreen(isFullscreen)
+                        statusGlanceHandler.setFullscreen(isFullscreen)
                     }
                 }
             } catch (_: Exception) {}

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -300,7 +300,8 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ||
-                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED
             ) {
                 statusGlanceHandler.updateState()
             }

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -248,6 +248,7 @@ class ScreenOffAccessibilityService :
                 aodWallpaperOverlayHandler.updateState()
                 if (key == SettingsRepository.KEY_AOD_WALLPAPER_MEDIA_EXCLUDED_APPS) {
                     duoOverlayHandler.updateState()
+                    statusGlanceHandler.updateState()
                 }
             } else if (key == SettingsRepository.KEY_DUO_ENABLED ||
                 key == SettingsRepository.KEY_DUO_USE_AUTO_DETECT ||

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -299,6 +299,7 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_MEDIA ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_ALBUM_ART_COLORS ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -16,6 +16,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -42,6 +43,7 @@ import com.sameerasw.essentials.services.handlers.NotificationLightingHandler
 import com.sameerasw.essentials.services.handlers.OmniGestureOverlayHandler
 import com.sameerasw.essentials.services.handlers.PocketModeHandler
 import com.sameerasw.essentials.services.handlers.StatusBarIconHandler
+import com.sameerasw.essentials.services.handlers.StatusGlanceHandler
 import com.sameerasw.essentials.services.receivers.FlashlightActionReceiver
 import com.sameerasw.essentials.utils.FreezeManager
 import com.sameerasw.essentials.utils.performHapticFeedback
@@ -71,6 +73,7 @@ class ScreenOffAccessibilityService :
     private lateinit var pocketModeHandler: PocketModeHandler
     private lateinit var smartPixelsHandler: com.sameerasw.essentials.services.handlers.SmartPixelsHandler
     private lateinit var duoOverlayHandler: DuoOverlayHandler
+    private lateinit var statusGlanceHandler: StatusGlanceHandler
 
     private var lightSensor: Sensor? = null
     private var lightSensorLux: Float = 100f
@@ -283,6 +286,21 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_ENABLE_UNSUPPORTED_FEATURES
             ) {
                 duoOverlayHandler.updateState()
+            } else if (key?.startsWith("status_glance_") == true ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_ENABLED ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_USE_AUTO_DETECT ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_OFFSET_X ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_OFFSET_Y ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_MAX_WIDTH ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_FONT_SIZE ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_FLASHLIGHT ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_CALENDAR ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_MEDIA ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN
+            ) {
+                statusGlanceHandler.updateState()
             }
         }
 
@@ -305,11 +323,13 @@ class ScreenOffAccessibilityService :
             com.sameerasw.essentials.services.handlers
                 .SmartPixelsHandler(this)
         duoOverlayHandler = DuoOverlayHandler(this)
+        statusGlanceHandler = StatusGlanceHandler(this)
 
         flashlightHandler.register()
         statusBarIconHandler.register()
         smartPixelsHandler.init()
         duoOverlayHandler.init()
+        statusGlanceHandler.init()
 
         // Screen Receiver
         screenReceiver =
@@ -326,6 +346,7 @@ class ScreenOffAccessibilityService :
                             aodForceTurnOffHandler.removeOverlay()
                             aodWallpaperOverlayHandler.onScreenOn()
                             duoOverlayHandler.onScreenOn()
+                            statusGlanceHandler.onScreenOn()
                             freezeHandler.removeCallbacks(freezeRunnable)
                             stopInputEventListener()
                             updateOmniOverlay()
@@ -340,6 +361,7 @@ class ScreenOffAccessibilityService :
                             ambientGlanceHandler.checkAndShowOnScreenOff()
                             aodWallpaperOverlayHandler.onScreenOff()
                             duoOverlayHandler.onScreenOff()
+                            statusGlanceHandler.onScreenOff()
                             omniGestureOverlayHandler.updateOverlay(false) // Always hide when screen is off
                             pocketModeHandler.onScreenOff()
                             updatePocketModeSensors()
@@ -436,6 +458,7 @@ class ScreenOffAccessibilityService :
             }
         updateOmniOverlay()
         duoOverlayHandler.updateState()
+        statusGlanceHandler.updateState()
     }
 
     private fun updateOmniOverlay() {
@@ -472,6 +495,7 @@ class ScreenOffAccessibilityService :
         omniGestureOverlayHandler.removeOverlay()
         smartPixelsHandler.destroy()
         duoOverlayHandler.destroy()
+        statusGlanceHandler.destroy()
         statusBarIconHandler.unregister()
         stopInputEventListener()
         cancelPocketFlashlightTurnOff()
@@ -653,10 +677,11 @@ class ScreenOffAccessibilityService :
         accuracy: Int,
     ) {}
 
-    override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+    override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         updateOmniOverlay() // Force refresh overlay on rotation
         duoOverlayHandler.onConfigurationChanged(newConfig)
+        statusGlanceHandler.onConfigurationChanged(newConfig)
     }
 
     override fun onKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/com/sameerasw/essentials/ui/activities/FeatureSettingsActivity.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/activities/FeatureSettingsActivity.kt
@@ -71,6 +71,7 @@ import com.sameerasw.essentials.ui.features.system.ButtonRemapSettingsUI
 import com.sameerasw.essentials.ui.features.system.CaffeinateSettingsUI
 import com.sameerasw.essentials.ui.features.system.CalendarSyncSettingsUI
 import com.sameerasw.essentials.ui.features.display.DuoSettingsUI
+import com.sameerasw.essentials.ui.features.display.StatusGlanceSettingsUI
 import com.sameerasw.essentials.ui.features.system.DynamicNightLightSettingsUI
 import com.sameerasw.essentials.ui.features.system.EssentialsOnDisplaySettingsUI
 import com.sameerasw.essentials.ui.features.system.FlashlightPulseSettingsUI
@@ -615,6 +616,7 @@ class FeatureSettingsActivity : AppCompatActivity() {
                                                             "Essentials On Display",
                                                             "Always on Display",
                                                             "Statusbar icons",
+                                                            "Status glance",
                                                             "Maps power saving mode",
                                                             "Duo",
                                                             "Lock screen clock",
@@ -1150,6 +1152,14 @@ class FeatureSettingsActivity : AppCompatActivity() {
 
                                     "Duo" -> {
                                         DuoSettingsUI(
+                                            viewModel = viewModel,
+                                            modifier = Modifier.padding(top = 16.dp),
+                                            highlightSetting = highlightSetting,
+                                        )
+                                    }
+
+                                    "Status glance" -> {
+                                        StatusGlanceSettingsUI(
                                             viewModel = viewModel,
                                             modifier = Modifier.padding(top = 16.dp),
                                             highlightSetting = highlightSetting,

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -42,6 +42,7 @@ import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
 import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
+import com.sameerasw.essentials.ui.features.display.sheets.StatusGlanceBatteryOptionsBottomSheet
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUIHelper
@@ -59,6 +60,7 @@ fun StatusGlanceSettingsUI(
 
     var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
     var showMediaAppSelectionSheet by remember { mutableStateOf(false) }
+    var showBatteryOptionsSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.check(context)
@@ -264,6 +266,20 @@ fun StatusGlanceSettingsUI(
                         },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_show_time"),
                     )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_show_battery_title),
+                        iconRes = R.drawable.battery_android_frame_full_24px,
+                        isChecked = viewModel.isStatusGlanceShowBattery.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceShowBattery(it)
+                        },
+                        onSettingsClick = {
+                            showBatteryOptionsSheet = true
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_show_battery"),
+                    )
                 }
 
                 Text(
@@ -326,6 +342,13 @@ fun StatusGlanceSettingsUI(
                 )
             },
             context = context,
+        )
+    }
+
+    if (showBatteryOptionsSheet) {
+        StatusGlanceBatteryOptionsBottomSheet(
+            viewModel = viewModel,
+            onDismissRequest = { showBatteryOptionsSheet = false },
         )
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -40,6 +40,7 @@ import com.sameerasw.essentials.domain.model.AppPermission
 import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
 import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.utils.HapticUtil
@@ -57,6 +58,7 @@ fun StatusGlanceSettingsUI(
     val view = LocalView.current
 
     var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
+    var showMediaAppSelectionSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.check(context)
@@ -235,9 +237,18 @@ fun StatusGlanceSettingsUI(
                         description = stringResource(R.string.status_glance_show_media_desc),
                         iconRes = R.drawable.rounded_motion_play_24,
                         isChecked = viewModel.isStatusGlanceShowMedia.value,
-                        onCheckedChange = {
+                        onCheckedChange = { isChecked ->
                             HapticUtil.performUIHaptic(view)
-                            viewModel.setStatusGlanceShowMedia(it)
+                            if (isChecked && !viewModel.isNotificationListenerEnabled.value) {
+                                requestingPermissionsFor = Pair(
+                                    R.string.feat_status_glance_title,
+                                    listOf(AppPermission.NOTIFICATION_LISTENER.key)
+                                )
+                            }
+                            viewModel.setStatusGlanceShowMedia(isChecked)
+                        },
+                        onSettingsClick = {
+                            showMediaAppSelectionSheet = true
                         },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_show_media"),
                     )
@@ -282,5 +293,27 @@ fun StatusGlanceSettingsUI(
                 Spacer(modifier = Modifier.height(16.dp))
             }
         }
+    }
+
+    if (showMediaAppSelectionSheet) {
+        AppSelectionSheet(
+            title = stringResource(R.string.duo_media_skip_apps_title),
+            onDismissRequest = { showMediaAppSelectionSheet = false },
+            onLoadApps = { viewModel.loadAodWallpaperMediaApps(it) },
+            onSaveApps = { ctx, apps ->
+                viewModel.saveAodWallpaperMediaApps(
+                    ctx,
+                    apps,
+                )
+            },
+            onAppToggle = { ctx, pkg, enabled ->
+                viewModel.updateAodWallpaperMediaAppEnabled(
+                    ctx,
+                    pkg,
+                    enabled,
+                )
+            },
+            context = context,
+        )
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -448,6 +448,18 @@ fun StatusGlanceSettingsUI(
                     )
 
                     IconToggleItem(
+                        title = stringResource(R.string.status_glance_album_art_colors_title),
+                        description = stringResource(R.string.status_glance_album_art_colors_desc),
+                        iconRes = R.drawable.rounded_palette_24,
+                        isChecked = viewModel.isStatusGlanceAlbumArtColors.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceAlbumArtColors(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_album_art_colors"),
+                    )
+
+                    IconToggleItem(
                         title = stringResource(R.string.status_glance_hide_in_quick_settings_title),
                         description = stringResource(R.string.status_glance_hide_in_quick_settings_desc),
                         iconRes = R.drawable.rounded_top_panel_close_24,

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -20,9 +20,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,19 +38,39 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.data.repository.SettingsRepository
+import com.sameerasw.essentials.domain.diy.Action
+import com.sameerasw.essentials.domain.diy.ActionRegistry
 import com.sameerasw.essentials.domain.model.AppPermission
+import com.sameerasw.essentials.domain.model.AppSelection
+import com.sameerasw.essentials.ui.components.CategoryExpandableSection
 import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
+import com.sameerasw.essentials.ui.core.sheets.CustomSettingsSheet
+import com.sameerasw.essentials.ui.core.sheets.DeviceEffectsSettingsSheet
+import com.sameerasw.essentials.ui.core.sheets.DimWallpaperSettingsSheet
+import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
+import com.sameerasw.essentials.ui.core.sheets.FreezeTagSettingsSheet
 import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
+import com.sameerasw.essentials.ui.core.sheets.ScreenOffSettingsSheet
+import com.sameerasw.essentials.ui.core.sheets.SingleAppSelectionSheet
+import com.sameerasw.essentials.ui.core.sheets.SometimesEssentialsSettingsSheet
+import com.sameerasw.essentials.ui.core.sheets.SoundModeSettingsSheet
+import com.sameerasw.essentials.ui.features.apps.sheets.KeyboardSelectionSheet
+import com.sameerasw.essentials.ui.features.audio.sheets.SetVolumeSettingsSheet
 import com.sameerasw.essentials.ui.features.display.sheets.StatusGlanceBatteryOptionsBottomSheet
 import com.sameerasw.essentials.ui.features.display.sheets.StatusGlanceCalendarOptionsBottomSheet
+import com.sameerasw.essentials.ui.features.system.LikeSongSettingsSheet
+import com.sameerasw.essentials.ui.features.system.RemapActionItem
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUIHelper
+import com.sameerasw.essentials.utils.ShellUtils
 import com.sameerasw.essentials.viewmodels.MainViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -64,8 +88,62 @@ fun StatusGlanceSettingsUI(
     var showBatteryOptionsSheet by remember { mutableStateOf(false) }
     var showCalendarOptionsSheet by remember { mutableStateOf(false) }
 
+    var pickingActionForGesture by remember { mutableStateOf<String?>(null) }
+    var activeConfigGesture by remember { mutableStateOf<String?>(null) }
+
+    var showFlashlightOptions by remember { mutableStateOf(false) }
+    val showLikeSongOptions = remember { mutableStateOf(false) }
+
+    var showDimSettings by remember { mutableStateOf(false) }
+    var showScreenOffSettings by remember { mutableStateOf(false) }
+    var showDeviceEffectsSettings by remember { mutableStateOf(false) }
+    var showSoundModeSettings by remember { mutableStateOf(false) }
+    var showSometimesEssentialsSettings by remember { mutableStateOf(false) }
+    var showFreezeTagSettings by remember { mutableStateOf(false) }
+    var showOpenAppSettings by remember { mutableStateOf(false) }
+    var showFreezeAppsSettings by remember { mutableStateOf(false) }
+    var temporarySelectedAppsForAction by remember { mutableStateOf<List<String>>(emptyList()) }
+    var showSetKeyboardSheet by remember { mutableStateOf(false) }
+    var showCustomSettingsSettings by remember { mutableStateOf(false) }
+    var showSetVolumeSettings by remember { mutableStateOf(false) }
+    var configAction by remember { mutableStateOf<Action?>(null) }
+
+    var showPermissionSheet by remember { mutableStateOf(false) }
+    var permissionKeysToShow by remember { mutableStateOf<List<String>>(emptyList()) }
+    var permissionFeatureTitle by remember { mutableStateOf<Any>("") }
+
     LaunchedEffect(Unit) {
         viewModel.check(context)
+    }
+
+    fun getMissingPermissionsHelper(action: Action?): List<String> {
+        if (action == null) return emptyList()
+        val resolvedPermissions = action.permissions.map { permKey ->
+            if (permKey == "SHIZUKU" || permKey == "ROOT") {
+                if (ShellUtils.isRootEnabled(context)) "ROOT" else "SHIZUKU"
+            } else {
+                permKey
+            }
+        }.distinct()
+
+        return resolvedPermissions.filter { permKey ->
+            when (permKey) {
+                "SHIZUKU" -> !viewModel.isShizukuPermissionGranted.value
+                "ROOT" -> !viewModel.isRootPermissionGranted.value
+                "WRITE_SETTINGS" -> !viewModel.isWriteSettingsEnabled.value
+                "NOTIFICATION_POLICY" -> !viewModel.isNotificationPolicyAccessGranted.value
+                "WRITE_SECURE_SETTINGS" -> !viewModel.isWriteSecureSettingsEnabled.value
+                else -> false
+            }
+        }
+    }
+
+    fun applyActionForGesture(gesture: String?, action: Action?) {
+        when (gesture) {
+            "tap" -> viewModel.setStatusGlanceTapAction(action)
+            "double_tap" -> viewModel.setStatusGlanceDoubleTapAction(action)
+            "long_press" -> viewModel.setStatusGlanceLongPressAction(action)
+        }
     }
 
     if (requestingPermissionsFor != null) {
@@ -101,7 +179,7 @@ fun StatusGlanceSettingsUI(
                     if (isChecked && !viewModel.isAccessibilityEnabled.value) {
                         requestingPermissionsFor = Pair(
                             R.string.feat_status_glance_title,
-                            listOf("ACCESSIBILITY")
+                            listOf(AppPermission.ACCESSIBILITY.key)
                         )
                     } else {
                         viewModel.setStatusGlanceEnabled(isChecked)
@@ -284,6 +362,69 @@ fun StatusGlanceSettingsUI(
                 }
 
                 Text(
+                    text = stringResource(R.string.status_glance_section_gestures),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    val tapAction = viewModel.statusGlanceTapAction.value
+                    val tapDescription = if (tapAction != null) {
+                        "${stringResource(R.string.status_glance_action_tap_media_desc)} • ${stringResource(tapAction.title)}"
+                    } else {
+                        stringResource(R.string.status_glance_action_tap_media_desc)
+                    }
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_touch_app_24,
+                        title = stringResource(R.string.status_glance_action_tap_title),
+                        description = tapDescription,
+                        showToggle = false,
+                        onClick = {
+                            HapticUtil.performVirtualKeyHaptic(view)
+                            pickingActionForGesture = "tap"
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_tap_action"),
+                    )
+
+                    val doubleTapAction = viewModel.statusGlanceDoubleTapAction.value
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_touch_app_24,
+                        title = stringResource(R.string.status_glance_action_double_tap_title),
+                        description = doubleTapAction?.let { stringResource(it.title) } ?: stringResource(R.string.status_glance_action_none),
+                        showToggle = false,
+                        onClick = {
+                            HapticUtil.performVirtualKeyHaptic(view)
+                            pickingActionForGesture = "double_tap"
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_double_tap_action"),
+                    )
+
+                    val longPressAction = viewModel.statusGlanceLongPressAction.value
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_front_hand_24,
+                        title = stringResource(R.string.status_glance_action_long_press_title),
+                        description = longPressAction?.let { stringResource(it.title) } ?: stringResource(R.string.status_glance_action_none),
+                        showToggle = false,
+                        onClick = {
+                            HapticUtil.performVirtualKeyHaptic(view)
+                            pickingActionForGesture = "long_press"
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_long_press_action"),
+                    )
+
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_skip_next_24,
+                        title = stringResource(R.string.status_glance_action_swipe_right_title),
+                        description = stringResource(R.string.status_glance_action_swipe_right_desc),
+                        showToggle = false,
+                    )
+                }
+
+                Text(
                     text = stringResource(R.string.status_glance_section_appearance),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -358,5 +499,361 @@ fun StatusGlanceSettingsUI(
             viewModel = viewModel,
             onDismissRequest = { showCalendarOptionsSheet = false },
         )
+    }
+
+    if (pickingActionForGesture != null) {
+        val currentGesture = pickingActionForGesture
+        val currentAction = when (currentGesture) {
+            "tap" -> viewModel.statusGlanceTapAction.value
+            "double_tap" -> viewModel.statusGlanceDoubleTapAction.value
+            "long_press" -> viewModel.statusGlanceLongPressAction.value
+            else -> null
+        }
+
+        EssentialsBottomSheet(
+            onDismissRequest = { pickingActionForGesture = null },
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.status_glance_action_pick_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                RoundedCardContainer(spacing = 2.dp) {
+                    RemapActionItem(
+                        title = stringResource(R.string.status_glance_action_none),
+                        isSelected = currentAction == null,
+                        onClick = {
+                            applyActionForGesture(currentGesture, null)
+                            pickingActionForGesture = null
+                        },
+                        iconRes = R.drawable.rounded_do_not_disturb_on_24,
+                    )
+                }
+
+                val actionCategories = remember {
+                    ActionRegistry.getCategories(screenOnOnly = false)
+                }
+
+                var expandedActionCategory by remember {
+                    mutableStateOf<Int?>(
+                        actionCategories.firstOrNull { category ->
+                            category.actions.any { currentAction != null && it::class == currentAction::class }
+                        }?.titleRes ?: actionCategories.firstOrNull()?.titleRes
+                    )
+                }
+
+                actionCategories.forEach { category ->
+                    CategoryExpandableSection(
+                        title = stringResource(category.titleRes),
+                        itemCount = category.actions.size,
+                        isExpanded = expandedActionCategory == category.titleRes,
+                        onToggleExpand = {
+                            expandedActionCategory =
+                                if (expandedActionCategory == category.titleRes) null else category.titleRes
+                        },
+                    ) {
+                        category.actions.forEach { action ->
+                            val resolvedAction =
+                                if (currentAction != null && currentAction::class == action::class) currentAction else action
+                            val isSelected =
+                                currentAction != null && currentAction::class == resolvedAction::class
+                            val missing = getMissingPermissionsHelper(resolvedAction)
+
+                            fun showMissingPermissionSheet() {
+                                permissionKeysToShow = missing
+                                permissionFeatureTitle = resolvedAction.title
+                                showPermissionSheet = true
+                            }
+
+                            RemapActionItem(
+                                title = stringResource(resolvedAction.title),
+                                iconRes = resolvedAction.icon,
+                                isSelected = isSelected,
+                                hasSettings = resolvedAction.isConfigurable ||
+                                    resolvedAction is Action.ToggleFlashlight ||
+                                    resolvedAction is Action.LikeCurrentSong,
+                                onClick = {
+                                    applyActionForGesture(currentGesture, resolvedAction)
+                                    pickingActionForGesture = null
+                                    if (missing.isNotEmpty()) {
+                                        showMissingPermissionSheet()
+                                    }
+                                },
+                                onSettingsClick = {
+                                    activeConfigGesture = currentGesture
+                                    if (resolvedAction is Action.ToggleFlashlight) {
+                                        showFlashlightOptions = true
+                                        return@RemapActionItem
+                                    }
+                                    if (resolvedAction is Action.LikeCurrentSong) {
+                                        showLikeSongOptions.value = true
+                                        return@RemapActionItem
+                                    }
+                                    if (missing.isNotEmpty()) {
+                                        showMissingPermissionSheet()
+                                        return@RemapActionItem
+                                    }
+
+                                    configAction = resolvedAction
+                                    when (resolvedAction) {
+                                        is Action.DimWallpaper -> showDimSettings = true
+                                        is Action.ScreenOff -> showScreenOffSettings = true
+                                        is Action.DeviceEffects -> showDeviceEffectsSettings = true
+                                        is Action.SoundMode -> showSoundModeSettings = true
+                                        is Action.SometimesEssentials -> showSometimesEssentialsSettings = true
+                                        is Action.FreezeTag -> showFreezeTagSettings = true
+                                        is Action.OpenApp -> showOpenAppSettings = true
+                                        is Action.FreezeApps -> {
+                                            temporarySelectedAppsForAction = resolvedAction.packageNames
+                                            showFreezeAppsSettings = true
+                                        }
+                                        is Action.UnfreezeApps -> {
+                                            temporarySelectedAppsForAction = resolvedAction.packageNames
+                                            showFreezeAppsSettings = true
+                                        }
+                                        is Action.Keyboard -> showSetKeyboardSheet = true
+                                        is Action.SetVolume -> showSetVolumeSettings = true
+                                        is Action.CustomSettings -> showCustomSettingsSettings = true
+                                        else -> {}
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showLikeSongOptions.value) {
+        LikeSongSettingsSheet(
+            onDismiss = { showLikeSongOptions.value = false },
+            viewModel = viewModel,
+            context = context,
+        )
+    }
+
+    if (showFlashlightOptions) {
+        ModalBottomSheet(
+            onDismissRequest = { showFlashlightOptions = false },
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp, top = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.flashlight_options_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                RoundedCardContainer(spacing = 2.dp) {
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_blur_on_24,
+                        title = stringResource(R.string.flashlight_fade_title),
+                        description = stringResource(R.string.flashlight_fade_desc),
+                        isChecked = viewModel.isFlashlightFadeEnabled.value,
+                        onCheckedChange = { viewModel.setFlashlightFadeEnabled(it, context) },
+                    )
+
+                    IconToggleItem(
+                        iconRes = R.drawable.rounded_flashlight_on_24,
+                        title = stringResource(R.string.flashlight_always_off_title),
+                        description = stringResource(R.string.flashlight_always_off_desc),
+                        isChecked = viewModel.isFlashlightAlwaysTurnOffEnabled.value,
+                        onCheckedChange = {
+                            viewModel.setFlashlightAlwaysTurnOffEnabled(it, context)
+                        },
+                    )
+                }
+
+                Button(
+                    onClick = {
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        showFlashlightOptions = false
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.extraLarge,
+                ) {
+                    Text(stringResource(R.string.action_done))
+                }
+            }
+        }
+    }
+
+    if (showDimSettings && configAction is Action.DimWallpaper) {
+        DimWallpaperSettingsSheet(
+            initialAction = configAction as Action.DimWallpaper,
+            onDismiss = { showDimSettings = false },
+            onSave = { newAction ->
+                showDimSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showScreenOffSettings && configAction is Action.ScreenOff) {
+        ScreenOffSettingsSheet(
+            initialAction = configAction as Action.ScreenOff,
+            onDismiss = { showScreenOffSettings = false },
+            onSave = { newAction ->
+                showScreenOffSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showDeviceEffectsSettings && configAction is Action.DeviceEffects) {
+        DeviceEffectsSettingsSheet(
+            initialAction = configAction as Action.DeviceEffects,
+            onDismiss = { showDeviceEffectsSettings = false },
+            onSave = { newAction ->
+                showDeviceEffectsSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showSoundModeSettings && configAction is Action.SoundMode) {
+        SoundModeSettingsSheet(
+            initialAction = configAction as Action.SoundMode,
+            onDismiss = { showSoundModeSettings = false },
+            onSave = { newAction ->
+                showSoundModeSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showSetVolumeSettings && configAction is Action.SetVolume) {
+        SetVolumeSettingsSheet(
+            initialAction = configAction as Action.SetVolume,
+            onDismiss = { showSetVolumeSettings = false },
+            onSave = { newAction ->
+                showSetVolumeSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showSometimesEssentialsSettings && configAction is Action.SometimesEssentials) {
+        SometimesEssentialsSettingsSheet(
+            initialAction = configAction as Action.SometimesEssentials,
+            onDismiss = { showSometimesEssentialsSettings = false },
+            onSave = { newAction ->
+                showSometimesEssentialsSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showFreezeTagSettings && configAction is Action.FreezeTag) {
+        val availableTags = remember {
+            SettingsRepository(context).getFreezeTags()
+        }
+        FreezeTagSettingsSheet(
+            initialAction = configAction as Action.FreezeTag,
+            availableTags = availableTags,
+            onDismiss = { showFreezeTagSettings = false },
+            onSave = { newAction ->
+                showFreezeTagSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showOpenAppSettings) {
+        SingleAppSelectionSheet(
+            onDismissRequest = { showOpenAppSettings = false },
+            onAppSelected = { app ->
+                val newAction = Action.OpenApp(packageName = app.packageName)
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showFreezeAppsSettings && (configAction is Action.FreezeApps || configAction is Action.UnfreezeApps)) {
+        AppSelectionSheet(
+            onDismissRequest = {
+                val finalAction = when (val action = configAction) {
+                    is Action.FreezeApps -> action.copy(packageNames = temporarySelectedAppsForAction)
+                    is Action.UnfreezeApps -> action.copy(packageNames = temporarySelectedAppsForAction)
+                    else -> configAction
+                }
+                if (finalAction != null) {
+                    applyActionForGesture(activeConfigGesture, finalAction)
+                }
+                showFreezeAppsSettings = false
+                configAction = null
+            },
+            onLoadApps = {
+                temporarySelectedAppsForAction.map { AppSelection(it, true) }
+            },
+            onSaveApps = { _, selections ->
+                temporarySelectedAppsForAction = selections.filter { it.isEnabled }.map { it.packageName }
+            },
+        )
+    }
+
+    if (showSetKeyboardSheet && configAction is Action.Keyboard) {
+        KeyboardSelectionSheet(
+            onDismissRequest = { newIme ->
+                showSetKeyboardSheet = false
+                applyActionForGesture(activeConfigGesture, Action.Keyboard(newIme))
+                configAction = null
+            },
+            selectedIme = (configAction as? Action.Keyboard)?.inputMethodId,
+        )
+    }
+
+    if (showCustomSettingsSettings && configAction is Action.CustomSettings) {
+        CustomSettingsSheet(
+            initialAction = configAction as Action.CustomSettings,
+            onDismiss = { showCustomSettingsSettings = false },
+            onSave = { newAction ->
+                showCustomSettingsSettings = false
+                applyActionForGesture(activeConfigGesture, newAction)
+                configAction = null
+            },
+        )
+    }
+
+    if (showPermissionSheet) {
+        val permissionItems = PermissionUIHelper.getPermissionItems(
+            permissionKeysToShow,
+            context,
+            viewModel,
+        )
+        if (permissionItems.isNotEmpty()) {
+            PermissionsBottomSheet(
+                onDismissRequest = {
+                    showPermissionSheet = false
+                    permissionKeysToShow = emptyList()
+                },
+                featureTitle = permissionFeatureTitle,
+                permissions = permissionItems,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -43,6 +43,7 @@ import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.AppSelectionSheet
 import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
 import com.sameerasw.essentials.ui.features.display.sheets.StatusGlanceBatteryOptionsBottomSheet
+import com.sameerasw.essentials.ui.features.display.sheets.StatusGlanceCalendarOptionsBottomSheet
 import com.sameerasw.essentials.ui.modifiers.highlight
 import com.sameerasw.essentials.utils.HapticUtil
 import com.sameerasw.essentials.utils.PermissionUIHelper
@@ -61,6 +62,7 @@ fun StatusGlanceSettingsUI(
     var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
     var showMediaAppSelectionSheet by remember { mutableStateOf(false) }
     var showBatteryOptionsSheet by remember { mutableStateOf(false) }
+    var showCalendarOptionsSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.check(context)
@@ -206,7 +208,6 @@ fun StatusGlanceSettingsUI(
                 ) {
                     IconToggleItem(
                         title = stringResource(R.string.status_glance_show_flashlight_title),
-                        description = stringResource(R.string.status_glance_show_flashlight_desc),
                         iconRes = R.drawable.rounded_flashlight_on_24,
                         isChecked = viewModel.isStatusGlanceShowFlashlight.value,
                         onCheckedChange = {
@@ -218,7 +219,6 @@ fun StatusGlanceSettingsUI(
 
                     IconToggleItem(
                         title = stringResource(R.string.status_glance_show_calendar_title),
-                        description = stringResource(R.string.status_glance_show_calendar_desc),
                         iconRes = R.drawable.rounded_calendar_today_24,
                         isChecked = viewModel.isStatusGlanceShowCalendar.value,
                         onCheckedChange = { isChecked ->
@@ -231,12 +231,14 @@ fun StatusGlanceSettingsUI(
                             }
                             viewModel.setStatusGlanceShowCalendar(isChecked)
                         },
+                        onSettingsClick = {
+                            showCalendarOptionsSheet = true
+                        },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_show_calendar"),
                     )
 
                     IconToggleItem(
                         title = stringResource(R.string.status_glance_show_media_title),
-                        description = stringResource(R.string.status_glance_show_media_desc),
                         iconRes = R.drawable.rounded_motion_play_24,
                         isChecked = viewModel.isStatusGlanceShowMedia.value,
                         onCheckedChange = { isChecked ->
@@ -257,7 +259,6 @@ fun StatusGlanceSettingsUI(
 
                     IconToggleItem(
                         title = stringResource(R.string.status_glance_show_time_title),
-                        description = stringResource(R.string.status_glance_show_time_desc),
                         iconRes = R.drawable.rounded_schedule_24,
                         isChecked = viewModel.isStatusGlanceShowTime.value,
                         onCheckedChange = {
@@ -349,6 +350,13 @@ fun StatusGlanceSettingsUI(
         StatusGlanceBatteryOptionsBottomSheet(
             viewModel = viewModel,
             onDismissRequest = { showBatteryOptionsSheet = false },
+        )
+    }
+
+    if (showCalendarOptionsSheet) {
+        StatusGlanceCalendarOptionsBottomSheet(
+            viewModel = viewModel,
+            onDismissRequest = { showCalendarOptionsSheet = false },
         )
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Feature - Display
+ * File: StatusGlanceSettingsUI.kt
+ * Description: UI settings composable for Status Glance ambient indicator feature.
+ */
+
+package com.sameerasw.essentials.ui.features.display
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.domain.model.AppPermission
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
+import com.sameerasw.essentials.ui.core.cards.IconToggleItem
+import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.PermissionsBottomSheet
+import com.sameerasw.essentials.ui.modifiers.highlight
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.utils.PermissionUIHelper
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun StatusGlanceSettingsUI(
+    viewModel: MainViewModel,
+    modifier: Modifier = Modifier,
+    highlightSetting: String? = null,
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    var requestingPermissionsFor by remember { mutableStateOf<Pair<Int, List<String>>?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.check(context)
+    }
+
+    if (requestingPermissionsFor != null) {
+        val (featureTitle, permKeys) = requestingPermissionsFor!!
+        val permissionItems = PermissionUIHelper.getPermissionItems(permKeys, context, viewModel)
+        PermissionsBottomSheet(
+            onDismissRequest = {
+                requestingPermissionsFor = null
+                viewModel.check(context)
+            },
+            featureTitle = featureTitle,
+            permissions = permissionItems,
+        )
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        RoundedCardContainer(
+            spacing = 2.dp,
+            cornerRadius = 24.dp,
+        ) {
+            IconToggleItem(
+                title = stringResource(R.string.status_glance_enable_title),
+                description = stringResource(R.string.status_glance_enable_desc),
+                iconRes = R.drawable.rounded_motion_play_24,
+                isChecked = viewModel.isStatusGlanceEnabled.value,
+                onCheckedChange = { isChecked ->
+                    HapticUtil.performUIHaptic(view)
+                    if (isChecked && !viewModel.isAccessibilityEnabled.value) {
+                        requestingPermissionsFor = Pair(
+                            R.string.feat_status_glance_title,
+                            listOf("ACCESSIBILITY")
+                        )
+                    } else {
+                        viewModel.setStatusGlanceEnabled(isChecked)
+                    }
+                },
+                modifier = Modifier.highlight(highlightSetting == "status_glance_enabled"),
+            )
+        }
+
+        AnimatedVisibility(
+            visible = viewModel.isStatusGlanceEnabled.value,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.status_glance_section_position),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_auto_detect_button_title),
+                        description = stringResource(R.string.status_glance_auto_detect_button_desc),
+                        iconRes = R.drawable.rounded_center_focus_strong_24,
+                        showToggle = false,
+                        onClick = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.autoDetectStatusGlancePosition(context)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_auto_detect"),
+                    )
+
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_offset_x_title),
+                        value = viewModel.statusGlanceOffsetX.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceOffsetX(it)
+                        },
+                        valueRange = 0f..100f,
+                        increment = 1f,
+                        iconRes = R.drawable.rounded_border_left_24,
+                        valueFormatter = { "${it.toInt()}%" },
+                    )
+
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_offset_y_title),
+                        value = viewModel.statusGlanceOffsetY.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceOffsetY(it)
+                        },
+                        valueRange = 0f..20f,
+                        increment = 0.5f,
+                        iconRes = R.drawable.rounded_border_top_24,
+                        valueFormatter = { "%.1f%%".format(it) },
+                    )
+
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_max_width_title),
+                        value = viewModel.statusGlanceMaxWidth.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceMaxWidth(it)
+                        },
+                        valueRange = 80f..350f,
+                        increment = 10f,
+                        iconRes = R.drawable.rounded_arrows_outward_24,
+                        valueFormatter = { "${it.toInt()} dp" },
+                    )
+
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_font_size_title),
+                        value = viewModel.statusGlanceFontSize.floatValue,
+                        onValueChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceFontSize(it)
+                        },
+                        valueRange = 9f..22f,
+                        increment = 1f,
+                        iconRes = R.drawable.rounded_mobile_text_24,
+                        valueFormatter = { "${it.toInt()} sp" },
+                    )
+                }
+
+                Text(
+                    text = stringResource(R.string.status_glance_section_what_to_show),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_show_flashlight_title),
+                        description = stringResource(R.string.status_glance_show_flashlight_desc),
+                        iconRes = R.drawable.rounded_flashlight_on_24,
+                        isChecked = viewModel.isStatusGlanceShowFlashlight.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceShowFlashlight(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_show_flashlight"),
+                    )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_show_calendar_title),
+                        description = stringResource(R.string.status_glance_show_calendar_desc),
+                        iconRes = R.drawable.rounded_calendar_today_24,
+                        isChecked = viewModel.isStatusGlanceShowCalendar.value,
+                        onCheckedChange = { isChecked ->
+                            HapticUtil.performUIHaptic(view)
+                            if (isChecked && !viewModel.isCalendarPermissionGranted.value) {
+                                requestingPermissionsFor = Pair(
+                                    R.string.status_glance_show_calendar_title,
+                                    listOf(AppPermission.READ_CALENDAR.key)
+                                )
+                            }
+                            viewModel.setStatusGlanceShowCalendar(isChecked)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_show_calendar"),
+                    )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_show_media_title),
+                        description = stringResource(R.string.status_glance_show_media_desc),
+                        iconRes = R.drawable.rounded_motion_play_24,
+                        isChecked = viewModel.isStatusGlanceShowMedia.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceShowMedia(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_show_media"),
+                    )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_show_time_title),
+                        description = stringResource(R.string.status_glance_show_time_desc),
+                        iconRes = R.drawable.rounded_schedule_24,
+                        isChecked = viewModel.isStatusGlanceShowTime.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceShowTime(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_show_time"),
+                    )
+                }
+
+                Text(
+                    text = stringResource(R.string.status_glance_section_appearance),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_background_pill_title),
+                        description = stringResource(R.string.status_glance_background_pill_desc),
+                        iconRes = R.drawable.rounded_circle_24,
+                        isChecked = viewModel.isStatusGlanceBackgroundPill.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceBackgroundPill(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_background_pill"),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -288,6 +288,18 @@ fun StatusGlanceSettingsUI(
                         },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_background_pill"),
                     )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_hide_in_quick_settings_title),
+                        description = stringResource(R.string.status_glance_hide_in_quick_settings_desc),
+                        iconRes = R.drawable.rounded_top_panel_close_24,
+                        isChecked = viewModel.isStatusGlanceHideInQuickSettings.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceHideInQuickSettings(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_hide_in_quick_settings"),
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -458,6 +458,18 @@ fun StatusGlanceSettingsUI(
                         },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_hide_in_quick_settings"),
                     )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_hide_when_locked_title),
+                        description = stringResource(R.string.status_glance_hide_when_locked_desc),
+                        iconRes = R.drawable.rounded_lock_24,
+                        isChecked = viewModel.isStatusGlanceHideWhenLocked.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceHideWhenLocked(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_hide_when_locked"),
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
@@ -4,11 +4,16 @@
  *
  * Feature Module: UI Feature - Display
  * File: StatusGlanceBatteryOptionsBottomSheet.kt
- * Description: Bottom sheet for configuring Status Glance battery display mode and dynamic visibility conditions.
+ * Description: Bottom sheet for configuring Status Glance battery display mode, icon size, and dynamic visibility conditions.
  */
 
 package com.sameerasw.essentials.ui.features.display.sheets
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -35,6 +40,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
@@ -73,14 +79,16 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                 modifier = Modifier.padding(start = 8.dp),
             )
 
-            val modes = listOf("icon", "percentage")
+            val modes = listOf("icon", "percentage", "both")
             val icons = listOf(
                 R.drawable.battery_android_frame_full_24px,
                 R.drawable.rounded_numbers_24,
+                R.drawable.battery_android_frame_plus_24px,
             )
             val labels = listOf(
                 stringResource(R.string.status_glance_battery_mode_icon),
                 stringResource(R.string.status_glance_battery_mode_percentage),
+                stringResource(R.string.status_glance_battery_mode_both),
             )
 
             RoundedCardContainer {
@@ -105,7 +113,8 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                                 .semantics { role = Role.RadioButton },
                             shapes = when (index) {
                                 0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
-                                else -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                modes.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
                             },
                         ) {
                             Row(
@@ -124,6 +133,27 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                             }
                         }
                     }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = viewModel.statusGlanceBatteryDisplayMode.value != "percentage",
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically(),
+            ) {
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_battery_icon_size_title),
+                        value = viewModel.statusGlanceBatteryIconSize.floatValue,
+                        onValueChange = { viewModel.setStatusGlanceBatteryIconSize(it) },
+                        valueRange = 10f..24f,
+                        increment = 1f,
+                        iconRes = R.drawable.battery_android_frame_full_24px,
+                        valueFormatter = { "${it.toInt()} dp" },
+                    )
                 }
             }
 
@@ -181,3 +211,4 @@ fun StatusGlanceBatteryOptionsBottomSheet(
         }
     }
 }
+

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -94,11 +96,12 @@ fun StatusGlanceBatteryOptionsBottomSheet(
             RoundedCardContainer {
                 Row(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .background(
                             color = MaterialTheme.colorScheme.surfaceBright,
-                            shape = RoundedCornerShape(MaterialTheme.shapes.extraSmall.bottomEnd),
+                            shape = RoundedCornerShape(24.dp),
                         )
-                        .padding(10.dp),
+                        .padding(8.dp),
                     horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
                 ) {
                     modes.forEachIndexed { index, mode ->
@@ -119,16 +122,19 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                         ) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                horizontalArrangement = Arrangement.Center,
                             ) {
                                 Icon(
                                     painter = painterResource(id = icons[index]),
                                     contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
+                                    modifier = Modifier.size(18.dp),
                                 )
+                                Spacer(modifier = Modifier.width(6.dp))
                                 Text(
                                     text = labels[index],
-                                    style = MaterialTheme.typography.labelLarge,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    maxLines = 1,
+                                    softWrap = false,
                                 )
                             }
                         }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Feature - Display
+ * File: StatusGlanceBatteryOptionsBottomSheet.kt
+ * Description: Bottom sheet for configuring Status Glance battery display mode and dynamic visibility conditions.
+ */
+
+package com.sameerasw.essentials.ui.features.display.sheets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.core.cards.IconToggleItem
+import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun StatusGlanceBatteryOptionsBottomSheet(
+    viewModel: MainViewModel,
+    onDismissRequest: () -> Unit,
+) {
+    val view = LocalView.current
+
+    EssentialsBottomSheet(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.status_glance_battery_options_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 8.dp, bottom = 4.dp),
+            )
+
+            Text(
+                text = stringResource(R.string.status_glance_battery_display_mode_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+
+            val modes = listOf("icon", "percentage")
+            val icons = listOf(
+                R.drawable.battery_android_frame_full_24px,
+                R.drawable.rounded_numbers_24,
+            )
+            val labels = listOf(
+                stringResource(R.string.status_glance_battery_mode_icon),
+                stringResource(R.string.status_glance_battery_mode_percentage),
+            )
+
+            RoundedCardContainer {
+                Row(
+                    modifier = Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            shape = RoundedCornerShape(MaterialTheme.shapes.extraSmall.bottomEnd),
+                        )
+                        .padding(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+                ) {
+                    modes.forEachIndexed { index, mode ->
+                        ToggleButton(
+                            checked = viewModel.statusGlanceBatteryDisplayMode.value == mode,
+                            onCheckedChange = {
+                                HapticUtil.performVirtualKeyHaptic(view)
+                                viewModel.setStatusGlanceBatteryDisplayMode(mode)
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics { role = Role.RadioButton },
+                            shapes = when (index) {
+                                0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                                else -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                            },
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = icons[index]),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                                Text(
+                                    text = labels[index],
+                                    style = MaterialTheme.typography.labelLarge,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Text(
+                text = stringResource(R.string.status_glance_section_what_to_show),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+
+            RoundedCardContainer(
+                spacing = 2.dp,
+                cornerRadius = 24.dp,
+            ) {
+                IconToggleItem(
+                    iconRes = R.drawable.battery_android_frame_alert_24px,
+                    title = stringResource(R.string.status_glance_battery_show_low_title),
+                    isChecked = viewModel.isStatusGlanceBatteryShowLow.value,
+                    onCheckedChange = { checked ->
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        viewModel.setStatusGlanceBatteryShowLow(checked)
+                    },
+                )
+
+                IconToggleItem(
+                    iconRes = R.drawable.battery_android_frame_bolt_24px,
+                    title = stringResource(R.string.status_glance_battery_show_charging_title),
+                    isChecked = viewModel.isStatusGlanceBatteryShowCharging.value,
+                    onCheckedChange = { checked ->
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        viewModel.setStatusGlanceBatteryShowCharging(checked)
+                    },
+                )
+
+                IconToggleItem(
+                    iconRes = R.drawable.battery_android_frame_full_24px,
+                    title = stringResource(R.string.status_glance_battery_show_full_title),
+                    isChecked = viewModel.isStatusGlanceBatteryShowFull.value,
+                    onCheckedChange = { checked ->
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        viewModel.setStatusGlanceBatteryShowFull(checked)
+                    },
+                )
+
+                IconToggleItem(
+                    iconRes = R.drawable.battery_android_frame_4_24px,
+                    title = stringResource(R.string.status_glance_battery_show_otherwise_title),
+                    isChecked = viewModel.isStatusGlanceBatteryShowOtherwise.value,
+                    onCheckedChange = { checked ->
+                        HapticUtil.performVirtualKeyHaptic(view)
+                        viewModel.setStatusGlanceBatteryShowOtherwise(checked)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceCalendarOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceCalendarOptionsBottomSheet.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: UI Feature - Display
+ * File: StatusGlanceCalendarOptionsBottomSheet.kt
+ * Description: Bottom sheet for configuring Status Glance upcoming calendar event timeframe and selected calendars.
+ */
+
+package com.sameerasw.essentials.ui.features.display.sheets
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.menus.SegmentedDropdownMenuItem
+import com.sameerasw.essentials.ui.core.cards.ConfigPickerItem
+import com.sameerasw.essentials.ui.core.cards.IconToggleItem
+import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
+import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
+import com.sameerasw.essentials.utils.HapticUtil
+import com.sameerasw.essentials.viewmodels.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatusGlanceCalendarOptionsBottomSheet(
+    viewModel: MainViewModel,
+    onDismissRequest: () -> Unit,
+) {
+    val context = LocalContext.current
+    val view = LocalView.current
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchStatusGlanceCalendars(context)
+    }
+
+    val timeframes = listOf(
+        "15m" to stringResource(R.string.status_glance_calendar_timeframe_15_mins),
+        "30m" to stringResource(R.string.status_glance_calendar_timeframe_30_mins),
+        "1h" to stringResource(R.string.status_glance_calendar_timeframe_1_hour),
+        "2h" to stringResource(R.string.status_glance_calendar_timeframe_2_hours),
+        "6h" to stringResource(R.string.status_glance_calendar_timeframe_6_hours),
+        "24h" to stringResource(R.string.status_glance_calendar_timeframe_24_hours),
+        "today" to stringResource(R.string.status_glance_calendar_timeframe_today),
+        "next" to stringResource(R.string.status_glance_calendar_timeframe_next),
+    )
+
+    val currentCode = viewModel.statusGlanceCalendarTimeframe.value
+    val currentLabel = timeframes.firstOrNull { it.first == currentCode }?.second
+        ?: stringResource(R.string.status_glance_calendar_timeframe_today)
+
+    EssentialsBottomSheet(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.status_glance_calendar_options_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 8.dp, bottom = 4.dp),
+            )
+
+            RoundedCardContainer {
+                ConfigPickerItem(
+                    title = stringResource(R.string.status_glance_calendar_timeframe_title),
+                    selectedValue = currentLabel,
+                    iconRes = R.drawable.rounded_schedule_24,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    timeframes.forEach { (code, label) ->
+                        SegmentedDropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                viewModel.setStatusGlanceCalendarTimeframe(code)
+                            },
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = stringResource(R.string.status_glance_calendar_select_calendars_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+
+            val calendars = viewModel.statusGlanceAvailableCalendars
+            if (calendars.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.status_glance_calendar_no_calendars),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(start = 8.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                val grouped = calendars.groupBy { it.accountName }
+                grouped.forEach { (accountName, accountCalendars) ->
+                    Text(
+                        text = accountName,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(start = 8.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+
+                    RoundedCardContainer(
+                        spacing = 2.dp,
+                        cornerRadius = 24.dp,
+                    ) {
+                        accountCalendars.forEach { calendar ->
+                            IconToggleItem(
+                                title = calendar.name,
+                                iconRes = R.drawable.rounded_calendar_today_24,
+                                isChecked = calendar.isSelected,
+                                onCheckedChange = {
+                                    HapticUtil.performVirtualKeyHaptic(view)
+                                    viewModel.toggleStatusGlanceCalendarSelection(calendar.id)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -160,6 +160,21 @@ class StatusGlanceView(context: Context) : View(context) {
             invalidate()
         }
 
+    var useAlbumArtColors: Boolean = true
+        set(value) {
+            field = value
+            val targetColor = if (value && activeSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+                paletteMediaColor!!
+            } else {
+                defaultMaterialYouColor
+            }
+            animateColorChange(targetColor)
+            updateTextColor(targetColor)
+            invalidate()
+        }
+
+    private fun isPillActive(): Boolean = useBackgroundPill || (useAlbumArtColors && activeSlot == GlanceSlot.MEDIA)
+
     var maxWidthDp: Float = 180f
         set(value) {
             field = value
@@ -243,7 +258,7 @@ class StatusGlanceView(context: Context) : View(context) {
             if (field != value) {
                 field = value
                 resolveColors()
-                if (activeSlot == GlanceSlot.MEDIA && rawArtworkPaletteColor != null) {
+                if (useAlbumArtColors && activeSlot == GlanceSlot.MEDIA && rawArtworkPaletteColor != null) {
                     paletteMediaColor = getThemeAdjustedColor(rawArtworkPaletteColor!!)
                     animateColorChange(paletteMediaColor!!)
                 } else {
@@ -288,7 +303,7 @@ class StatusGlanceView(context: Context) : View(context) {
                     rawArtworkPaletteColor = color
                     val adjustedColor = getThemeAdjustedColor(color)
                     paletteMediaColor = adjustedColor
-                    if (activeSlot == GlanceSlot.MEDIA) {
+                    if (useAlbumArtColors && activeSlot == GlanceSlot.MEDIA) {
                         animateColorChange(adjustedColor)
                     }
                 }
@@ -567,7 +582,7 @@ class StatusGlanceView(context: Context) : View(context) {
 
         if (activeSlot == GlanceSlot.NONE) {
             activeSlot = newSlot
-            val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+            val targetColor = if (useAlbumArtColors && newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
                 paletteMediaColor!!
             } else {
                 defaultMaterialYouColor
@@ -616,7 +631,7 @@ class StatusGlanceView(context: Context) : View(context) {
         activeSlot = newSlot
         isTransitioning = true
 
-        val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+        val targetColor = if (useAlbumArtColors && newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
             paletteMediaColor!!
         } else {
             defaultMaterialYouColor
@@ -646,7 +661,7 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     private fun updateTextColor(bgColor: Int) {
-        if (!useBackgroundPill) {
+        if (!isPillActive()) {
             currentTextColor = if (isDarkTheme) Color.WHITE else Color.BLACK
             return
         }
@@ -976,7 +991,7 @@ class StatusGlanceView(context: Context) : View(context) {
                 if (clockText.isBlank()) 10f * density else 0f
             }
             val textLeft = if (hasIcon) (iconLeft + iconSize + textSpacing) else (cursorX + textSpacing)
-            val textRight = (if (useBackgroundPill) right else right - 8f * density) - batteryReservedWidth
+            val textRight = (if (isPillActive()) right else right - 8f * density) - batteryReservedWidth
             val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
 
             if (!isTransitioning) {
@@ -997,7 +1012,7 @@ class StatusGlanceView(context: Context) : View(context) {
                 val marqueeBounds = RectF(fadeStart, top, textRight, bottom)
                 val saveLayerCount = canvas.saveLayer(marqueeBounds, null)
 
-                if (useBackgroundPill && batteryAlpha <= 0f) {
+                if (isPillActive() && batteryAlpha <= 0f) {
                     marqueeClipPath.reset()
                     val radii = floatArrayOf(
                         0f, 0f,
@@ -1162,7 +1177,7 @@ class StatusGlanceView(context: Context) : View(context) {
 
         val alphaInt = (slotAlpha * iconAlpha * 255).toInt().coerceIn(0, 255)
 
-        if (useBackgroundPill) {
+        if (isPillActive()) {
             pillPaint.color = currentPillColor
             pillPaint.alpha = alphaInt
             canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -28,7 +28,6 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Shader
 import android.graphics.Typeface
-import android.graphics.Xfermode
 import android.os.Build
 import android.view.View
 import android.view.animation.DecelerateInterpolator
@@ -82,6 +81,66 @@ class StatusGlanceView(context: Context) : View(context) {
         set(value) {
             field = value
             reevaluateSlot()
+        }
+
+    var showBattery: Boolean = false
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var batteryDisplayMode: String = "icon"
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var showBatteryWhenLow: Boolean = true
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var showBatteryWhileCharging: Boolean = true
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var showBatteryWhileFull: Boolean = true
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var showBatteryOtherwise: Boolean = true
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var batteryLevel: Int = 100
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var isBatteryCharging: Boolean = false
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var isBatteryFull: Boolean = false
+        set(value) {
+            field = value
+            reevaluateBatteryState()
+        }
+
+    var isPowerSaveMode: Boolean = false
+        set(value) {
+            field = value
+            reevaluateBatteryState()
         }
 
     var useBackgroundPill: Boolean = false
@@ -149,6 +208,7 @@ class StatusGlanceView(context: Context) : View(context) {
         set(value) {
             field = value
             textPaint.textSize = value * density
+            batteryTextPaint.textSize = (value * 0.85f) * density
             reevaluateSlot()
         }
 
@@ -272,6 +332,12 @@ class StatusGlanceView(context: Context) : View(context) {
     private var revealProgress: Float = 1f
     private var revealAnimator: ValueAnimator? = null
 
+    // Battery state & animation
+    private var isBatteryVisible: Boolean = false
+    private var batteryAlpha: Float = 0f
+    private var batteryAlphaAnimator: ValueAnimator? = null
+    private val batteryIconBitmapCache = mutableMapOf<Int, Bitmap>()
+
     private var slotAlpha: Float = 1f
     private var alphaAnimator: ValueAnimator? = null
     private var colorAnimator: ValueAnimator? = null
@@ -290,6 +356,11 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         textSize = 13f * density
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
+    }
+
+    private val batteryTextPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = (17f * 0.85f) * density
         typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
     }
 
@@ -401,6 +472,43 @@ class StatusGlanceView(context: Context) : View(context) {
         }
     }
 
+    private fun isBatteryConditionMet(): Boolean {
+        if (!showBattery) return false
+        val isLow = batteryLevel <= 20
+        val isCharging = isBatteryCharging
+        val isFull = isBatteryFull || batteryLevel >= 100
+        val isOtherwise = !isLow && !isCharging && !isFull
+
+        return (isLow && showBatteryWhenLow) ||
+            (isCharging && showBatteryWhileCharging) ||
+            (isFull && showBatteryWhileFull) ||
+            (isOtherwise && showBatteryOtherwise)
+    }
+
+    private fun reevaluateBatteryState() {
+        val shouldShow = isBatteryConditionMet()
+        if (isBatteryVisible != shouldShow) {
+            isBatteryVisible = shouldShow
+            batteryAlphaAnimator?.cancel()
+            val targetAlpha = if (shouldShow) 1f else 0f
+            batteryAlphaAnimator = ValueAnimator.ofFloat(batteryAlpha, targetAlpha).apply {
+                duration = 260L
+                interpolator = DecelerateInterpolator()
+                addUpdateListener {
+                    batteryAlpha = it.animatedValue as Float
+                    targetContentWidth = calculateTargetWidth()
+                    animateWidth()
+                    invalidate()
+                }
+                start()
+            }
+        } else {
+            targetContentWidth = calculateTargetWidth()
+            animateWidth()
+            invalidate()
+        }
+    }
+
     fun reevaluateSlot() {
         val now = System.currentTimeMillis()
         val isEventWithin15Min = isEventToday && (nextEventTimeMillis - now) in 0..(15 * 60 * 1000L)
@@ -462,7 +570,6 @@ class StatusGlanceView(context: Context) : View(context) {
             return
         }
 
-        // Snapshot current content before updating
         previousSlot = activeSlot
         val (prevClock, prevMarquee) = getSlotTexts(activeSlot)
         previousClockText = prevClock
@@ -592,9 +699,6 @@ class StatusGlanceView(context: Context) : View(context) {
         marqueeOffset = 0f
     }
 
-    /**
-     * Returns Pair(clockText, marqueeText)
-     */
     private fun getSlotTexts(slot: GlanceSlot): Pair<String, String> {
         return when (slot) {
             GlanceSlot.FLASHLIGHT -> Pair("", context.getString(R.string.status_glance_slot_flashlight))
@@ -621,6 +725,28 @@ class StatusGlanceView(context: Context) : View(context) {
                 if (showCalendar && isEventToday && nextEventTitle.isNotBlank()) calendarIcon else null
             }
             GlanceSlot.NONE -> null
+        }
+    }
+
+    private fun getBatteryDrawableId(): Int {
+        return when {
+            isPowerSaveMode -> R.drawable.battery_android_frame_plus_24px
+            isBatteryCharging -> R.drawable.battery_android_frame_bolt_24px
+            batteryLevel <= 15 -> R.drawable.battery_android_frame_alert_24px
+            batteryLevel <= 10 -> R.drawable.battery_android_0_24px
+            batteryLevel <= 25 -> R.drawable.battery_android_frame_1_24px
+            batteryLevel <= 40 -> R.drawable.battery_android_frame_2_24px
+            batteryLevel <= 60 -> R.drawable.battery_android_frame_3_24px
+            batteryLevel <= 75 -> R.drawable.battery_android_frame_4_24px
+            batteryLevel <= 90 -> R.drawable.battery_android_frame_5_24px
+            else -> R.drawable.battery_android_frame_full_24px
+        }
+    }
+
+    private fun getBatteryBitmap(sizePx: Int): Bitmap? {
+        val drawableId = getBatteryDrawableId()
+        return batteryIconBitmapCache.getOrPut(drawableId) {
+            getBitmapFromVector(drawableId, sizePx) ?: return null
         }
     }
 
@@ -655,6 +781,17 @@ class StatusGlanceView(context: Context) : View(context) {
         if (marqueeText.isNotBlank()) {
             val marqueeWidth = textPaint.measureText(marqueeText)
             calculated += marqueeWidth
+        }
+
+        if (isBatteryConditionMet() || batteryAlpha > 0f) {
+            val batteryWidth = if (batteryDisplayMode == "icon") {
+                22f * density
+            } else {
+                val pctText = "$batteryLevel%"
+                batteryTextPaint.measureText(pctText)
+            }
+            val batterySpacing = 5f * density
+            calculated += (batterySpacing + batteryWidth) * batteryAlpha
         }
 
         val maxAllowedWidth = maxWidthDp * density
@@ -720,6 +857,8 @@ class StatusGlanceView(context: Context) : View(context) {
         artworkPaint.alpha = combinedIconAlpha
         textPaint.color = currentTextColor
         textPaint.alpha = combinedTextAlpha
+        batteryTextPaint.color = currentTextColor
+        batteryTextPaint.alpha = combinedTextAlpha
 
         var cursorX = left
 
@@ -749,6 +888,18 @@ class StatusGlanceView(context: Context) : View(context) {
         }
         val iconTop = glanceCenterY - iconSize / 2f + offsetY
 
+        // Compute reserved right space for battery
+        val batteryReservedWidth = if (batteryAlpha > 0f) {
+            val itemW = if (batteryDisplayMode == "icon") {
+                16f * density
+            } else {
+                batteryTextPaint.measureText("$batteryLevel%")
+            }
+            (itemW + 5f * density) * batteryAlpha
+        } else {
+            0f
+        }
+
         if (marqueeText.isNotBlank() && combinedTextAlpha > 0) {
             val textSpacing = if (hasIcon) {
                 if (isArtwork) 3f * density else 4f * density
@@ -756,7 +907,7 @@ class StatusGlanceView(context: Context) : View(context) {
                 if (clockText.isBlank()) 10f * density else 0f
             }
             val textLeft = if (hasIcon) (iconLeft + iconSize + textSpacing) else (cursorX + textSpacing)
-            val textRight = if (useBackgroundPill) right else right - 8f * density
+            val textRight = (if (useBackgroundPill) right else right - 8f * density) - batteryReservedWidth
             val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
 
             if (!isTransitioning) {
@@ -777,7 +928,7 @@ class StatusGlanceView(context: Context) : View(context) {
                 val marqueeBounds = RectF(fadeStart, top, textRight, bottom)
                 val saveLayerCount = canvas.saveLayer(marqueeBounds, null)
 
-                if (useBackgroundPill) {
+                if (useBackgroundPill && batteryAlpha <= 0f) {
                     marqueeClipPath.reset()
                     val radii = floatArrayOf(
                         0f, 0f,
@@ -802,12 +953,27 @@ class StatusGlanceView(context: Context) : View(context) {
                 canvas.drawText(marqueeText, x1, textY, textPaint)
                 canvas.drawText(marqueeText, x2, textY, textPaint)
 
+                // Left fade gradient
                 marqueeFadePaint.shader = LinearGradient(
                     fadeStart, 0f, fadeStart + fadeWidth, 0f,
                     Color.TRANSPARENT, Color.BLACK,
                     Shader.TileMode.CLAMP
                 )
                 canvas.drawRect(fadeStart, top, fadeStart + fadeWidth, bottom, marqueeFadePaint)
+
+                // Right fade gradient when battery indicator is present
+                if (batteryAlpha > 0f) {
+                    val rightFadeWidth = 14f * density
+                    val rightFadeStart = (textRight - rightFadeWidth).coerceAtLeast(fadeStart + fadeWidth)
+                    if (rightFadeStart < textRight) {
+                        marqueeFadePaint.shader = LinearGradient(
+                            rightFadeStart, 0f, textRight, 0f,
+                            Color.BLACK, Color.TRANSPARENT,
+                            Shader.TileMode.CLAMP
+                        )
+                        canvas.drawRect(rightFadeStart, top, textRight, bottom, marqueeFadePaint)
+                    }
+                }
 
                 canvas.restoreToCount(saveLayerCount)
             } else {
@@ -836,6 +1002,34 @@ class StatusGlanceView(context: Context) : View(context) {
                 iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
                 val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
                 canvas.drawBitmap(icon, null, dstRect, iconPaint)
+            }
+        }
+
+        if (batteryAlpha > 0f && expandPhase > 0.3f) {
+            val batteryPhaseAlpha = ((expandPhase - 0.3f) / 0.7f).coerceIn(0f, 1f)
+            val combinedBatteryAlpha = (slotAlpha * alphaMultiplier * revealTextAlpha * batteryAlpha * batteryPhaseAlpha * 255).toInt().coerceIn(0, 255)
+            if (combinedBatteryAlpha > 0) {
+                if (batteryDisplayMode == "icon") {
+                    val batteryIconSize = 16f * density
+                    val batteryIcon = getBatteryBitmap(batteryIconSize.toInt())
+                    if (batteryIcon != null) {
+                        iconPaint.alpha = combinedBatteryAlpha
+                        iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                        val batteryLeft = right - (5.5f * density) - batteryIconSize
+                        val batteryTop = glanceCenterY - batteryIconSize / 2f + offsetY
+                        val dstRect = RectF(batteryLeft, batteryTop, batteryLeft + batteryIconSize, batteryTop + batteryIconSize)
+                        canvas.drawBitmap(batteryIcon, null, dstRect, iconPaint)
+                    }
+                } else {
+                    val pctText = "$batteryLevel%"
+                    batteryTextPaint.alpha = combinedBatteryAlpha
+                    batteryTextPaint.color = currentTextColor
+                    batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
+                    val pctWidth = batteryTextPaint.measureText(pctText)
+                    val pctX = right - (5.5f * density) - pctWidth
+                    val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
+                    canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+                }
             }
         }
     }
@@ -894,7 +1088,6 @@ class StatusGlanceView(context: Context) : View(context) {
             val newOffsetY = transitionDirection * (1f - p) * flipDistance
             val newAlpha = p.coerceIn(0f, 1f)
 
-            //  outgoing slot
             drawSlotContent(
                 canvas = canvas,
                 clockText = previousClockText,
@@ -914,7 +1107,6 @@ class StatusGlanceView(context: Context) : View(context) {
                 expandPhase = expandPhase
             )
 
-            //  incoming slot
             val (currentClock, currentMarquee) = getSlotTexts(activeSlot)
             val currentIcon = getSlotIcon(activeSlot)
             val currentIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
@@ -971,5 +1163,6 @@ class StatusGlanceView(context: Context) : View(context) {
         colorAnimator?.cancel()
         transitionAnimator?.cancel()
         revealAnimator?.cancel()
+        batteryAlphaAnimator?.cancel()
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -204,6 +204,14 @@ class StatusGlanceView(context: Context) : View(context) {
             }
         }
 
+    var isLandscape: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
     var fontSize: Float = 13f
         set(value) {
             field = value
@@ -799,7 +807,7 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     fun updateVisibilityState(immediate: Boolean = false) {
-        val shouldHide = isLocked || isScreenOff || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
+        val shouldHide = isLocked || isScreenOff || isLandscape || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
         if (isVisibilityHidden == shouldHide && !immediate) return
         isVisibilityHidden = shouldHide
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2026 sameerasw.com
+ * License: MIT License
+ *
+ * Feature Module: Utilities - Overlays
+ * File: StatusGlanceView.kt
+ * Description: Status Glance ambient chip indicator canvas view for status bar display.
+ */
+
+package com.sameerasw.essentials.utils
+
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.os.Build
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+import android.view.animation.LinearInterpolator
+import androidx.core.content.ContextCompat
+import androidx.palette.graphics.Palette
+import com.sameerasw.essentials.R
+
+class StatusGlanceView(context: Context) : View(context) {
+    private val density = resources.displayMetrics.density
+
+    enum class GlanceSlot {
+        NONE,
+        FLASHLIGHT,
+        CALENDAR_URGENT,
+        MEDIA,
+        CALENDAR_TODAY,
+        TIME
+    }
+
+    var glanceCenterX: Float = 0f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var glanceCenterY: Float = 0f
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    var showFlashlight: Boolean = true
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var showCalendar: Boolean = true
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var showMedia: Boolean = true
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var showTime: Boolean = true
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var useBackgroundPill: Boolean = false
+        set(value) {
+            field = value
+            updateTextColor(currentPillColor)
+            invalidate()
+        }
+
+    var maxWidthDp: Float = 180f
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var fontSize: Float = 13f
+        set(value) {
+            field = value
+            textPaint.textSize = value * density
+            reevaluateSlot()
+        }
+
+    // State data
+    var isFlashlightOn: Boolean = false
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var isMediaPlaying: Boolean = false
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var mediaTitle: String = ""
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var mediaArtist: String = ""
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var mediaArtworkBitmap: Bitmap? = null
+        set(value) {
+            field = value
+            if (value != null) {
+                Palette.from(value).generate { palette ->
+                    palette?.dominantSwatch?.rgb?.let { color ->
+                        paletteMediaColor = color
+                        if (activeSlot == GlanceSlot.MEDIA) {
+                            animateColorChange(color)
+                        }
+                    }
+                }
+            } else {
+                paletteMediaColor = null
+                if (activeSlot == GlanceSlot.MEDIA) {
+                    animateColorChange(defaultMaterialYouColor)
+                }
+            }
+            reevaluateSlot()
+        }
+
+    var nextEventTitle: String = ""
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var nextEventTimeMillis: Long = 0L
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var isEventToday: Boolean = false
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    var currentTimeString: String = ""
+        set(value) {
+            field = value
+            reevaluateSlot()
+        }
+
+    // Active Slot
+    var activeSlot: GlanceSlot = GlanceSlot.NONE
+        private set
+
+    // Colors
+    private var defaultMaterialYouColor: Int = Color.parseColor("#388E3C")
+    private var paletteMediaColor: Int? = null
+    private var currentPillColor: Int = defaultMaterialYouColor
+    private var currentTextColor: Int = Color.WHITE
+
+    // Animated values
+    private var currentContentWidth: Float = 0f
+    private var targetContentWidth: Float = 0f
+    private var widthAnimator: ValueAnimator? = null
+
+    private var slotAlpha: Float = 1f
+    private var alphaAnimator: ValueAnimator? = null
+    private var colorAnimator: ValueAnimator? = null
+
+    // Marquee values
+    private var marqueeOffset: Float = 0f
+    private var marqueeAnimator: ValueAnimator? = null
+    private var isMarqueeNeeded: Boolean = false
+    private var lastMarqueeText: String = ""
+    private var lastMaxTextWidth: Float = 0f
+
+    // Paints
+    private val pillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = 13f * density
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
+    }
+
+    private val iconPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        isFilterBitmap = true
+    }
+
+    // Bitmaps
+    private var flashlightIcon: Bitmap? = null
+    private var calendarIcon: Bitmap? = null
+    private var mediaIcon: Bitmap? = null
+    private var timeIcon: Bitmap? = null
+
+    private val textBounds = Rect()
+    private val chipRect = RectF()
+
+    init {
+        resolveColors()
+        loadIcons()
+    }
+
+    private fun resolveColors() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val primaryColor = ContextCompat.getColor(context, android.R.color.system_accent1_600)
+            defaultMaterialYouColor = primaryColor
+        } else {
+            defaultMaterialYouColor = Color.parseColor("#388E3C")
+        }
+        currentPillColor = defaultMaterialYouColor
+        updateTextColor(currentPillColor)
+    }
+
+    private fun loadIcons() {
+        flashlightIcon = getBitmapFromVector(R.drawable.rounded_flashlight_on_24, (14 * density).toInt())
+        calendarIcon = getBitmapFromVector(R.drawable.rounded_calendar_today_24, (14 * density).toInt())
+        mediaIcon = getBitmapFromVector(R.drawable.rounded_motion_play_24, (14 * density).toInt())
+        timeIcon = getBitmapFromVector(R.drawable.rounded_schedule_24, (14 * density).toInt())
+    }
+
+    private fun getBitmapFromVector(drawableId: Int, sizePx: Int): Bitmap? {
+        return try {
+            val drawable = ContextCompat.getDrawable(context, drawableId) ?: return null
+            val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(bitmap)
+            drawable.setBounds(0, 0, canvas.width, canvas.height)
+            drawable.draw(canvas)
+            bitmap
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun reevaluateSlot() {
+        val now = System.currentTimeMillis()
+        val isEventWithin15Min = isEventToday && (nextEventTimeMillis - now) in 0..(15 * 60 * 1000L)
+
+        val newSlot = when {
+            showFlashlight && isFlashlightOn -> GlanceSlot.FLASHLIGHT
+            showCalendar && isEventWithin15Min && nextEventTitle.isNotBlank() -> GlanceSlot.CALENDAR_URGENT
+            showMedia && isMediaPlaying -> GlanceSlot.MEDIA
+            showCalendar && isEventToday && nextEventTitle.isNotBlank() -> GlanceSlot.CALENDAR_TODAY
+            showTime && currentTimeString.isNotBlank() -> GlanceSlot.TIME
+            else -> GlanceSlot.NONE
+        }
+
+        if (newSlot != activeSlot) {
+            transitionToSlot(newSlot)
+        } else {
+            targetContentWidth = calculateTargetWidth()
+            animateWidth()
+            invalidate()
+        }
+    }
+
+    private fun transitionToSlot(newSlot: GlanceSlot) {
+        stopMarquee()
+        if (activeSlot == GlanceSlot.NONE) {
+            activeSlot = newSlot
+            val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+                paletteMediaColor!!
+            } else {
+                defaultMaterialYouColor
+            }
+            currentPillColor = targetColor
+            updateTextColor(targetColor)
+            targetContentWidth = calculateTargetWidth()
+            currentContentWidth = targetContentWidth
+            slotAlpha = 1f
+            invalidate()
+            return
+        }
+
+        alphaAnimator?.cancel()
+        alphaAnimator = ValueAnimator.ofFloat(slotAlpha, 0f).apply {
+            duration = 150
+            addUpdateListener {
+                slotAlpha = it.animatedValue as Float
+                invalidate()
+            }
+            addListener(object : android.animation.AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: android.animation.Animator) {
+                    activeSlot = newSlot
+                    val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+                        paletteMediaColor!!
+                    } else {
+                        defaultMaterialYouColor
+                    }
+                    currentPillColor = targetColor
+                    updateTextColor(targetColor)
+                    targetContentWidth = calculateTargetWidth()
+                    animateWidth()
+
+                    alphaAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
+                        duration = 200
+                        addUpdateListener { anim ->
+                            slotAlpha = anim.animatedValue as Float
+                            invalidate()
+                        }
+                        start()
+                    }
+                }
+            })
+            start()
+        }
+    }
+
+    private fun updateTextColor(bgColor: Int) {
+        if (!useBackgroundPill) {
+            currentTextColor = Color.WHITE
+            return
+        }
+        val luminance = (0.299 * Color.red(bgColor) + 0.587 * Color.green(bgColor) + 0.114 * Color.blue(bgColor)) / 255.0
+        currentTextColor = if (luminance > 0.5) Color.BLACK else Color.WHITE
+    }
+
+    private fun animateColorChange(targetColor: Int) {
+        colorAnimator?.cancel()
+        colorAnimator = ValueAnimator.ofObject(ArgbEvaluator(), currentPillColor, targetColor).apply {
+            duration = 300
+            addUpdateListener {
+                currentPillColor = it.animatedValue as Int
+                updateTextColor(currentPillColor)
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    private fun animateWidth() {
+        widthAnimator?.cancel()
+        widthAnimator = ValueAnimator.ofFloat(currentContentWidth, targetContentWidth).apply {
+            duration = 250
+            interpolator = DecelerateInterpolator()
+            addUpdateListener {
+                currentContentWidth = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    private fun checkAndStartMarquee(text: String, maxTextWidth: Float) {
+        val textWidth = textPaint.measureText(text)
+        val needed = textWidth > maxTextWidth && maxTextWidth > 0f
+
+        if (needed) {
+            if (!isMarqueeNeeded || text != lastMarqueeText || kotlin.math.abs(maxTextWidth - lastMaxTextWidth) > 1f) {
+                isMarqueeNeeded = true
+                lastMarqueeText = text
+                lastMaxTextWidth = maxTextWidth
+                marqueeAnimator?.cancel()
+                marqueeOffset = 0f
+
+                val marqueeGap = 28f * density
+                val totalDistance = textWidth + marqueeGap
+                val speedDpPerSec = 30f
+                val durationMs = ((totalDistance / density) / speedDpPerSec * 1000L).toLong().coerceAtLeast(2000L)
+
+                marqueeAnimator = ValueAnimator.ofFloat(0f, totalDistance).apply {
+                    duration = durationMs
+                    interpolator = LinearInterpolator()
+                    repeatCount = ValueAnimator.INFINITE
+                    repeatMode = ValueAnimator.RESTART
+                    startDelay = 1200L
+                    addUpdateListener {
+                        marqueeOffset = it.animatedValue as Float
+                        invalidate()
+                    }
+                    start()
+                }
+            }
+        } else {
+            if (isMarqueeNeeded || text != lastMarqueeText) {
+                stopMarquee()
+                lastMarqueeText = text
+                lastMaxTextWidth = maxTextWidth
+            }
+        }
+    }
+
+    private fun stopMarquee() {
+        isMarqueeNeeded = false
+        lastMarqueeText = ""
+        lastMaxTextWidth = 0f
+        marqueeAnimator?.cancel()
+        marqueeAnimator = null
+        marqueeOffset = 0f
+    }
+
+    private fun getActiveText(): String {
+        return when (activeSlot) {
+            GlanceSlot.FLASHLIGHT -> context.getString(R.string.status_glance_slot_flashlight)
+            GlanceSlot.CALENDAR_URGENT, GlanceSlot.CALENDAR_TODAY -> nextEventTitle
+            GlanceSlot.MEDIA -> {
+                if (mediaArtist.isNotBlank()) "$mediaTitle • $mediaArtist" else mediaTitle
+            }
+            GlanceSlot.TIME -> currentTimeString
+            GlanceSlot.NONE -> ""
+        }
+    }
+
+    private fun getActiveIcon(): Bitmap? {
+        return when (activeSlot) {
+            GlanceSlot.FLASHLIGHT -> flashlightIcon
+            GlanceSlot.CALENDAR_URGENT, GlanceSlot.CALENDAR_TODAY -> calendarIcon
+            GlanceSlot.MEDIA -> mediaArtworkBitmap ?: mediaIcon
+            GlanceSlot.TIME -> timeIcon
+            GlanceSlot.NONE -> null
+        }
+    }
+
+    private fun calculateTargetWidth(): Float {
+        if (activeSlot == GlanceSlot.NONE) return 0f
+        val text = getActiveText()
+        textPaint.getTextBounds(text, 0, text.length, textBounds)
+        val textWidth = textBounds.width().toFloat()
+        val iconSize = 14f * density
+        val padding = 10f * density
+        val spacing = 6f * density
+
+        val maxAllowedWidth = maxWidthDp * density
+        val calculated = padding * 2 + iconSize + spacing + textWidth
+        return calculated.coerceAtMost(maxAllowedWidth)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (activeSlot == GlanceSlot.NONE && currentContentWidth <= 0f) return
+
+        val height = 24f * density
+        val width = currentContentWidth
+        if (width <= 0f) return
+
+        val left = glanceCenterX
+        val top = glanceCenterY - height / 2f
+        val right = left + width
+        val bottom = glanceCenterY + height / 2f
+        val cornerRadius = height / 2f
+
+        chipRect.set(left, top, right, bottom)
+
+        val alphaInt = (slotAlpha * 255).toInt().coerceIn(0, 255)
+
+        // Draw background pill if enabled
+        if (useBackgroundPill) {
+            pillPaint.color = currentPillColor
+            pillPaint.alpha = alphaInt
+            canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)
+        }
+
+        // Draw Icon and Text
+        val icon = getActiveIcon()
+        val iconSize = 14f * density
+        val paddingLeft = 8f * density
+        val iconLeft = left + paddingLeft
+        val iconTop = glanceCenterY - iconSize / 2f
+
+        iconPaint.alpha = alphaInt
+        if (icon != null) {
+            if (activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null) {
+                val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
+                iconPaint.colorFilter = null
+                canvas.drawBitmap(icon, null, dstRect, iconPaint)
+            } else {
+                iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
+                canvas.drawBitmap(icon, null, dstRect, iconPaint)
+            }
+        }
+
+        // Draw Text
+        val text = getActiveText()
+        if (text.isNotBlank()) {
+            val textLeft = iconLeft + iconSize + 6f * density
+            val textRight = right - 8f * density
+            val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
+
+            checkAndStartMarquee(text, maxTextWidth)
+
+            textPaint.color = currentTextColor
+            textPaint.alpha = alphaInt
+
+            textPaint.getTextBounds(text, 0, text.length, textBounds)
+            val textY = glanceCenterY - textBounds.exactCenterY()
+
+            if (isMarqueeNeeded) {
+                val saveCount = canvas.save()
+                canvas.clipRect(textLeft, top, textRight, bottom)
+                val marqueeGap = 28f * density
+                val textWidth = textPaint.measureText(text)
+                val x1 = textLeft - marqueeOffset
+                val x2 = x1 + textWidth + marqueeGap
+                canvas.drawText(text, x1, textY, textPaint)
+                canvas.drawText(text, x2, textY, textPaint)
+                canvas.restoreToCount(saveCount)
+            } else {
+                canvas.drawText(text, textLeft, textY, textPaint)
+            }
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        stopMarquee()
+        widthAnimator?.cancel()
+        alphaAnimator?.cancel()
+        colorAnimator?.cancel()
+    }
+}

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -9,6 +9,8 @@
 
 package com.sameerasw.essentials.utils
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
 import android.content.Context
@@ -195,6 +197,17 @@ class StatusGlanceView(context: Context) : View(context) {
     var activeSlot: GlanceSlot = GlanceSlot.NONE
         private set
 
+    // Slot transition state for car meter roll / flip animation
+    private var previousSlot: GlanceSlot = GlanceSlot.NONE
+    private var previousText: String = ""
+    private var previousIcon: Bitmap? = null
+    private var previousIsArtwork: Boolean = false
+
+    private var transitionProgress: Float = 0f
+    private var transitionDirection: Int = 1
+    private var isTransitioning: Boolean = false
+    private var transitionAnimator: ValueAnimator? = null
+
     // Colors
     private var defaultMaterialYouColor: Int = Color.parseColor("#388E3C")
     private var paletteMediaColor: Int? = null
@@ -243,6 +256,7 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private val textBounds = Rect()
     private val chipRect = RectF()
+    private val containerClipPath = Path()
     private val marqueeClipPath = Path()
     private val marqueeFadePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_IN)
@@ -326,6 +340,17 @@ class StatusGlanceView(context: Context) : View(context) {
         }
     }
 
+    private fun getSlotPriority(slot: GlanceSlot): Int {
+        return when (slot) {
+            GlanceSlot.FLASHLIGHT -> 5
+            GlanceSlot.CALENDAR_URGENT -> 4
+            GlanceSlot.MEDIA -> 3
+            GlanceSlot.CALENDAR_TODAY -> 2
+            GlanceSlot.TIME -> 1
+            GlanceSlot.NONE -> 0
+        }
+    }
+
     fun reevaluateSlot() {
         val now = System.currentTimeMillis()
         val isEventWithin15Min = isEventToday && (nextEventTimeMillis - now) in 0..(15 * 60 * 1000L)
@@ -350,6 +375,7 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private fun transitionToSlot(newSlot: GlanceSlot) {
         stopMarquee()
+
         if (activeSlot == GlanceSlot.NONE) {
             activeSlot = newSlot
             val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
@@ -366,34 +392,68 @@ class StatusGlanceView(context: Context) : View(context) {
             return
         }
 
-        alphaAnimator?.cancel()
-        alphaAnimator = ValueAnimator.ofFloat(slotAlpha, 0f).apply {
-            duration = 150
+        if (newSlot == GlanceSlot.NONE) {
+            alphaAnimator?.cancel()
+            alphaAnimator = ValueAnimator.ofFloat(slotAlpha, 0f).apply {
+                duration = 200
+                addUpdateListener {
+                    slotAlpha = it.animatedValue as Float
+                    invalidate()
+                }
+                addListener(object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        activeSlot = GlanceSlot.NONE
+                        isTransitioning = false
+                        currentContentWidth = 0f
+                        invalidate()
+                    }
+                })
+                start()
+            }
+            return
+        }
+
+        // Snapshot current content before updating
+        previousSlot = activeSlot
+        previousText = getActiveText()
+        previousIcon = getActiveIcon()
+        previousIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
+
+        // Determine counter flip direction: +1 if higher priority incoming (roll up), -1 if lower priority (roll down)
+        val oldPriority = getSlotPriority(activeSlot)
+        val newPriority = getSlotPriority(newSlot)
+        transitionDirection = if (newPriority >= oldPriority) 1 else -1
+
+        activeSlot = newSlot
+        isTransitioning = true
+
+        val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
+            paletteMediaColor!!
+        } else {
+            defaultMaterialYouColor
+        }
+
+        // Animate width smoothly
+        targetContentWidth = calculateTargetWidth()
+        animateWidth()
+
+        // Animate background color change smoothly without affecting container structure
+        animateColorChange(targetColor)
+
+        // Animate odometer / meter flip transition inside container
+        transitionAnimator?.cancel()
+        transitionAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 360L
+            interpolator = DecelerateInterpolator(1.8f)
             addUpdateListener {
-                slotAlpha = it.animatedValue as Float
+                transitionProgress = it.animatedValue as Float
                 invalidate()
             }
-            addListener(object : android.animation.AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: android.animation.Animator) {
-                    activeSlot = newSlot
-                    val targetColor = if (newSlot == GlanceSlot.MEDIA && paletteMediaColor != null) {
-                        paletteMediaColor!!
-                    } else {
-                        defaultMaterialYouColor
-                    }
-                    currentPillColor = targetColor
-                    updateTextColor(targetColor)
-                    targetContentWidth = calculateTargetWidth()
-                    animateWidth()
-
-                    alphaAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
-                        duration = 200
-                        addUpdateListener { anim ->
-                            slotAlpha = anim.animatedValue as Float
-                            invalidate()
-                        }
-                        start()
-                    }
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    isTransitioning = false
+                    transitionProgress = 0f
+                    invalidate()
                 }
             })
             start()
@@ -412,7 +472,8 @@ class StatusGlanceView(context: Context) : View(context) {
     private fun animateColorChange(targetColor: Int) {
         colorAnimator?.cancel()
         colorAnimator = ValueAnimator.ofObject(ArgbEvaluator(), currentPillColor, targetColor).apply {
-            duration = 300
+            duration = 380L
+            interpolator = DecelerateInterpolator()
             addUpdateListener {
                 currentPillColor = it.animatedValue as Int
                 updateTextColor(currentPillColor)
@@ -425,8 +486,8 @@ class StatusGlanceView(context: Context) : View(context) {
     private fun animateWidth() {
         widthAnimator?.cancel()
         widthAnimator = ValueAnimator.ofFloat(currentContentWidth, targetContentWidth).apply {
-            duration = 250
-            interpolator = DecelerateInterpolator()
+            duration = 320L
+            interpolator = DecelerateInterpolator(1.6f)
             addUpdateListener {
                 currentContentWidth = it.animatedValue as Float
                 invalidate()
@@ -436,6 +497,8 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     private fun checkAndStartMarquee(text: String, maxTextWidth: Float) {
+        if (isTransitioning) return
+
         val textWidth = textPaint.measureText(text)
         val needed = textWidth > maxTextWidth && maxTextWidth > 0f
 
@@ -521,59 +584,49 @@ class StatusGlanceView(context: Context) : View(context) {
         return calculated.coerceAtMost(maxAllowedWidth)
     }
 
-    override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
-        if (activeSlot == GlanceSlot.NONE && currentContentWidth <= 0f) return
+    private fun drawSlotContent(
+        canvas: Canvas,
+        text: String,
+        icon: Bitmap?,
+        isArtwork: Boolean,
+        alphaMultiplier: Float,
+        offsetY: Float,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        cornerRadius: Float,
+        chipHeight: Float
+    ) {
+        if (alphaMultiplier <= 0f) return
 
-        val height = 24f * density
-        val width = currentContentWidth
-        if (width <= 0f) return
-
-        val left = glanceCenterX
-        val top = glanceCenterY - height / 2f
-        val right = left + width
-        val bottom = glanceCenterY + height / 2f
-        val cornerRadius = height / 2f
-
-        chipRect.set(left, top, right, bottom)
-
-        val alphaInt = (slotAlpha * 255).toInt().coerceIn(0, 255)
-
-        // Draw background pill if enabled
-        if (useBackgroundPill) {
-            pillPaint.color = currentPillColor
-            pillPaint.alpha = alphaInt
-            canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)
-        }
-
-        // Draw Icon and Text
-        val isArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
-        val icon = getActiveIcon()
         val iconSize = if (isArtwork) 22f * density else 14f * density
         val paddingLeft = if (isArtwork) 1f * density else 8f * density
         val iconLeft = left + paddingLeft
-        val iconTop = glanceCenterY - iconSize / 2f
+        val iconTop = glanceCenterY - iconSize / 2f + offsetY
 
-        iconPaint.alpha = alphaInt
-        artworkPaint.alpha = alphaInt
+        val combinedAlpha = (slotAlpha * alphaMultiplier * 255).toInt().coerceIn(0, 255)
+        iconPaint.alpha = combinedAlpha
+        artworkPaint.alpha = combinedAlpha
 
         // Draw Text
-        val text = getActiveText()
         if (text.isNotBlank()) {
             val spacing = if (isArtwork) 5f * density else 6f * density
             val textLeft = iconLeft + iconSize + spacing
             val textRight = if (useBackgroundPill) right else right - 8f * density
             val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
 
-            checkAndStartMarquee(text, maxTextWidth)
+            if (!isTransitioning) {
+                checkAndStartMarquee(text, maxTextWidth)
+            }
 
             textPaint.color = currentTextColor
-            textPaint.alpha = alphaInt
+            textPaint.alpha = combinedAlpha
 
             textPaint.getTextBounds(text, 0, text.length, textBounds)
-            val textY = glanceCenterY - textBounds.exactCenterY()
+            val textY = glanceCenterY - textBounds.exactCenterY() + offsetY
 
-            if (isMarqueeNeeded) {
+            if (isMarqueeNeeded && !isTransitioning) {
                 val fadeWidth = 12f * density
                 val marqueeBounds = RectF(textLeft, top, textRight, bottom)
                 val saveLayerCount = canvas.saveLayer(marqueeBounds, null)
@@ -597,13 +650,13 @@ class StatusGlanceView(context: Context) : View(context) {
                 }
 
                 val marqueeGap = 28f * density
-                val textWidth = textPaint.measureText(text)
+                val textWidthMeasure = textPaint.measureText(text)
                 val x1 = textLeft - marqueeOffset
-                val x2 = x1 + textWidth + marqueeGap
+                val x2 = x1 + textWidthMeasure + marqueeGap
                 canvas.drawText(text, x1, textY, textPaint)
                 canvas.drawText(text, x2, textY, textPaint)
 
-                // fade
+                // Left fade gradient
                 marqueeFadePaint.shader = LinearGradient(
                     textLeft, 0f, textLeft + fadeWidth, 0f,
                     Color.TRANSPARENT, Color.BLACK,
@@ -617,17 +670,18 @@ class StatusGlanceView(context: Context) : View(context) {
             }
         }
 
+        // Draw Icon on top of text layer
         if (icon != null) {
             if (isArtwork) {
                 val artworkRadius = iconSize / 2f
                 val artworkCenterX = iconLeft + artworkRadius
-                val artworkCenterY = glanceCenterY
+                val artworkCenterY = glanceCenterY + offsetY
 
                 val shader = BitmapShader(icon, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
                 val matrix = android.graphics.Matrix()
                 val scale = iconSize / icon.width.coerceAtMost(icon.height).toFloat()
                 val dx = iconLeft - (icon.width * scale - iconSize) / 2f
-                val dy = iconTop - (icon.height * scale - iconSize) / 2f
+                val dy = (glanceCenterY - iconSize / 2f + offsetY) - (icon.height * scale - iconSize) / 2f
                 matrix.setScale(scale, scale)
                 matrix.postTranslate(dx, dy)
                 shader.setLocalMatrix(matrix)
@@ -642,12 +696,112 @@ class StatusGlanceView(context: Context) : View(context) {
         }
     }
 
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (activeSlot == GlanceSlot.NONE && currentContentWidth <= 0f) return
+
+        val height = 24f * density
+        val width = currentContentWidth
+        if (width <= 0f) return
+
+        val left = glanceCenterX
+        val top = glanceCenterY - height / 2f
+        val right = left + width
+        val bottom = glanceCenterY + height / 2f
+        val cornerRadius = height / 2f
+
+        chipRect.set(left, top, right, bottom)
+
+        val alphaInt = (slotAlpha * 255).toInt().coerceIn(0, 255)
+
+        // 1. Draw background pill container (stays completely intact and morphs width/color smoothly)
+        if (useBackgroundPill) {
+            pillPaint.color = currentPillColor
+            pillPaint.alpha = alphaInt
+            canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)
+        }
+
+        // 2. Draw content with odometer flip animation inside the container
+        val saveContainerCount = canvas.save()
+        containerClipPath.reset()
+        containerClipPath.addRoundRect(chipRect, cornerRadius, cornerRadius, Path.Direction.CW)
+        canvas.clipPath(containerClipPath)
+
+        if (isTransitioning) {
+            val flipDistance = height * 0.95f
+            val p = transitionProgress
+
+            // Direction: +1 means incoming rolls up from bottom (+flipDistance -> 0), outgoing rolls up (0 -> -flipDistance)
+            // -1 means incoming rolls down from top (-flipDistance -> 0), outgoing rolls down (0 -> +flipDistance)
+            val oldOffsetY = -transitionDirection * p * flipDistance
+            val oldAlpha = (1f - p).coerceIn(0f, 1f)
+
+            val newOffsetY = transitionDirection * (1f - p) * flipDistance
+            val newAlpha = p.coerceIn(0f, 1f)
+
+            // Draw outgoing slot
+            drawSlotContent(
+                canvas = canvas,
+                text = previousText,
+                icon = previousIcon,
+                isArtwork = previousIsArtwork,
+                alphaMultiplier = oldAlpha,
+                offsetY = oldOffsetY,
+                left = left,
+                top = top,
+                right = right,
+                bottom = bottom,
+                cornerRadius = cornerRadius,
+                chipHeight = height
+            )
+
+            // Draw incoming slot
+            val currentText = getActiveText()
+            val currentIcon = getActiveIcon()
+            val currentIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
+            drawSlotContent(
+                canvas = canvas,
+                text = currentText,
+                icon = currentIcon,
+                isArtwork = currentIsArtwork,
+                alphaMultiplier = newAlpha,
+                offsetY = newOffsetY,
+                left = left,
+                top = top,
+                right = right,
+                bottom = bottom,
+                cornerRadius = cornerRadius,
+                chipHeight = height
+            )
+        } else {
+            val currentText = getActiveText()
+            val currentIcon = getActiveIcon()
+            val currentIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
+            drawSlotContent(
+                canvas = canvas,
+                text = currentText,
+                icon = currentIcon,
+                isArtwork = currentIsArtwork,
+                alphaMultiplier = 1f,
+                offsetY = 0f,
+                left = left,
+                top = top,
+                right = right,
+                bottom = bottom,
+                cornerRadius = cornerRadius,
+                chipHeight = height
+            )
+        }
+
+        canvas.restoreToCount(saveContainerCount)
+    }
+
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         stopMarquee()
         widthAnimator?.cancel()
         alphaAnimator?.cancel()
         colorAnimator?.cancel()
+        transitionAnimator?.cancel()
     }
 }
-

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -182,6 +182,14 @@ class StatusGlanceView(context: Context) : View(context) {
             }
         }
 
+    var hideWhenLocked: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
     var isFullscreen: Boolean = false
         set(value) {
             if (field != value) {
@@ -824,7 +832,7 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     fun updateVisibilityState(immediate: Boolean = false) {
-        val shouldHide = isLocked || isScreenOff || isLandscape || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
+        val shouldHide = (isLocked && hideWhenLocked) || isScreenOff || isLandscape || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
         if (isVisibilityHidden == shouldHide && !immediate) return
         isVisibilityHidden = shouldHide
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -97,6 +97,54 @@ class StatusGlanceView(context: Context) : View(context) {
             reevaluateSlot()
         }
 
+    var hideWhenFullscreen: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
+    var hideInQuickSettings: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
+    var isFullscreen: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
+    var isShadeExpanded: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
+    var isLocked: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
+    var isScreenOff: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
     var fontSize: Float = 13f
         set(value) {
             field = value
@@ -218,6 +266,11 @@ class StatusGlanceView(context: Context) : View(context) {
     private var currentContentWidth: Float = 0f
     private var targetContentWidth: Float = 0f
     private var widthAnimator: ValueAnimator? = null
+
+    // Visibility and reveal animation
+    private var isVisibilityHidden: Boolean = false
+    private var revealProgress: Float = 1f
+    private var revealAnimator: ValueAnimator? = null
 
     private var slotAlpha: Float = 1f
     private var alphaAnimator: ValueAnimator? = null
@@ -608,6 +661,38 @@ class StatusGlanceView(context: Context) : View(context) {
         return calculated.coerceAtMost(maxAllowedWidth)
     }
 
+    fun updateVisibilityState(immediate: Boolean = false) {
+        val shouldHide = isLocked || isScreenOff || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
+        if (isVisibilityHidden == shouldHide && !immediate) return
+        isVisibilityHidden = shouldHide
+
+        revealAnimator?.cancel()
+        val startVal = revealProgress
+        val targetVal = if (shouldHide) 0f else 1f
+
+        if (immediate) {
+            revealProgress = targetVal
+            invalidate()
+            return
+        }
+
+        val durationMs = if (shouldHide) 240L else 380L
+
+        revealAnimator = ValueAnimator.ofFloat(startVal, targetVal).apply {
+            duration = durationMs
+            interpolator = if (shouldHide) {
+                LinearInterpolator()
+            } else {
+                DecelerateInterpolator(1.8f)
+            }
+            addUpdateListener {
+                revealProgress = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
     private fun drawSlotContent(
         canvas: Canvas,
         clockText: String,
@@ -621,15 +706,20 @@ class StatusGlanceView(context: Context) : View(context) {
         right: Float,
         bottom: Float,
         cornerRadius: Float,
-        chipHeight: Float
+        chipHeight: Float,
+        revealTextAlpha: Float = 1f,
+        revealIconAlpha: Float = 1f,
+        expandPhase: Float = 1f
     ) {
         if (alphaMultiplier <= 0f) return
 
-        val combinedAlpha = (slotAlpha * alphaMultiplier * 255).toInt().coerceIn(0, 255)
-        iconPaint.alpha = combinedAlpha
-        artworkPaint.alpha = combinedAlpha
+        val combinedTextAlpha = (slotAlpha * alphaMultiplier * revealTextAlpha * 255).toInt().coerceIn(0, 255)
+        val combinedIconAlpha = (slotAlpha * alphaMultiplier * revealIconAlpha * 255).toInt().coerceIn(0, 255)
+
+        iconPaint.alpha = combinedIconAlpha
+        artworkPaint.alpha = combinedIconAlpha
         textPaint.color = currentTextColor
-        textPaint.alpha = combinedAlpha
+        textPaint.alpha = combinedTextAlpha
 
         var cursorX = left
 
@@ -638,7 +728,9 @@ class StatusGlanceView(context: Context) : View(context) {
             cursorX += clockPaddingLeft
             textPaint.getTextBounds(clockText, 0, clockText.length, textBounds)
             val clockY = glanceCenterY - textBounds.exactCenterY() + offsetY
-            canvas.drawText(clockText, cursorX, clockY, textPaint)
+            if (combinedTextAlpha > 0) {
+                canvas.drawText(clockText, cursorX, clockY, textPaint)
+            }
             cursorX += textPaint.measureText(clockText) + (4f * density)
         }
 
@@ -648,10 +740,16 @@ class StatusGlanceView(context: Context) : View(context) {
             if (isArtwork) 1f * density else 8f * density
         } else 0f
 
-        val iconLeft = cursorX + iconPaddingLeft
+        val restingIconLeft = cursorX + iconPaddingLeft
+        val centeredIconLeft = left + (chipHeight - iconSize) / 2f
+        val iconLeft = if (expandPhase < 1f) {
+            centeredIconLeft + (restingIconLeft - centeredIconLeft) * expandPhase
+        } else {
+            restingIconLeft
+        }
         val iconTop = glanceCenterY - iconSize / 2f + offsetY
 
-        if (marqueeText.isNotBlank()) {
+        if (marqueeText.isNotBlank() && combinedTextAlpha > 0) {
             val textSpacing = if (hasIcon) {
                 if (isArtwork) 3f * density else 4f * density
             } else {
@@ -717,8 +815,7 @@ class StatusGlanceView(context: Context) : View(context) {
             }
         }
 
-        
-        if (hasIcon) {
+        if (hasIcon && combinedIconAlpha > 0) {
             if (isArtwork) {
                 val artworkRadius = iconSize / 2f
                 val artworkCenterX = iconLeft + artworkRadius
@@ -745,21 +842,36 @@ class StatusGlanceView(context: Context) : View(context) {
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        if (revealProgress <= 0f) return
         if (activeSlot == GlanceSlot.NONE && currentContentWidth <= 0f) return
 
         val height = 24f * density
-        val width = currentContentWidth
+        val baseCircularWidth = height
+        val fullWidth = currentContentWidth.coerceAtLeast(baseCircularWidth)
+
+        val iconPhase = (revealProgress / 0.35f).coerceIn(0f, 1f)
+        val expandPhase = ((revealProgress - 0.35f) / 0.65f).coerceIn(0f, 1f)
+        val textAlpha = ((revealProgress - 0.45f) / 0.55f).coerceIn(0f, 1f)
+        val iconAlpha = iconPhase
+        val iconScale = 0.5f + 0.5f * iconPhase
+
+        val width = if (revealProgress < 1f) {
+            (baseCircularWidth + (fullWidth - baseCircularWidth) * expandPhase) * (if (expandPhase == 0f) iconScale else 1f)
+        } else {
+            currentContentWidth
+        }
         if (width <= 0f) return
 
+        val currentHeight = if (revealProgress < 1f && expandPhase == 0f) height * iconScale else height
         val left = glanceCenterX
-        val top = glanceCenterY - height / 2f
+        val top = glanceCenterY - currentHeight / 2f
         val right = left + width
-        val bottom = glanceCenterY + height / 2f
-        val cornerRadius = height / 2f
+        val bottom = glanceCenterY + currentHeight / 2f
+        val cornerRadius = currentHeight / 2f
 
         chipRect.set(left, top, right, bottom)
 
-        val alphaInt = (slotAlpha * 255).toInt().coerceIn(0, 255)
+        val alphaInt = (slotAlpha * iconAlpha * 255).toInt().coerceIn(0, 255)
 
         if (useBackgroundPill) {
             pillPaint.color = currentPillColor
@@ -796,7 +908,10 @@ class StatusGlanceView(context: Context) : View(context) {
                 right = right,
                 bottom = bottom,
                 cornerRadius = cornerRadius,
-                chipHeight = height
+                chipHeight = height,
+                revealTextAlpha = textAlpha,
+                revealIconAlpha = iconAlpha,
+                expandPhase = expandPhase
             )
 
             //  incoming slot
@@ -816,7 +931,10 @@ class StatusGlanceView(context: Context) : View(context) {
                 right = right,
                 bottom = bottom,
                 cornerRadius = cornerRadius,
-                chipHeight = height
+                chipHeight = height,
+                revealTextAlpha = textAlpha,
+                revealIconAlpha = iconAlpha,
+                expandPhase = expandPhase
             )
         } else {
             val (currentClock, currentMarquee) = getSlotTexts(activeSlot)
@@ -835,7 +953,10 @@ class StatusGlanceView(context: Context) : View(context) {
                 right = right,
                 bottom = bottom,
                 cornerRadius = cornerRadius,
-                chipHeight = height
+                chipHeight = height,
+                revealTextAlpha = textAlpha,
+                revealIconAlpha = iconAlpha,
+                expandPhase = expandPhase
             )
         }
 
@@ -849,5 +970,6 @@ class StatusGlanceView(context: Context) : View(context) {
         alphaAnimator?.cancel()
         colorAnimator?.cancel()
         transitionAnimator?.cancel()
+        revealAnimator?.cancel()
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -13,14 +13,20 @@ import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapShader
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.LinearGradient
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.graphics.RectF
+import android.graphics.Shader
 import android.graphics.Typeface
+import android.graphics.Xfermode
 import android.os.Build
 import android.view.View
 import android.view.animation.DecelerateInterpolator
@@ -97,6 +103,20 @@ class StatusGlanceView(context: Context) : View(context) {
             reevaluateSlot()
         }
 
+    var isDarkTheme: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                resolveColors()
+                if (activeSlot == GlanceSlot.MEDIA && rawArtworkPaletteColor != null) {
+                    paletteMediaColor = getThemeAdjustedColor(rawArtworkPaletteColor!!)
+                    animateColorChange(paletteMediaColor!!)
+                } else {
+                    animateColorChange(defaultMaterialYouColor)
+                }
+            }
+        }
+
     // State data
     var isFlashlightOn: Boolean = false
         set(value) {
@@ -122,19 +142,23 @@ class StatusGlanceView(context: Context) : View(context) {
             reevaluateSlot()
         }
 
+    private var rawArtworkPaletteColor: Int? = null
+
     var mediaArtworkBitmap: Bitmap? = null
         set(value) {
             field = value
             if (value != null) {
                 Palette.from(value).generate { palette ->
-                    palette?.dominantSwatch?.rgb?.let { color ->
-                        paletteMediaColor = color
-                        if (activeSlot == GlanceSlot.MEDIA) {
-                            animateColorChange(color)
-                        }
+                    val color = extractPaletteAccent(palette)
+                    rawArtworkPaletteColor = color
+                    val adjustedColor = getThemeAdjustedColor(color)
+                    paletteMediaColor = adjustedColor
+                    if (activeSlot == GlanceSlot.MEDIA) {
+                        animateColorChange(adjustedColor)
                     }
                 }
             } else {
+                rawArtworkPaletteColor = null
                 paletteMediaColor = null
                 if (activeSlot == GlanceSlot.MEDIA) {
                     animateColorChange(defaultMaterialYouColor)
@@ -207,6 +231,10 @@ class StatusGlanceView(context: Context) : View(context) {
         isFilterBitmap = true
     }
 
+    private val artworkPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        isFilterBitmap = true
+    }
+
     // Bitmaps
     private var flashlightIcon: Bitmap? = null
     private var calendarIcon: Bitmap? = null
@@ -215,6 +243,10 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private val textBounds = Rect()
     private val chipRect = RectF()
+    private val marqueeClipPath = Path()
+    private val marqueeFadePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_IN)
+    }
 
     init {
         resolveColors()
@@ -222,14 +254,56 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     private fun resolveColors() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val primaryColor = ContextCompat.getColor(context, android.R.color.system_accent1_600)
-            defaultMaterialYouColor = primaryColor
+        defaultMaterialYouColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (isDarkTheme) {
+                ContextCompat.getColor(context, android.R.color.system_accent1_200)
+            } else {
+                ContextCompat.getColor(context, android.R.color.system_accent1_600)
+            }
         } else {
-            defaultMaterialYouColor = Color.parseColor("#388E3C")
+            if (isDarkTheme) Color.parseColor("#81C784") else Color.parseColor("#2E7D32")
         }
         currentPillColor = defaultMaterialYouColor
         updateTextColor(currentPillColor)
+    }
+
+    private fun extractPaletteAccent(palette: Palette?): Int {
+        val dominantSwatch = palette?.dominantSwatch
+        val vibrantSwatch = palette?.vibrantSwatch
+        val lightVibrantSwatch = palette?.lightVibrantSwatch
+        val darkVibrantSwatch = palette?.darkVibrantSwatch
+        val mutedSwatch = palette?.mutedSwatch
+        val lightMutedSwatch = palette?.lightMutedSwatch
+        val darkMutedSwatch = palette?.darkMutedSwatch
+
+        return if (isDarkTheme) {
+            vibrantSwatch?.rgb
+                ?: lightVibrantSwatch?.rgb
+                ?: dominantSwatch?.rgb
+                ?: mutedSwatch?.rgb
+                ?: lightMutedSwatch?.rgb
+                ?: Color.WHITE
+        } else {
+            darkVibrantSwatch?.rgb
+                ?: vibrantSwatch?.rgb
+                ?: dominantSwatch?.rgb
+                ?: darkMutedSwatch?.rgb
+                ?: mutedSwatch?.rgb
+                ?: Color.BLACK
+        }
+    }
+
+    private fun getThemeAdjustedColor(color: Int): Int {
+        val hsv = FloatArray(3)
+        Color.colorToHSV(color, hsv)
+        if (isDarkTheme) {
+            hsv[1] = (hsv[1] * 0.75f).coerceIn(0.25f, 0.90f)
+            hsv[2] = (hsv[2] * 1.25f).coerceIn(0.85f, 1.0f)
+        } else {
+            hsv[1] = (hsv[1] * 1.25f).coerceIn(0.65f, 1.0f)
+            hsv[2] = (hsv[2] * 0.60f).coerceIn(0.20f, 0.55f)
+        }
+        return Color.HSVToColor(hsv)
     }
 
     private fun loadIcons() {
@@ -328,7 +402,7 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private fun updateTextColor(bgColor: Int) {
         if (!useBackgroundPill) {
-            currentTextColor = Color.WHITE
+            currentTextColor = if (isDarkTheme) Color.WHITE else Color.BLACK
             return
         }
         val luminance = (0.299 * Color.red(bgColor) + 0.587 * Color.green(bgColor) + 0.114 * Color.blue(bgColor)) / 255.0
@@ -436,12 +510,14 @@ class StatusGlanceView(context: Context) : View(context) {
         val text = getActiveText()
         textPaint.getTextBounds(text, 0, text.length, textBounds)
         val textWidth = textBounds.width().toFloat()
-        val iconSize = 14f * density
-        val padding = 10f * density
-        val spacing = 6f * density
+        val isArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
+        val iconSize = if (isArtwork) 22f * density else 14f * density
+        val paddingLeft = if (isArtwork) 1f * density else 8f * density
+        val paddingRight = 10f * density
+        val spacing = if (isArtwork) 5f * density else 6f * density
 
         val maxAllowedWidth = maxWidthDp * density
-        val calculated = padding * 2 + iconSize + spacing + textWidth
+        val calculated = paddingLeft + iconSize + spacing + textWidth + paddingRight
         return calculated.coerceAtMost(maxAllowedWidth)
     }
 
@@ -471,30 +547,22 @@ class StatusGlanceView(context: Context) : View(context) {
         }
 
         // Draw Icon and Text
+        val isArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
         val icon = getActiveIcon()
-        val iconSize = 14f * density
-        val paddingLeft = 8f * density
+        val iconSize = if (isArtwork) 22f * density else 14f * density
+        val paddingLeft = if (isArtwork) 1f * density else 8f * density
         val iconLeft = left + paddingLeft
         val iconTop = glanceCenterY - iconSize / 2f
 
         iconPaint.alpha = alphaInt
-        if (icon != null) {
-            if (activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null) {
-                val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
-                iconPaint.colorFilter = null
-                canvas.drawBitmap(icon, null, dstRect, iconPaint)
-            } else {
-                iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
-                val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
-                canvas.drawBitmap(icon, null, dstRect, iconPaint)
-            }
-        }
+        artworkPaint.alpha = alphaInt
 
         // Draw Text
         val text = getActiveText()
         if (text.isNotBlank()) {
-            val textLeft = iconLeft + iconSize + 6f * density
-            val textRight = right - 8f * density
+            val spacing = if (isArtwork) 5f * density else 6f * density
+            val textLeft = iconLeft + iconSize + spacing
+            val textRight = if (useBackgroundPill) right else right - 8f * density
             val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
 
             checkAndStartMarquee(text, maxTextWidth)
@@ -506,17 +574,70 @@ class StatusGlanceView(context: Context) : View(context) {
             val textY = glanceCenterY - textBounds.exactCenterY()
 
             if (isMarqueeNeeded) {
-                val saveCount = canvas.save()
-                canvas.clipRect(textLeft, top, textRight, bottom)
+                val fadeWidth = 12f * density
+                val marqueeBounds = RectF(textLeft, top, textRight, bottom)
+                val saveLayerCount = canvas.saveLayer(marqueeBounds, null)
+
+                if (useBackgroundPill) {
+                    marqueeClipPath.reset()
+                    val radii = floatArrayOf(
+                        0f, 0f,
+                        cornerRadius, cornerRadius,
+                        cornerRadius, cornerRadius,
+                        0f, 0f
+                    )
+                    marqueeClipPath.addRoundRect(
+                        RectF(textLeft, top, right, bottom),
+                        radii,
+                        Path.Direction.CW
+                    )
+                    canvas.clipPath(marqueeClipPath)
+                } else {
+                    canvas.clipRect(textLeft, top, textRight, bottom)
+                }
+
                 val marqueeGap = 28f * density
                 val textWidth = textPaint.measureText(text)
                 val x1 = textLeft - marqueeOffset
                 val x2 = x1 + textWidth + marqueeGap
                 canvas.drawText(text, x1, textY, textPaint)
                 canvas.drawText(text, x2, textY, textPaint)
-                canvas.restoreToCount(saveCount)
+
+                // fade
+                marqueeFadePaint.shader = LinearGradient(
+                    textLeft, 0f, textLeft + fadeWidth, 0f,
+                    Color.TRANSPARENT, Color.BLACK,
+                    Shader.TileMode.CLAMP
+                )
+                canvas.drawRect(textLeft, top, textLeft + fadeWidth, bottom, marqueeFadePaint)
+
+                canvas.restoreToCount(saveLayerCount)
             } else {
                 canvas.drawText(text, textLeft, textY, textPaint)
+            }
+        }
+
+        if (icon != null) {
+            if (isArtwork) {
+                val artworkRadius = iconSize / 2f
+                val artworkCenterX = iconLeft + artworkRadius
+                val artworkCenterY = glanceCenterY
+
+                val shader = BitmapShader(icon, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+                val matrix = android.graphics.Matrix()
+                val scale = iconSize / icon.width.coerceAtMost(icon.height).toFloat()
+                val dx = iconLeft - (icon.width * scale - iconSize) / 2f
+                val dy = iconTop - (icon.height * scale - iconSize) / 2f
+                matrix.setScale(scale, scale)
+                matrix.postTranslate(dx, dy)
+                shader.setLocalMatrix(matrix)
+
+                artworkPaint.shader = shader
+                canvas.drawCircle(artworkCenterX, artworkCenterY, artworkRadius, artworkPaint)
+            } else {
+                iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                val dstRect = RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
+                canvas.drawBitmap(icon, null, dstRect, iconPaint)
             }
         }
     }
@@ -529,3 +650,4 @@ class StatusGlanceView(context: Context) : View(context) {
         colorAnimator?.cancel()
     }
 }
+

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -45,8 +45,7 @@ class StatusGlanceView(context: Context) : View(context) {
         FLASHLIGHT,
         CALENDAR_URGENT,
         MEDIA,
-        CALENDAR_TODAY,
-        TIME
+        DEFAULT
     }
 
     var glanceCenterX: Float = 0f
@@ -199,7 +198,8 @@ class StatusGlanceView(context: Context) : View(context) {
 
     // Slot transition state for car meter roll / flip animation
     private var previousSlot: GlanceSlot = GlanceSlot.NONE
-    private var previousText: String = ""
+    private var previousClockText: String = ""
+    private var previousMarqueeText: String = ""
     private var previousIcon: Bitmap? = null
     private var previousIsArtwork: Boolean = false
 
@@ -252,7 +252,6 @@ class StatusGlanceView(context: Context) : View(context) {
     private var flashlightIcon: Bitmap? = null
     private var calendarIcon: Bitmap? = null
     private var mediaIcon: Bitmap? = null
-    private var timeIcon: Bitmap? = null
 
     private val textBounds = Rect()
     private val chipRect = RectF()
@@ -324,7 +323,6 @@ class StatusGlanceView(context: Context) : View(context) {
         flashlightIcon = getBitmapFromVector(R.drawable.rounded_flashlight_on_24, (14 * density).toInt())
         calendarIcon = getBitmapFromVector(R.drawable.rounded_calendar_today_24, (14 * density).toInt())
         mediaIcon = getBitmapFromVector(R.drawable.rounded_motion_play_24, (14 * density).toInt())
-        timeIcon = getBitmapFromVector(R.drawable.rounded_schedule_24, (14 * density).toInt())
     }
 
     private fun getBitmapFromVector(drawableId: Int, sizePx: Int): Bitmap? {
@@ -342,11 +340,10 @@ class StatusGlanceView(context: Context) : View(context) {
 
     private fun getSlotPriority(slot: GlanceSlot): Int {
         return when (slot) {
-            GlanceSlot.FLASHLIGHT -> 5
-            GlanceSlot.CALENDAR_URGENT -> 4
-            GlanceSlot.MEDIA -> 3
-            GlanceSlot.CALENDAR_TODAY -> 2
-            GlanceSlot.TIME -> 1
+            GlanceSlot.FLASHLIGHT -> 4
+            GlanceSlot.CALENDAR_URGENT -> 3
+            GlanceSlot.MEDIA -> 2
+            GlanceSlot.DEFAULT -> 1
             GlanceSlot.NONE -> 0
         }
     }
@@ -359,8 +356,7 @@ class StatusGlanceView(context: Context) : View(context) {
             showFlashlight && isFlashlightOn -> GlanceSlot.FLASHLIGHT
             showCalendar && isEventWithin15Min && nextEventTitle.isNotBlank() -> GlanceSlot.CALENDAR_URGENT
             showMedia && isMediaPlaying -> GlanceSlot.MEDIA
-            showCalendar && isEventToday && nextEventTitle.isNotBlank() -> GlanceSlot.CALENDAR_TODAY
-            showTime && currentTimeString.isNotBlank() -> GlanceSlot.TIME
+            showTime || (showCalendar && isEventToday && nextEventTitle.isNotBlank()) -> GlanceSlot.DEFAULT
             else -> GlanceSlot.NONE
         }
 
@@ -415,11 +411,12 @@ class StatusGlanceView(context: Context) : View(context) {
 
         // Snapshot current content before updating
         previousSlot = activeSlot
-        previousText = getActiveText()
-        previousIcon = getActiveIcon()
+        val (prevClock, prevMarquee) = getSlotTexts(activeSlot)
+        previousClockText = prevClock
+        previousMarqueeText = prevMarquee
+        previousIcon = getSlotIcon(activeSlot)
         previousIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
 
-        // Determine counter flip direction: +1 if higher priority incoming (roll up), -1 if lower priority (roll down)
         val oldPriority = getSlotPriority(activeSlot)
         val newPriority = getSlotPriority(newSlot)
         transitionDirection = if (newPriority >= oldPriority) 1 else -1
@@ -433,14 +430,10 @@ class StatusGlanceView(context: Context) : View(context) {
             defaultMaterialYouColor
         }
 
-        // Animate width smoothly
         targetContentWidth = calculateTargetWidth()
         animateWidth()
-
-        // Animate background color change smoothly without affecting container structure
         animateColorChange(targetColor)
 
-        // Animate odometer / meter flip transition inside container
         transitionAnimator?.cancel()
         transitionAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = 360L
@@ -546,47 +539,79 @@ class StatusGlanceView(context: Context) : View(context) {
         marqueeOffset = 0f
     }
 
-    private fun getActiveText(): String {
-        return when (activeSlot) {
-            GlanceSlot.FLASHLIGHT -> context.getString(R.string.status_glance_slot_flashlight)
-            GlanceSlot.CALENDAR_URGENT, GlanceSlot.CALENDAR_TODAY -> nextEventTitle
+    /**
+     * Returns Pair(clockText, marqueeText)
+     */
+    private fun getSlotTexts(slot: GlanceSlot): Pair<String, String> {
+        return when (slot) {
+            GlanceSlot.FLASHLIGHT -> Pair("", context.getString(R.string.status_glance_slot_flashlight))
+            GlanceSlot.CALENDAR_URGENT -> Pair("", nextEventTitle)
             GlanceSlot.MEDIA -> {
-                if (mediaArtist.isNotBlank()) "$mediaTitle • $mediaArtist" else mediaTitle
+                val mediaText = if (mediaArtist.isNotBlank()) "$mediaTitle • $mediaArtist" else mediaTitle
+                Pair("", mediaText)
             }
-            GlanceSlot.TIME -> currentTimeString
-            GlanceSlot.NONE -> ""
+            GlanceSlot.DEFAULT -> {
+                val clock = if (showTime) currentTimeString else ""
+                val calendar = if (showCalendar && isEventToday && nextEventTitle.isNotBlank()) nextEventTitle else ""
+                Pair(clock, calendar)
+            }
+            GlanceSlot.NONE -> Pair("", "")
         }
     }
 
-    private fun getActiveIcon(): Bitmap? {
-        return when (activeSlot) {
+    private fun getSlotIcon(slot: GlanceSlot): Bitmap? {
+        return when (slot) {
             GlanceSlot.FLASHLIGHT -> flashlightIcon
-            GlanceSlot.CALENDAR_URGENT, GlanceSlot.CALENDAR_TODAY -> calendarIcon
+            GlanceSlot.CALENDAR_URGENT -> calendarIcon
             GlanceSlot.MEDIA -> mediaArtworkBitmap ?: mediaIcon
-            GlanceSlot.TIME -> timeIcon
+            GlanceSlot.DEFAULT -> {
+                if (showCalendar && isEventToday && nextEventTitle.isNotBlank()) calendarIcon else null
+            }
             GlanceSlot.NONE -> null
         }
     }
 
     private fun calculateTargetWidth(): Float {
         if (activeSlot == GlanceSlot.NONE) return 0f
-        val text = getActiveText()
-        textPaint.getTextBounds(text, 0, text.length, textBounds)
-        val textWidth = textBounds.width().toFloat()
+        val (clockText, marqueeText) = getSlotTexts(activeSlot)
+        val icon = getSlotIcon(activeSlot)
         val isArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
-        val iconSize = if (isArtwork) 22f * density else 14f * density
-        val paddingLeft = if (isArtwork) 1f * density else 8f * density
+        val iconSize = if (icon != null) {
+            if (isArtwork) 22f * density else 14f * density
+        } else 0f
+
+        val paddingLeft = if (icon != null) {
+            if (isArtwork) 1f * density else 8f * density
+        } else 10f * density
+
         val paddingRight = 10f * density
-        val spacing = if (isArtwork) 5f * density else 6f * density
+        val iconSpacing = if (icon != null) {
+            if (isArtwork) 3f * density else 4f * density
+        } else 0f
+
+        var calculated = paddingLeft + iconSize + iconSpacing + paddingRight
+
+        if (clockText.isNotBlank()) {
+            val clockWidth = textPaint.measureText(clockText)
+            calculated += clockWidth
+            if (marqueeText.isNotBlank()) {
+                calculated += 4f * density
+            }
+        }
+
+        if (marqueeText.isNotBlank()) {
+            val marqueeWidth = textPaint.measureText(marqueeText)
+            calculated += marqueeWidth
+        }
 
         val maxAllowedWidth = maxWidthDp * density
-        val calculated = paddingLeft + iconSize + spacing + textWidth + paddingRight
         return calculated.coerceAtMost(maxAllowedWidth)
     }
 
     private fun drawSlotContent(
         canvas: Canvas,
-        text: String,
+        clockText: String,
+        marqueeText: String,
         icon: Bitmap?,
         isArtwork: Boolean,
         alphaMultiplier: Float,
@@ -600,35 +625,58 @@ class StatusGlanceView(context: Context) : View(context) {
     ) {
         if (alphaMultiplier <= 0f) return
 
-        val iconSize = if (isArtwork) 22f * density else 14f * density
-        val paddingLeft = if (isArtwork) 1f * density else 8f * density
-        val iconLeft = left + paddingLeft
-        val iconTop = glanceCenterY - iconSize / 2f + offsetY
-
         val combinedAlpha = (slotAlpha * alphaMultiplier * 255).toInt().coerceIn(0, 255)
         iconPaint.alpha = combinedAlpha
         artworkPaint.alpha = combinedAlpha
+        textPaint.color = currentTextColor
+        textPaint.alpha = combinedAlpha
 
-        // Draw Text
-        if (text.isNotBlank()) {
-            val spacing = if (isArtwork) 5f * density else 6f * density
-            val textLeft = iconLeft + iconSize + spacing
+        var cursorX = left
+
+        if (clockText.isNotBlank()) {
+            val clockPaddingLeft = 10f * density
+            cursorX += clockPaddingLeft
+            textPaint.getTextBounds(clockText, 0, clockText.length, textBounds)
+            val clockY = glanceCenterY - textBounds.exactCenterY() + offsetY
+            canvas.drawText(clockText, cursorX, clockY, textPaint)
+            cursorX += textPaint.measureText(clockText) + (4f * density)
+        }
+
+        val hasIcon = icon != null
+        val iconSize = if (isArtwork) 22f * density else 14f * density
+        val iconPaddingLeft = if (clockText.isBlank()) {
+            if (isArtwork) 1f * density else 8f * density
+        } else 0f
+
+        val iconLeft = cursorX + iconPaddingLeft
+        val iconTop = glanceCenterY - iconSize / 2f + offsetY
+
+        if (marqueeText.isNotBlank()) {
+            val textSpacing = if (hasIcon) {
+                if (isArtwork) 3f * density else 4f * density
+            } else {
+                if (clockText.isBlank()) 10f * density else 0f
+            }
+            val textLeft = if (hasIcon) (iconLeft + iconSize + textSpacing) else (cursorX + textSpacing)
             val textRight = if (useBackgroundPill) right else right - 8f * density
             val maxTextWidth = (textRight - textLeft).coerceAtLeast(0f)
 
             if (!isTransitioning) {
-                checkAndStartMarquee(text, maxTextWidth)
+                checkAndStartMarquee(marqueeText, maxTextWidth)
             }
 
-            textPaint.color = currentTextColor
-            textPaint.alpha = combinedAlpha
-
-            textPaint.getTextBounds(text, 0, text.length, textBounds)
+            textPaint.getTextBounds(marqueeText, 0, marqueeText.length, textBounds)
             val textY = glanceCenterY - textBounds.exactCenterY() + offsetY
 
             if (isMarqueeNeeded && !isTransitioning) {
-                val fadeWidth = 12f * density
-                val marqueeBounds = RectF(textLeft, top, textRight, bottom)
+                val fadeOverlap = if (hasIcon) {
+                    if (isArtwork) 4f * density else 3f * density
+                } else {
+                    4f * density
+                }
+                val fadeStart = (textLeft - fadeOverlap).coerceAtLeast(left)
+                val fadeWidth = 14f * density
+                val marqueeBounds = RectF(fadeStart, top, textRight, bottom)
                 val saveLayerCount = canvas.saveLayer(marqueeBounds, null)
 
                 if (useBackgroundPill) {
@@ -640,38 +688,37 @@ class StatusGlanceView(context: Context) : View(context) {
                         0f, 0f
                     )
                     marqueeClipPath.addRoundRect(
-                        RectF(textLeft, top, right, bottom),
+                        RectF(fadeStart, top, right, bottom),
                         radii,
                         Path.Direction.CW
                     )
                     canvas.clipPath(marqueeClipPath)
                 } else {
-                    canvas.clipRect(textLeft, top, textRight, bottom)
+                    canvas.clipRect(fadeStart, top, textRight, bottom)
                 }
 
                 val marqueeGap = 28f * density
-                val textWidthMeasure = textPaint.measureText(text)
+                val textWidthMeasure = textPaint.measureText(marqueeText)
                 val x1 = textLeft - marqueeOffset
                 val x2 = x1 + textWidthMeasure + marqueeGap
-                canvas.drawText(text, x1, textY, textPaint)
-                canvas.drawText(text, x2, textY, textPaint)
+                canvas.drawText(marqueeText, x1, textY, textPaint)
+                canvas.drawText(marqueeText, x2, textY, textPaint)
 
-                // Left fade gradient
                 marqueeFadePaint.shader = LinearGradient(
-                    textLeft, 0f, textLeft + fadeWidth, 0f,
+                    fadeStart, 0f, fadeStart + fadeWidth, 0f,
                     Color.TRANSPARENT, Color.BLACK,
                     Shader.TileMode.CLAMP
                 )
-                canvas.drawRect(textLeft, top, textLeft + fadeWidth, bottom, marqueeFadePaint)
+                canvas.drawRect(fadeStart, top, fadeStart + fadeWidth, bottom, marqueeFadePaint)
 
                 canvas.restoreToCount(saveLayerCount)
             } else {
-                canvas.drawText(text, textLeft, textY, textPaint)
+                canvas.drawText(marqueeText, textLeft, textY, textPaint)
             }
         }
 
-        // Draw Icon on top of text layer
-        if (icon != null) {
+        
+        if (hasIcon) {
             if (isArtwork) {
                 val artworkRadius = iconSize / 2f
                 val artworkCenterX = iconLeft + artworkRadius
@@ -714,14 +761,12 @@ class StatusGlanceView(context: Context) : View(context) {
 
         val alphaInt = (slotAlpha * 255).toInt().coerceIn(0, 255)
 
-        // 1. Draw background pill container (stays completely intact and morphs width/color smoothly)
         if (useBackgroundPill) {
             pillPaint.color = currentPillColor
             pillPaint.alpha = alphaInt
             canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)
         }
 
-        // 2. Draw content with odometer flip animation inside the container
         val saveContainerCount = canvas.save()
         containerClipPath.reset()
         containerClipPath.addRoundRect(chipRect, cornerRadius, cornerRadius, Path.Direction.CW)
@@ -731,18 +776,17 @@ class StatusGlanceView(context: Context) : View(context) {
             val flipDistance = height * 0.95f
             val p = transitionProgress
 
-            // Direction: +1 means incoming rolls up from bottom (+flipDistance -> 0), outgoing rolls up (0 -> -flipDistance)
-            // -1 means incoming rolls down from top (-flipDistance -> 0), outgoing rolls down (0 -> +flipDistance)
             val oldOffsetY = -transitionDirection * p * flipDistance
             val oldAlpha = (1f - p).coerceIn(0f, 1f)
 
             val newOffsetY = transitionDirection * (1f - p) * flipDistance
             val newAlpha = p.coerceIn(0f, 1f)
 
-            // Draw outgoing slot
+            //  outgoing slot
             drawSlotContent(
                 canvas = canvas,
-                text = previousText,
+                clockText = previousClockText,
+                marqueeText = previousMarqueeText,
                 icon = previousIcon,
                 isArtwork = previousIsArtwork,
                 alphaMultiplier = oldAlpha,
@@ -755,13 +799,14 @@ class StatusGlanceView(context: Context) : View(context) {
                 chipHeight = height
             )
 
-            // Draw incoming slot
-            val currentText = getActiveText()
-            val currentIcon = getActiveIcon()
+            //  incoming slot
+            val (currentClock, currentMarquee) = getSlotTexts(activeSlot)
+            val currentIcon = getSlotIcon(activeSlot)
             val currentIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
             drawSlotContent(
                 canvas = canvas,
-                text = currentText,
+                clockText = currentClock,
+                marqueeText = currentMarquee,
                 icon = currentIcon,
                 isArtwork = currentIsArtwork,
                 alphaMultiplier = newAlpha,
@@ -774,12 +819,13 @@ class StatusGlanceView(context: Context) : View(context) {
                 chipHeight = height
             )
         } else {
-            val currentText = getActiveText()
-            val currentIcon = getActiveIcon()
+            val (currentClock, currentMarquee) = getSlotTexts(activeSlot)
+            val currentIcon = getSlotIcon(activeSlot)
             val currentIsArtwork = activeSlot == GlanceSlot.MEDIA && mediaArtworkBitmap != null
             drawSlotContent(
                 canvas = canvas,
-                text = currentText,
+                clockText = currentClock,
+                marqueeText = currentMarquee,
                 icon = currentIcon,
                 isArtwork = currentIsArtwork,
                 alphaMultiplier = 1f,

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -32,6 +32,7 @@ import android.os.Build
 import android.view.View
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.LinearInterpolator
+import android.view.animation.OvershootInterpolator
 import androidx.core.content.ContextCompat
 import androidx.palette.graphics.Palette
 import com.sameerasw.essentials.R
@@ -356,6 +357,12 @@ class StatusGlanceView(context: Context) : View(context) {
     private var isMarqueeNeeded: Boolean = false
     private var lastMarqueeText: String = ""
     private var lastMaxTextWidth: Float = 0f
+
+    // Gesture animations
+    private var swipeArtworkOffset: Float = 0f
+    private var swipeArtworkAnimator: ValueAnimator? = null
+    private var animatedTapScale: Float = 1.0f
+    private var tapScaleAnimator: ValueAnimator? = null
 
     // Paints
     private val pillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -838,6 +845,40 @@ class StatusGlanceView(context: Context) : View(context) {
         }
     }
 
+    fun setSwipeArtworkOffset(offset: Float) {
+        swipeArtworkAnimator?.cancel()
+        swipeArtworkOffset = offset.coerceAtLeast(0f)
+        invalidate()
+    }
+
+    fun releaseSwipeArtwork() {
+        swipeArtworkAnimator?.cancel()
+        val start = swipeArtworkOffset
+        if (start == 0f) return
+        swipeArtworkAnimator = ValueAnimator.ofFloat(start, 0f).apply {
+            duration = 320L
+            interpolator = OvershootInterpolator(1.2f)
+            addUpdateListener {
+                swipeArtworkOffset = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    fun triggerTapAnimation() {
+        tapScaleAnimator?.cancel()
+        tapScaleAnimator = ValueAnimator.ofFloat(0.92f, 1.0f).apply {
+            duration = 300L
+            interpolator = OvershootInterpolator(2.0f)
+            addUpdateListener {
+                animatedTapScale = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
     private fun drawSlotContent(
         canvas: Canvas,
         clockText: String,
@@ -992,13 +1033,13 @@ class StatusGlanceView(context: Context) : View(context) {
         if (hasIcon && combinedIconAlpha > 0) {
             if (isArtwork) {
                 val artworkRadius = iconSize / 2f
-                val artworkCenterX = iconLeft + artworkRadius
+                val artworkCenterX = iconLeft + artworkRadius + swipeArtworkOffset
                 val artworkCenterY = glanceCenterY + offsetY
 
                 val shader = BitmapShader(icon, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
                 val matrix = android.graphics.Matrix()
                 val scale = iconSize / icon.width.coerceAtMost(icon.height).toFloat()
-                val dx = iconLeft - (icon.width * scale - iconSize) / 2f
+                val dx = (iconLeft + swipeArtworkOffset) - (icon.width * scale - iconSize) / 2f
                 val dy = (glanceCenterY - iconSize / 2f + offsetY) - (icon.height * scale - iconSize) / 2f
                 matrix.setScale(scale, scale)
                 matrix.postTranslate(dx, dy)
@@ -1073,6 +1114,11 @@ class StatusGlanceView(context: Context) : View(context) {
 
         chipRect.set(left, top, right, bottom)
 
+        val saveContainerCount = canvas.save()
+        if (animatedTapScale != 1.0f) {
+            canvas.scale(animatedTapScale, animatedTapScale, left + width / 2f, glanceCenterY)
+        }
+
         val alphaInt = (slotAlpha * iconAlpha * 255).toInt().coerceIn(0, 255)
 
         if (useBackgroundPill) {
@@ -1081,7 +1127,6 @@ class StatusGlanceView(context: Context) : View(context) {
             canvas.drawRoundRect(chipRect, cornerRadius, cornerRadius, pillPaint)
         }
 
-        val saveContainerCount = canvas.save()
         containerClipPath.reset()
         containerClipPath.addRoundRect(chipRect, cornerRadius, cornerRadius, Path.Direction.CW)
         canvas.clipPath(containerClipPath)
@@ -1172,5 +1217,7 @@ class StatusGlanceView(context: Context) : View(context) {
         transitionAnimator?.cancel()
         revealAnimator?.cancel()
         batteryAlphaAnimator?.cancel()
+        swipeArtworkAnimator?.cancel()
+        tapScaleAnimator?.cancel()
     }
 }

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -96,6 +96,15 @@ class StatusGlanceView(context: Context) : View(context) {
             reevaluateBatteryState()
         }
 
+    var batteryIconSizeDp: Float = 16f
+        set(value) {
+            if (field != value) {
+                field = value
+                batteryIconBitmapCache.clear()
+                reevaluateBatteryState()
+            }
+        }
+
     var showBatteryWhenLow: Boolean = true
         set(value) {
             field = value
@@ -799,11 +808,12 @@ class StatusGlanceView(context: Context) : View(context) {
         }
 
         if (isBatteryConditionMet() || batteryAlpha > 0f) {
-            val batteryWidth = if (batteryDisplayMode == "icon") {
-                22f * density
-            } else {
-                val pctText = "$batteryLevel%"
-                batteryTextPaint.measureText(pctText)
+            val iconSizePx = batteryIconSizeDp * density
+            val batteryWidth = when (batteryDisplayMode) {
+                "icon" -> iconSizePx
+                "percentage" -> batteryTextPaint.measureText("$batteryLevel%")
+                "both" -> iconSizePx + 2f * density + batteryTextPaint.measureText("$batteryLevel%")
+                else -> iconSizePx
             }
             val batterySpacing = 5f * density
             calculated += (batterySpacing + batteryWidth) * batteryAlpha
@@ -939,10 +949,12 @@ class StatusGlanceView(context: Context) : View(context) {
 
         // Compute reserved right space for battery
         val batteryReservedWidth = if (batteryAlpha > 0f) {
-            val itemW = if (batteryDisplayMode == "icon") {
-                16f * density
-            } else {
-                batteryTextPaint.measureText("$batteryLevel%")
+            val iconSizePx = batteryIconSizeDp * density
+            val itemW = when (batteryDisplayMode) {
+                "icon" -> iconSizePx
+                "percentage" -> batteryTextPaint.measureText("$batteryLevel%")
+                "both" -> iconSizePx + 2f * density + batteryTextPaint.measureText("$batteryLevel%")
+                else -> iconSizePx
             }
             (itemW + 5f * density) * batteryAlpha
         } else {
@@ -1058,26 +1070,47 @@ class StatusGlanceView(context: Context) : View(context) {
             val batteryPhaseAlpha = ((expandPhase - 0.3f) / 0.7f).coerceIn(0f, 1f)
             val combinedBatteryAlpha = (slotAlpha * alphaMultiplier * revealTextAlpha * batteryAlpha * batteryPhaseAlpha * 255).toInt().coerceIn(0, 255)
             if (combinedBatteryAlpha > 0) {
-                if (batteryDisplayMode == "icon") {
-                    val batteryIconSize = 16f * density
-                    val batteryIcon = getBatteryBitmap(batteryIconSize.toInt())
-                    if (batteryIcon != null) {
-                        iconPaint.alpha = combinedBatteryAlpha
-                        iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
-                        val batteryLeft = right - (5.5f * density) - batteryIconSize
-                        val batteryTop = glanceCenterY - batteryIconSize / 2f + offsetY
-                        val dstRect = RectF(batteryLeft, batteryTop, batteryLeft + batteryIconSize, batteryTop + batteryIconSize)
-                        canvas.drawBitmap(batteryIcon, null, dstRect, iconPaint)
+                val iconSizePx = batteryIconSizeDp * density
+                val pctText = "$batteryLevel%"
+                val pctWidth = batteryTextPaint.measureText(pctText)
+
+                when (batteryDisplayMode) {
+                    "icon" -> {
+                        val batteryIcon = getBatteryBitmap(iconSizePx.toInt())
+                        if (batteryIcon != null) {
+                            iconPaint.alpha = combinedBatteryAlpha
+                            iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                            val batteryLeft = right - (5.5f * density) - iconSizePx
+                            val batteryTop = glanceCenterY - iconSizePx / 2f + offsetY
+                            canvas.drawBitmap(batteryIcon, null, RectF(batteryLeft, batteryTop, batteryLeft + iconSizePx, batteryTop + iconSizePx), iconPaint)
+                        }
                     }
-                } else {
-                    val pctText = "$batteryLevel%"
-                    batteryTextPaint.alpha = combinedBatteryAlpha
-                    batteryTextPaint.color = currentTextColor
-                    batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
-                    val pctWidth = batteryTextPaint.measureText(pctText)
-                    val pctX = right - (5.5f * density) - pctWidth
-                    val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
-                    canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+                    "percentage" -> {
+                        batteryTextPaint.alpha = combinedBatteryAlpha
+                        batteryTextPaint.color = currentTextColor
+                        batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
+                        val pctX = right - (5.5f * density) - pctWidth
+                        val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
+                        canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+                    }
+                    "both" -> {
+                        // Draw percentage text first (rightmost), then icon to its left
+                        batteryTextPaint.alpha = combinedBatteryAlpha
+                        batteryTextPaint.color = currentTextColor
+                        batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
+                        val pctX = right - (5.5f * density) - pctWidth
+                        val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
+                        canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+
+                        val batteryIcon = getBatteryBitmap(iconSizePx.toInt())
+                        if (batteryIcon != null) {
+                            iconPaint.alpha = combinedBatteryAlpha
+                            iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                            val batteryLeft = pctX - 2f * density - iconSizePx
+                            val batteryTop = glanceCenterY - iconSizePx / 2f + offsetY
+                            canvas.drawBitmap(batteryIcon, null, RectF(batteryLeft, batteryTop, batteryLeft + iconSizePx, batteryTop + iconSizePx), iconPaint)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -175,6 +175,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceShowTime = mutableStateOf(true)
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
     val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
+    val isStatusGlanceHideInQuickSettings = mutableStateOf(true)
 
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
@@ -700,6 +701,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ->
                         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ->
+                        isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1973,6 +1977,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceShowTime.value = settingsRepository.isStatusGlanceShowTimeEnabled()
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
+        isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4773,6 +4778,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceHideWhenFullscreen(enabled: Boolean) {
         isStatusGlanceHideWhenFullscreen.value = enabled
         settingsRepository.setStatusGlanceHideWhenFullscreenEnabled(enabled)
+    }
+
+    fun setStatusGlanceHideInQuickSettings(enabled: Boolean) {
+        isStatusGlanceHideInQuickSettings.value = enabled
+        settingsRepository.setStatusGlanceHideInQuickSettingsEnabled(enabled)
     }
 
     fun setStatusGlanceMaxWidth(value: Float) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -185,6 +185,9 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBatteryShowCharging = mutableStateOf(true)
     val isStatusGlanceBatteryShowFull = mutableStateOf(true)
     val isStatusGlanceBatteryShowOtherwise = mutableStateOf(true)
+    val statusGlanceTapAction = mutableStateOf<Action?>(null)
+    val statusGlanceDoubleTapAction = mutableStateOf<Action?>(null)
+    val statusGlanceLongPressAction = mutableStateOf<Action?>(null)
 
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
@@ -737,6 +740,15 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE ->
                         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_TAP_ACTION ->
+                        statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION ->
+                        statusGlanceDoubleTapAction.value = settingsRepository.getStatusGlanceDoubleTapAction()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_LONG_PRESS_ACTION ->
+                        statusGlanceLongPressAction.value = settingsRepository.getStatusGlanceLongPressAction()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -2019,6 +2031,9 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBatteryShowCharging.value = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
         isStatusGlanceBatteryShowFull.value = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+        statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
+        statusGlanceDoubleTapAction.value = settingsRepository.getStatusGlanceDoubleTapAction()
+        statusGlanceLongPressAction.value = settingsRepository.getStatusGlanceLongPressAction()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4936,6 +4951,21 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceBatteryShowOtherwise(enabled: Boolean) {
         isStatusGlanceBatteryShowOtherwise.value = enabled
         settingsRepository.setStatusGlanceBatteryShowOtherwiseEnabled(enabled)
+    }
+
+    fun setStatusGlanceTapAction(action: Action?) {
+        statusGlanceTapAction.value = action
+        settingsRepository.setStatusGlanceTapAction(action)
+    }
+
+    fun setStatusGlanceDoubleTapAction(action: Action?) {
+        statusGlanceDoubleTapAction.value = action
+        settingsRepository.setStatusGlanceDoubleTapAction(action)
+    }
+
+    fun setStatusGlanceLongPressAction(action: Action?) {
+        statusGlanceLongPressAction.value = action
+        settingsRepository.setStatusGlanceLongPressAction(action)
     }
 
     fun setStatusGlanceMaxWidth(value: Float) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -179,6 +179,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
     val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
     val isStatusGlanceHideInQuickSettings = mutableStateOf(true)
+    val isStatusGlanceHideWhenLocked = mutableStateOf(true)
     val isStatusGlanceShowBattery = mutableStateOf(false)
     val statusGlanceBatteryDisplayMode = mutableStateOf("icon")
     val isStatusGlanceBatteryShowLow = mutableStateOf(true)
@@ -723,6 +724,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ->
                         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED ->
+                        isStatusGlanceHideWhenLocked.value = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
 
                     SettingsRepository.KEY_STATUS_GLANCE_SHOW_BATTERY ->
                         isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
@@ -2029,6 +2033,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+        isStatusGlanceHideWhenLocked.value = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
         isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
         statusGlanceBatteryDisplayMode.value = settingsRepository.getStatusGlanceBatteryDisplayMode()
         isStatusGlanceBatteryShowLow.value = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
@@ -4926,6 +4931,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceHideInQuickSettings(enabled: Boolean) {
         isStatusGlanceHideInQuickSettings.value = enabled
         settingsRepository.setStatusGlanceHideInQuickSettingsEnabled(enabled)
+    }
+
+    fun setStatusGlanceHideWhenLocked(enabled: Boolean) {
+        isStatusGlanceHideWhenLocked.value = enabled
+        settingsRepository.setStatusGlanceHideWhenLockedEnabled(enabled)
     }
 
     fun setStatusGlanceShowBattery(enabled: Boolean) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -176,6 +176,12 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
     val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
     val isStatusGlanceHideInQuickSettings = mutableStateOf(true)
+    val isStatusGlanceShowBattery = mutableStateOf(false)
+    val statusGlanceBatteryDisplayMode = mutableStateOf("icon")
+    val isStatusGlanceBatteryShowLow = mutableStateOf(true)
+    val isStatusGlanceBatteryShowCharging = mutableStateOf(true)
+    val isStatusGlanceBatteryShowFull = mutableStateOf(true)
+    val isStatusGlanceBatteryShowOtherwise = mutableStateOf(true)
 
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
@@ -704,6 +710,24 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ->
                         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_SHOW_BATTERY ->
+                        isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_DISPLAY_MODE ->
+                        statusGlanceBatteryDisplayMode.value = settingsRepository.getStatusGlanceBatteryDisplayMode()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_LOW ->
+                        isStatusGlanceBatteryShowLow.value = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING ->
+                        isStatusGlanceBatteryShowCharging.value = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_FULL ->
+                        isStatusGlanceBatteryShowFull.value = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE ->
+                        isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1978,6 +2002,12 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+        isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
+        statusGlanceBatteryDisplayMode.value = settingsRepository.getStatusGlanceBatteryDisplayMode()
+        isStatusGlanceBatteryShowLow.value = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
+        isStatusGlanceBatteryShowCharging.value = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
+        isStatusGlanceBatteryShowFull.value = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
+        isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4783,6 +4813,36 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceHideInQuickSettings(enabled: Boolean) {
         isStatusGlanceHideInQuickSettings.value = enabled
         settingsRepository.setStatusGlanceHideInQuickSettingsEnabled(enabled)
+    }
+
+    fun setStatusGlanceShowBattery(enabled: Boolean) {
+        isStatusGlanceShowBattery.value = enabled
+        settingsRepository.setStatusGlanceShowBatteryEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryDisplayMode(mode: String) {
+        statusGlanceBatteryDisplayMode.value = mode
+        settingsRepository.setStatusGlanceBatteryDisplayMode(mode)
+    }
+
+    fun setStatusGlanceBatteryShowLow(enabled: Boolean) {
+        isStatusGlanceBatteryShowLow.value = enabled
+        settingsRepository.setStatusGlanceBatteryShowLowEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryShowCharging(enabled: Boolean) {
+        isStatusGlanceBatteryShowCharging.value = enabled
+        settingsRepository.setStatusGlanceBatteryShowChargingEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryShowFull(enabled: Boolean) {
+        isStatusGlanceBatteryShowFull.value = enabled
+        settingsRepository.setStatusGlanceBatteryShowFullEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryShowOtherwise(enabled: Boolean) {
+        isStatusGlanceBatteryShowOtherwise.value = enabled
+        settingsRepository.setStatusGlanceBatteryShowOtherwiseEnabled(enabled)
     }
 
     fun setStatusGlanceMaxWidth(value: Float) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -171,6 +171,9 @@ class MainViewModel : ViewModel() {
     val statusGlanceFontSize = mutableFloatStateOf(13f)
     val isStatusGlanceShowFlashlight = mutableStateOf(true)
     val isStatusGlanceShowCalendar = mutableStateOf(true)
+    val statusGlanceCalendarTimeframe = mutableStateOf("today")
+    val statusGlanceSelectedCalendarIds = mutableStateOf<Set<String>>(emptySet())
+    val statusGlanceAvailableCalendars = mutableStateListOf<CalendarAccount>()
     val isStatusGlanceShowMedia = mutableStateOf(true)
     val isStatusGlanceShowTime = mutableStateOf(true)
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
@@ -695,6 +698,12 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_SHOW_CALENDAR ->
                         isStatusGlanceShowCalendar.value = settingsRepository.isStatusGlanceShowCalendarEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_CALENDAR_TIMEFRAME ->
+                        statusGlanceCalendarTimeframe.value = settingsRepository.getStatusGlanceCalendarTimeframe()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_CALENDAR_SELECTED_CALENDARS ->
+                        statusGlanceSelectedCalendarIds.value = settingsRepository.getStatusGlanceCalendarSelectedCalendars()
 
                     SettingsRepository.KEY_STATUS_GLANCE_SHOW_MEDIA ->
                         isStatusGlanceShowMedia.value = settingsRepository.isStatusGlanceShowMediaEnabled()
@@ -1997,6 +2006,8 @@ class MainViewModel : ViewModel() {
         statusGlanceFontSize.floatValue = settingsRepository.getStatusGlanceFontSize()
         isStatusGlanceShowFlashlight.value = settingsRepository.isStatusGlanceShowFlashlightEnabled()
         isStatusGlanceShowCalendar.value = settingsRepository.isStatusGlanceShowCalendarEnabled()
+        statusGlanceCalendarTimeframe.value = settingsRepository.getStatusGlanceCalendarTimeframe()
+        statusGlanceSelectedCalendarIds.value = settingsRepository.getStatusGlanceCalendarSelectedCalendars()
         isStatusGlanceShowMedia.value = settingsRepository.isStatusGlanceShowMediaEnabled()
         isStatusGlanceShowTime.value = settingsRepository.isStatusGlanceShowTimeEnabled()
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
@@ -4788,6 +4799,88 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceShowCalendar(enabled: Boolean) {
         isStatusGlanceShowCalendar.value = enabled
         settingsRepository.setStatusGlanceShowCalendarEnabled(enabled)
+    }
+
+    fun setStatusGlanceCalendarTimeframe(timeframe: String) {
+        statusGlanceCalendarTimeframe.value = timeframe
+        settingsRepository.setStatusGlanceCalendarTimeframe(timeframe)
+    }
+
+    fun fetchStatusGlanceCalendars(context: Context) {
+        if (ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_CALENDAR,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val savedSelected = settingsRepository.getStatusGlanceCalendarSelectedCalendars()
+            withContext(Dispatchers.Main) {
+                statusGlanceSelectedCalendarIds.value = savedSelected
+            }
+
+            val calendars = mutableListOf<CalendarAccount>()
+            val projection =
+                arrayOf(
+                    CalendarContract.Calendars._ID,
+                    CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+                    CalendarContract.Calendars.ACCOUNT_NAME,
+                    CalendarContract.Calendars.CALENDAR_COLOR,
+                )
+
+            context.contentResolver
+                .query(
+                    CalendarContract.Calendars.CONTENT_URI,
+                    projection,
+                    null,
+                    null,
+                    null,
+                )?.use { cursor ->
+                    val idColumn = cursor.getColumnIndex(CalendarContract.Calendars._ID)
+                    val nameColumn = cursor.getColumnIndex(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
+                    val accountColumn = cursor.getColumnIndex(CalendarContract.Calendars.ACCOUNT_NAME)
+
+                    while (cursor.moveToNext()) {
+                        val id = cursor.getLong(idColumn)
+                        val name = cursor.getString(nameColumn) ?: "Unnamed Calendar"
+                        val account = cursor.getString(accountColumn) ?: "Local"
+
+                        calendars.add(
+                            CalendarAccount(
+                                id,
+                                name,
+                                account,
+                                savedSelected.isEmpty() || savedSelected.contains(id.toString()),
+                            ),
+                        )
+                    }
+                }
+
+            withContext(Dispatchers.Main) {
+                statusGlanceAvailableCalendars.clear()
+                statusGlanceAvailableCalendars.addAll(calendars)
+            }
+        }
+    }
+
+    fun toggleStatusGlanceCalendarSelection(calendarId: Long) {
+        val currentIds = statusGlanceSelectedCalendarIds.value.toMutableSet()
+        val idString = calendarId.toString()
+        if (currentIds.contains(idString)) {
+            currentIds.remove(idString)
+        } else {
+            currentIds.add(idString)
+        }
+        statusGlanceSelectedCalendarIds.value = currentIds
+        settingsRepository.saveStatusGlanceCalendarSelectedCalendars(currentIds)
+
+        val index = statusGlanceAvailableCalendars.indexOfFirst { it.id == calendarId }
+        if (index != -1) {
+            statusGlanceAvailableCalendars[index] =
+                statusGlanceAvailableCalendars[index].copy(isSelected = currentIds.contains(idString))
+        }
     }
 
     fun setStatusGlanceShowMedia(enabled: Boolean) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -177,6 +177,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceShowMedia = mutableStateOf(true)
     val isStatusGlanceShowTime = mutableStateOf(true)
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
+    val isStatusGlanceAlbumArtColors = mutableStateOf(true)
     val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
     val isStatusGlanceHideInQuickSettings = mutableStateOf(true)
     val isStatusGlanceHideWhenLocked = mutableStateOf(true)
@@ -718,6 +719,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ->
                         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_ALBUM_ART_COLORS ->
+                        isStatusGlanceAlbumArtColors.value = settingsRepository.isStatusGlanceAlbumArtColorsEnabled()
 
                     SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ->
                         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
@@ -2031,6 +2035,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceShowMedia.value = settingsRepository.isStatusGlanceShowMediaEnabled()
         isStatusGlanceShowTime.value = settingsRepository.isStatusGlanceShowTimeEnabled()
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+        isStatusGlanceAlbumArtColors.value = settingsRepository.isStatusGlanceAlbumArtColorsEnabled()
         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
         isStatusGlanceHideWhenLocked.value = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
@@ -4921,6 +4926,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceBackgroundPill(enabled: Boolean) {
         isStatusGlanceBackgroundPill.value = enabled
         settingsRepository.setStatusGlanceBackgroundPillEnabled(enabled)
+    }
+
+    fun setStatusGlanceAlbumArtColors(enabled: Boolean) {
+        isStatusGlanceAlbumArtColors.value = enabled
+        settingsRepository.setStatusGlanceAlbumArtColorsEnabled(enabled)
     }
 
     fun setStatusGlanceHideWhenFullscreen(enabled: Boolean) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -22,12 +22,14 @@ import android.content.pm.PackageManager
 import android.database.ContentObserver
 import android.graphics.Bitmap
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.provider.CalendarContract
 import android.provider.Settings
 import android.util.Log
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDelegate
@@ -160,6 +162,20 @@ class MainViewModel : ViewModel() {
     val duoSlideMode = mutableStateOf("none")
     val isDuoSlideTrack = mutableStateOf(false)
     val isDuoSlideInvertDirection = mutableStateOf(false)
+
+    val isStatusGlanceEnabled = mutableStateOf(false)
+    val isStatusGlanceAutoDetect = mutableStateOf(true)
+    val statusGlanceOffsetX = mutableFloatStateOf(60f)
+    val statusGlanceOffsetY = mutableFloatStateOf(2f)
+    val statusGlanceMaxWidth = mutableFloatStateOf(180f)
+    val statusGlanceFontSize = mutableFloatStateOf(13f)
+    val isStatusGlanceShowFlashlight = mutableStateOf(true)
+    val isStatusGlanceShowCalendar = mutableStateOf(true)
+    val isStatusGlanceShowMedia = mutableStateOf(true)
+    val isStatusGlanceShowTime = mutableStateOf(true)
+    val isStatusGlanceBackgroundPill = mutableStateOf(false)
+    val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
+
     val snoozeChannels =
         mutableStateOf<List<com.sameerasw.essentials.domain.model.SnoozeChannel>>(emptyList())
     val mapsChannels =
@@ -648,6 +664,42 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_DUO_SLIDE_INVERT_DIRECTION ->
                         isDuoSlideInvertDirection.value = settingsRepository.isDuoSlideInvertDirectionEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_ENABLED ->
+                        isStatusGlanceEnabled.value = settingsRepository.isStatusGlanceEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_USE_AUTO_DETECT ->
+                        isStatusGlanceAutoDetect.value = settingsRepository.isStatusGlanceAutoDetectEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_OFFSET_X ->
+                        statusGlanceOffsetX.floatValue = settingsRepository.getStatusGlanceOffsetX()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_OFFSET_Y ->
+                        statusGlanceOffsetY.floatValue = settingsRepository.getStatusGlanceOffsetY()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_MAX_WIDTH ->
+                        statusGlanceMaxWidth.floatValue = settingsRepository.getStatusGlanceMaxWidth()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_FONT_SIZE ->
+                        statusGlanceFontSize.floatValue = settingsRepository.getStatusGlanceFontSize()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_SHOW_FLASHLIGHT ->
+                        isStatusGlanceShowFlashlight.value = settingsRepository.isStatusGlanceShowFlashlightEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_SHOW_CALENDAR ->
+                        isStatusGlanceShowCalendar.value = settingsRepository.isStatusGlanceShowCalendarEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_SHOW_MEDIA ->
+                        isStatusGlanceShowMedia.value = settingsRepository.isStatusGlanceShowMediaEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ->
+                        isStatusGlanceShowTime.value = settingsRepository.isStatusGlanceShowTimeEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ->
+                        isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ->
+                        isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
 
                     SettingsRepository.KEY_SCREEN_LOCKED_SECURITY_ENABLED ->
                         isScreenLockedSecurityEnabled.value =
@@ -1909,6 +1961,18 @@ class MainViewModel : ViewModel() {
         duoSlideMode.value = settingsRepository.getDuoSlideMode()
         isDuoSlideTrack.value = settingsRepository.isDuoSlideTrackEnabled()
         isDuoSlideInvertDirection.value = settingsRepository.isDuoSlideInvertDirectionEnabled()
+        isStatusGlanceEnabled.value = settingsRepository.isStatusGlanceEnabled()
+        isStatusGlanceAutoDetect.value = settingsRepository.isStatusGlanceAutoDetectEnabled()
+        statusGlanceOffsetX.floatValue = settingsRepository.getStatusGlanceOffsetX()
+        statusGlanceOffsetY.floatValue = settingsRepository.getStatusGlanceOffsetY()
+        statusGlanceMaxWidth.floatValue = settingsRepository.getStatusGlanceMaxWidth()
+        statusGlanceFontSize.floatValue = settingsRepository.getStatusGlanceFontSize()
+        isStatusGlanceShowFlashlight.value = settingsRepository.isStatusGlanceShowFlashlightEnabled()
+        isStatusGlanceShowCalendar.value = settingsRepository.isStatusGlanceShowCalendarEnabled()
+        isStatusGlanceShowMedia.value = settingsRepository.isStatusGlanceShowMediaEnabled()
+        isStatusGlanceShowTime.value = settingsRepository.isStatusGlanceShowTimeEnabled()
+        isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
+        isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
         loadSnoozeChannels(context)
         loadMapsChannels(context)
         isSnoozeHeadsUpEnabled.value =
@@ -4659,6 +4723,97 @@ class MainViewModel : ViewModel() {
     fun setDuoSlideInvertDirection(enabled: Boolean) {
         isDuoSlideInvertDirection.value = enabled
         settingsRepository.setDuoSlideInvertDirection(enabled)
+    }
+
+    fun setStatusGlanceEnabled(enabled: Boolean) {
+        isStatusGlanceEnabled.value = enabled
+        settingsRepository.setStatusGlanceEnabled(enabled)
+    }
+
+    fun setStatusGlanceAutoDetect(enabled: Boolean) {
+        isStatusGlanceAutoDetect.value = enabled
+        settingsRepository.setStatusGlanceAutoDetectEnabled(enabled)
+    }
+
+    fun setStatusGlanceOffsetX(value: Float) {
+        statusGlanceOffsetX.floatValue = value
+        settingsRepository.setStatusGlanceOffsetX(value)
+    }
+
+    fun setStatusGlanceOffsetY(value: Float) {
+        statusGlanceOffsetY.floatValue = value
+        settingsRepository.setStatusGlanceOffsetY(value)
+    }
+
+    fun setStatusGlanceShowFlashlight(enabled: Boolean) {
+        isStatusGlanceShowFlashlight.value = enabled
+        settingsRepository.setStatusGlanceShowFlashlightEnabled(enabled)
+    }
+
+    fun setStatusGlanceShowCalendar(enabled: Boolean) {
+        isStatusGlanceShowCalendar.value = enabled
+        settingsRepository.setStatusGlanceShowCalendarEnabled(enabled)
+    }
+
+    fun setStatusGlanceShowMedia(enabled: Boolean) {
+        isStatusGlanceShowMedia.value = enabled
+        settingsRepository.setStatusGlanceShowMediaEnabled(enabled)
+    }
+
+    fun setStatusGlanceShowTime(enabled: Boolean) {
+        isStatusGlanceShowTime.value = enabled
+        settingsRepository.setStatusGlanceShowTimeEnabled(enabled)
+    }
+
+    fun setStatusGlanceBackgroundPill(enabled: Boolean) {
+        isStatusGlanceBackgroundPill.value = enabled
+        settingsRepository.setStatusGlanceBackgroundPillEnabled(enabled)
+    }
+
+    fun setStatusGlanceHideWhenFullscreen(enabled: Boolean) {
+        isStatusGlanceHideWhenFullscreen.value = enabled
+        settingsRepository.setStatusGlanceHideWhenFullscreenEnabled(enabled)
+    }
+
+    fun setStatusGlanceMaxWidth(value: Float) {
+        statusGlanceMaxWidth.floatValue = value
+        settingsRepository.setStatusGlanceMaxWidth(value)
+    }
+
+    fun setStatusGlanceFontSize(value: Float) {
+        statusGlanceFontSize.floatValue = value
+        settingsRepository.setStatusGlanceFontSize(value)
+    }
+
+    fun autoDetectStatusGlancePosition(context: Context) {
+        val wm = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager ?: return
+        val dm = context.resources.displayMetrics
+        val screenWidth = dm.widthPixels.toFloat()
+        val screenHeight = dm.heightPixels.toFloat()
+        val density = dm.density
+
+        var detectedXPercent = 60f
+        var detectedYPercent = 2f
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            @Suppress("DEPRECATION")
+            val cutout = wm.defaultDisplay?.cutout
+            if (cutout != null && cutout.boundingRects.isNotEmpty()) {
+                val targetRect = cutout.boundingRects.firstOrNull()
+                if (targetRect != null) {
+                    detectedXPercent = ((targetRect.right + 8f * density) / screenWidth) * 100f
+                    detectedYPercent = (targetRect.centerY().toFloat() / screenHeight) * 100f
+                }
+            } else {
+                val resourceId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
+                val statusBarHeight = if (resourceId > 0) context.resources.getDimensionPixelSize(resourceId).toFloat() else 24f * density
+                detectedXPercent = 50f
+                detectedYPercent = ((statusBarHeight / 2f) / screenHeight) * 100f
+            }
+        }
+
+        setStatusGlanceOffsetX(detectedXPercent.coerceIn(0f, 100f))
+        setStatusGlanceOffsetY(detectedYPercent.coerceIn(0f, 20f))
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -185,6 +185,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBatteryShowCharging = mutableStateOf(true)
     val isStatusGlanceBatteryShowFull = mutableStateOf(true)
     val isStatusGlanceBatteryShowOtherwise = mutableStateOf(true)
+    val statusGlanceBatteryIconSize = mutableFloatStateOf(16f)
     val statusGlanceTapAction = mutableStateOf<Action?>(null)
     val statusGlanceDoubleTapAction = mutableStateOf<Action?>(null)
     val statusGlanceLongPressAction = mutableStateOf<Action?>(null)
@@ -740,6 +741,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE ->
                         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_ICON_SIZE ->
+                        statusGlanceBatteryIconSize.floatValue = settingsRepository.getStatusGlanceBatteryIconSize()
 
                     SettingsRepository.KEY_STATUS_GLANCE_TAP_ACTION ->
                         statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
@@ -2031,6 +2035,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBatteryShowCharging.value = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
         isStatusGlanceBatteryShowFull.value = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+        statusGlanceBatteryIconSize.floatValue = settingsRepository.getStatusGlanceBatteryIconSize()
         statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
         statusGlanceDoubleTapAction.value = settingsRepository.getStatusGlanceDoubleTapAction()
         statusGlanceLongPressAction.value = settingsRepository.getStatusGlanceLongPressAction()
@@ -4951,6 +4956,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceBatteryShowOtherwise(enabled: Boolean) {
         isStatusGlanceBatteryShowOtherwise.value = enabled
         settingsRepository.setStatusGlanceBatteryShowOtherwiseEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryIconSize(size: Float) {
+        statusGlanceBatteryIconSize.floatValue = size
+        settingsRepository.setStatusGlanceBatteryIconSize(size)
     }
 
     fun setStatusGlanceTapAction(action: Action?) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2567,4 +2567,13 @@
     <string name="status_glance_calendar_select_calendars_title">Calendars to show</string>
     <string name="status_glance_calendar_no_calendars">No calendars found on device</string>
     <string name="status_glance_calendar_event_in_time">in %1$s</string>
+    <string name="status_glance_section_gestures">Gestures</string>
+    <string name="status_glance_action_tap_title">Single tap</string>
+    <string name="status_glance_action_tap_media_desc">Play / Pause when media is playing</string>
+    <string name="status_glance_action_double_tap_title">Double tap</string>
+    <string name="status_glance_action_long_press_title">Long press</string>
+    <string name="status_glance_action_swipe_right_title">Swipe right</string>
+    <string name="status_glance_action_swipe_right_desc">Skip to next track when media is playing</string>
+    <string name="status_glance_action_pick_title">Pick action</string>
+    <string name="status_glance_action_none">None</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2547,7 +2547,7 @@
     <string name="status_glance_battery_options_title">Battery options</string>
     <string name="status_glance_battery_display_mode_title">Display mode</string>
     <string name="status_glance_battery_mode_icon">Icon</string>
-    <string name="status_glance_battery_mode_percentage">Percentage</string>
+    <string name="status_glance_battery_mode_percentage">Percent</string>
     <string name="status_glance_battery_mode_both">Both</string>
     <string name="status_glance_battery_icon_size_title">Battery icon size</string>
     <string name="status_glance_battery_show_low_title">Show when low battery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2539,6 +2539,8 @@
     <string name="status_glance_background_pill_desc">Using material you colors</string>
     <string name="status_glance_hide_in_quick_settings_title">Hide in quick settings</string>
     <string name="status_glance_hide_in_quick_settings_desc">Automatically hide when notification shade or quick settings is expanded</string>
+    <string name="status_glance_hide_when_locked_title">Hide on lock screen</string>
+    <string name="status_glance_hide_when_locked_desc">Hide the chip while the device is locked</string>
     <string name="status_glance_slot_flashlight">Flashlight On</string>
     <string name="status_glance_show_battery_title">Battery</string>
     <string name="status_glance_show_battery_desc">Display battery indicator on the right side of the pill</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2546,6 +2546,8 @@
     <string name="status_glance_battery_display_mode_title">Display mode</string>
     <string name="status_glance_battery_mode_icon">Icon</string>
     <string name="status_glance_battery_mode_percentage">Percentage</string>
+    <string name="status_glance_battery_mode_both">Both</string>
+    <string name="status_glance_battery_icon_size_title">Battery icon size</string>
     <string name="status_glance_battery_show_low_title">Show when low battery</string>
     <string name="status_glance_battery_show_low_desc">When battery drops below 20%</string>
     <string name="status_glance_battery_show_charging_title">Show while charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2537,5 +2537,7 @@
     <string name="status_glance_section_appearance">Appearance</string>
     <string name="status_glance_background_pill_title">Background pill</string>
     <string name="status_glance_background_pill_desc">Using material you colors</string>
+    <string name="status_glance_hide_in_quick_settings_title">Hide in quick settings</string>
+    <string name="status_glance_hide_in_quick_settings_desc">Automatically hide when notification shade or quick settings is expanded</string>
     <string name="status_glance_slot_flashlight">Flashlight On</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2554,4 +2554,17 @@
     <string name="status_glance_battery_show_full_desc">When battery is fully charged</string>
     <string name="status_glance_battery_show_otherwise_title">Show otherwise</string>
     <string name="status_glance_battery_show_otherwise_desc">Always show during normal discharging states</string>
+    <string name="status_glance_calendar_options_title">Calendar events options</string>
+    <string name="status_glance_calendar_timeframe_title">Show upcoming events in</string>
+    <string name="status_glance_calendar_timeframe_15_mins">15 mins</string>
+    <string name="status_glance_calendar_timeframe_30_mins">30 mins</string>
+    <string name="status_glance_calendar_timeframe_1_hour">1 hour</string>
+    <string name="status_glance_calendar_timeframe_2_hours">2 hours</string>
+    <string name="status_glance_calendar_timeframe_6_hours">6 hours</string>
+    <string name="status_glance_calendar_timeframe_24_hours">24 hrs</string>
+    <string name="status_glance_calendar_timeframe_today">today</string>
+    <string name="status_glance_calendar_timeframe_next">Next</string>
+    <string name="status_glance_calendar_select_calendars_title">Calendars to show</string>
+    <string name="status_glance_calendar_no_calendars">No calendars found on device</string>
+    <string name="status_glance_calendar_event_in_time">in %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2511,4 +2511,31 @@
     <string name="duo_action_pick_title">Pick action</string>
     <string name="duo_action_none">None</string>
     <string name="duo_slide_mirror_direction_title">Mirror directions</string>
+
+    <!-- Status Glance -->
+    <string name="feat_status_glance_title">Status glance</string>
+    <string name="feat_status_glance_desc">At a glance overlay</string>
+    <string name="about_desc_status_glance">Status glance shows a priority-driven ambient chip beside your front camera punch hole. It dynamically displays active flashlight, upcoming calendar events, currently playing media, and the current time.</string>
+    <string name="status_glance_enable_title">Enable Status glance</string>
+    <string name="status_glance_enable_desc">Display status glance</string>
+    <string name="status_glance_section_position">Position</string>
+    <string name="status_glance_auto_detect_button_title">Detect camera position</string>
+    <string name="status_glance_auto_detect_button_desc">Set coordinates beside your front camera automatically</string>
+    <string name="status_glance_offset_x_title">Horizontal position</string>
+    <string name="status_glance_offset_y_title">Vertical position</string>
+    <string name="status_glance_max_width_title">Maximum width</string>
+    <string name="status_glance_font_size_title">Font size</string>
+    <string name="status_glance_section_what_to_show">What to show</string>
+    <string name="status_glance_show_flashlight_title">Flashlight</string>
+    <string name="status_glance_show_flashlight_desc">Highest priority indicator when torch is active</string>
+    <string name="status_glance_show_calendar_title">Calendar events</string>
+    <string name="status_glance_show_calendar_desc">Upcoming events today; urgent within 15 minutes</string>
+    <string name="status_glance_show_media_title">Media playback</string>
+    <string name="status_glance_show_media_desc">Currently playing track with album art tint</string>
+    <string name="status_glance_show_time_title">Time</string>
+    <string name="status_glance_show_time_desc">Default fallback clock</string>
+    <string name="status_glance_section_appearance">Appearance</string>
+    <string name="status_glance_background_pill_title">Background pill</string>
+    <string name="status_glance_background_pill_desc">Surround status with dynamic Material You capsule</string>
+    <string name="status_glance_slot_flashlight">Flashlight On</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2540,4 +2540,18 @@
     <string name="status_glance_hide_in_quick_settings_title">Hide in quick settings</string>
     <string name="status_glance_hide_in_quick_settings_desc">Automatically hide when notification shade or quick settings is expanded</string>
     <string name="status_glance_slot_flashlight">Flashlight On</string>
+    <string name="status_glance_show_battery_title">Battery</string>
+    <string name="status_glance_show_battery_desc">Display battery indicator on the right side of the pill</string>
+    <string name="status_glance_battery_options_title">Battery options</string>
+    <string name="status_glance_battery_display_mode_title">Display mode</string>
+    <string name="status_glance_battery_mode_icon">Icon</string>
+    <string name="status_glance_battery_mode_percentage">Percentage</string>
+    <string name="status_glance_battery_show_low_title">Show when low battery</string>
+    <string name="status_glance_battery_show_low_desc">When battery drops below 20%</string>
+    <string name="status_glance_battery_show_charging_title">Show while charging</string>
+    <string name="status_glance_battery_show_charging_desc">When device is plugged in or charging</string>
+    <string name="status_glance_battery_show_full_title">Show while full</string>
+    <string name="status_glance_battery_show_full_desc">When battery is fully charged</string>
+    <string name="status_glance_battery_show_otherwise_title">Show otherwise</string>
+    <string name="status_glance_battery_show_otherwise_desc">Always show during normal discharging states</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2537,6 +2537,8 @@
     <string name="status_glance_section_appearance">Appearance</string>
     <string name="status_glance_background_pill_title">Background pill</string>
     <string name="status_glance_background_pill_desc">Using material you colors</string>
+    <string name="status_glance_album_art_colors_title">Album art colors</string>
+    <string name="status_glance_album_art_colors_desc">Use media artwork colors for the background pill during playback</string>
     <string name="status_glance_hide_in_quick_settings_title">Hide in quick settings</string>
     <string name="status_glance_hide_in_quick_settings_desc">Automatically hide when notification shade or quick settings is expanded</string>
     <string name="status_glance_hide_when_locked_title">Hide on lock screen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2527,15 +2527,15 @@
     <string name="status_glance_font_size_title">Font size</string>
     <string name="status_glance_section_what_to_show">What to show</string>
     <string name="status_glance_show_flashlight_title">Flashlight</string>
-    <string name="status_glance_show_flashlight_desc">Highest priority indicator when torch is active</string>
+    <string name="status_glance_show_flashlight_desc">Shown when active</string>
     <string name="status_glance_show_calendar_title">Calendar events</string>
-    <string name="status_glance_show_calendar_desc">Upcoming events today; urgent within 15 minutes</string>
+    <string name="status_glance_show_calendar_desc">Upcoming events schedule</string>
     <string name="status_glance_show_media_title">Media playback</string>
-    <string name="status_glance_show_media_desc">Currently playing track with album art tint</string>
+    <string name="status_glance_show_media_desc">Currently playing track with album art</string>
     <string name="status_glance_show_time_title">Time</string>
     <string name="status_glance_show_time_desc">Default fallback clock</string>
     <string name="status_glance_section_appearance">Appearance</string>
     <string name="status_glance_background_pill_title">Background pill</string>
-    <string name="status_glance_background_pill_desc">Surround status with dynamic Material You capsule</string>
+    <string name="status_glance_background_pill_desc">Using material you colors</string>
     <string name="status_glance_slot_flashlight">Flashlight On</string>
 </resources>


### PR DESCRIPTION
This pull request introduces the new "Status Glance" feature, which adds an ambient chip to the interface with rich gesture and customization options. The implementation includes new settings, permissions, feature registration, and a dedicated touch handler class, as well as integration into the main accessibility service.

**Status Glance Feature Implementation:**

* Added a new `StatusGlanceHandler` (with associated touch handler) for managing the Status Glance ambient chip, including gesture recognition for single tap, double tap, long press, and swipe, with media controls and customizable actions (`StatusGlanceTouchHandler.kt`).
* Integrated the handler into the main `ScreenOffAccessibilityService`, ensuring it is properly initialized and its state is updated on relevant settings changes (`ScreenOffAccessibilityService.kt`). [[1]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R46) [[2]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R76) [[3]](diffhunk://#diff-ab4ea5a51ba8ccf8cc20e4f0f32b59b50ba9aa425d69f6d4fb6215ddef315b08R251)

**Settings & Configuration:**

* Added a comprehensive set of new settings keys and getter/setter methods in `SettingsRepository` to support all aspects of the Status Glance feature, including appearance, behavior, and actions (`SettingsRepository.kt`). [[1]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R396-R421) [[2]](diffhunk://#diff-3034452163f09f9c5b913dccd6f93b4a3fefaf773460d401d8904f6f151eb1a7R3220-R3307)

**Feature & Permission Registration:**

* Registered the Status Glance feature in the `FeatureRegistry` with metadata, toggle logic, and beta flag, making it available in the app's feature list (`FeatureRegistry.kt`).
* Registered required permissions (ACCESSIBILITY, NOTIFICATION_LISTENER, READ_CALENDAR) for Status Glance in the `PermissionRegistry` to ensure proper access control (`PermissionRegistry.kt`). [[1]](diffhunk://#diff-b1f1d547c9026cdc9d71b988988d5b536d7b0aad6cabde798889fb8abc00d6c6R59-R60) [[2]](diffhunk://#diff-b1f1d547c9026cdc9d71b988988d5b536d7b0aad6cabde798889fb8abc00d6c6R117)