### PR TITLE
feat(status-glance): battery both mode, icon size slider & lock screen support

### DIFF
--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -416,6 +416,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_BATTERY_ICON_SIZE = "status_glance_battery_icon_size"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
+        const val KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED = "status_glance_hide_when_locked"
         const val KEY_STATUS_GLANCE_TAP_ACTION = "status_glance_tap_action"
         const val KEY_STATUS_GLANCE_DOUBLE_TAP_ACTION = "status_glance_double_tap_action"
         const val KEY_STATUS_GLANCE_LONG_PRESS_ACTION = "status_glance_long_press_action"
@@ -3279,6 +3280,9 @@ class SettingsRepository(
 
     fun isStatusGlanceHideInQuickSettingsEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, true)
     fun setStatusGlanceHideInQuickSettingsEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS, enabled)
+
+    fun isStatusGlanceHideWhenLockedEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED, true)
+    fun setStatusGlanceHideWhenLockedEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED, enabled)
 
     fun isStatusGlanceShowBatteryEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, false)
     fun setStatusGlanceShowBatteryEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_SHOW_BATTERY, enabled)

--- a/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/sameerasw/essentials/data/repository/SettingsRepository.kt
@@ -413,6 +413,7 @@ class SettingsRepository(
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_CHARGING = "status_glance_battery_show_charging"
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_FULL = "status_glance_battery_show_full"
         const val KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE = "status_glance_battery_show_otherwise"
+        const val KEY_STATUS_GLANCE_BATTERY_ICON_SIZE = "status_glance_battery_icon_size"
         const val KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN = "status_glance_hide_when_fullscreen"
         const val KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS = "status_glance_hide_in_quick_settings"
         const val KEY_STATUS_GLANCE_TAP_ACTION = "status_glance_tap_action"
@@ -3296,6 +3297,9 @@ class SettingsRepository(
 
     fun isStatusGlanceBatteryShowOtherwiseEnabled(): Boolean = getBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, true)
     fun setStatusGlanceBatteryShowOtherwiseEnabled(enabled: Boolean) = putBoolean(KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE, enabled)
+
+    fun getStatusGlanceBatteryIconSize(): Float = getFloat(KEY_STATUS_GLANCE_BATTERY_ICON_SIZE, 16f)
+    fun setStatusGlanceBatteryIconSize(size: Float) = putFloat(KEY_STATUS_GLANCE_BATTERY_ICON_SIZE, size)
 
     fun getStatusGlanceTapAction(): Action? = getRemapAction(KEY_STATUS_GLANCE_TAP_ACTION)
     fun setStatusGlanceTapAction(action: Action?) = setRemapAction(KEY_STATUS_GLANCE_TAP_ACTION, action)

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -292,6 +292,7 @@ class StatusGlanceHandler(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun getOverlayLayoutParams(): WindowManager.LayoutParams {
         val type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
 
@@ -299,7 +300,8 @@ class StatusGlanceHandler(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                 WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
-                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
         )
 
         return WindowManager.LayoutParams(
@@ -326,8 +328,9 @@ class StatusGlanceHandler(
         updateTouchAnchor()
     }
 
+    @Suppress("DEPRECATION")
     private fun updateTouchAnchor() {
-        if (!settingsRepository.isStatusGlanceEnabled() || glanceView == null || windowManager == null || isScreenOff || isLocked || isLandscape || (isFullscreen && settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()) || (isShadeExpanded && settingsRepository.isStatusGlanceHideInQuickSettingsEnabled())) {
+        if (!settingsRepository.isStatusGlanceEnabled() || glanceView == null || windowManager == null || isScreenOff || (isLocked && settingsRepository.isStatusGlanceHideWhenLockedEnabled()) || isLandscape || (isFullscreen && settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()) || (isShadeExpanded && settingsRepository.isStatusGlanceHideInQuickSettingsEnabled())) {
             removeTouchAnchor()
             return
         }
@@ -365,7 +368,8 @@ class StatusGlanceHandler(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
-                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -226,6 +226,7 @@ class StatusGlanceHandler(
             v.useBackgroundPill = settingsRepository.isStatusGlanceBackgroundPillEnabled()
             v.hideWhenFullscreen = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
             v.hideInQuickSettings = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+            v.hideWhenLocked = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
             v.maxWidthDp = settingsRepository.getStatusGlanceMaxWidth()
             v.fontSize = settingsRepository.getStatusGlanceFontSize()
             v.isFlashlightOn = isFlashlightOn

--- a/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/handlers/StatusGlanceHandler.kt
@@ -232,6 +232,7 @@ class StatusGlanceHandler(
 
             v.showBattery = settingsRepository.isStatusGlanceShowBatteryEnabled()
             v.batteryDisplayMode = settingsRepository.getStatusGlanceBatteryDisplayMode()
+            v.batteryIconSizeDp = settingsRepository.getStatusGlanceBatteryIconSize()
             v.showBatteryWhenLow = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
             v.showBatteryWhileCharging = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
             v.showBatteryWhileFull = settingsRepository.isStatusGlanceBatteryShowFullEnabled()

--- a/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
+++ b/app/src/main/java/com/sameerasw/essentials/services/tiles/ScreenOffAccessibilityService.kt
@@ -297,7 +297,8 @@ class ScreenOffAccessibilityService :
                 key == SettingsRepository.KEY_STATUS_GLANCE_SHOW_TIME ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_BACKGROUND_PILL ||
                 key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_FULLSCREEN ||
-                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ||
+                key == SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED
             ) {
                 statusGlanceHandler.updateState()
             }

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/StatusGlanceSettingsUI.kt
@@ -458,6 +458,18 @@ fun StatusGlanceSettingsUI(
                         },
                         modifier = Modifier.highlight(highlightSetting == "status_glance_hide_in_quick_settings"),
                     )
+
+                    IconToggleItem(
+                        title = stringResource(R.string.status_glance_hide_when_locked_title),
+                        description = stringResource(R.string.status_glance_hide_when_locked_desc),
+                        iconRes = R.drawable.rounded_lock_24,
+                        isChecked = viewModel.isStatusGlanceHideWhenLocked.value,
+                        onCheckedChange = {
+                            HapticUtil.performUIHaptic(view)
+                            viewModel.setStatusGlanceHideWhenLocked(it)
+                        },
+                        modifier = Modifier.highlight(highlightSetting == "status_glance_hide_when_locked"),
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
@@ -4,11 +4,16 @@
  *
  * Feature Module: UI Feature - Display
  * File: StatusGlanceBatteryOptionsBottomSheet.kt
- * Description: Bottom sheet for configuring Status Glance battery display mode and dynamic visibility conditions.
+ * Description: Bottom sheet for configuring Status Glance battery display mode, icon size, and dynamic visibility conditions.
  */
 
 package com.sameerasw.essentials.ui.features.display.sheets
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -35,6 +40,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.sameerasw.essentials.R
+import com.sameerasw.essentials.ui.components.sliders.ConfigSliderItem
 import com.sameerasw.essentials.ui.core.cards.IconToggleItem
 import com.sameerasw.essentials.ui.core.containers.RoundedCardContainer
 import com.sameerasw.essentials.ui.core.sheets.EssentialsBottomSheet
@@ -73,14 +79,16 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                 modifier = Modifier.padding(start = 8.dp),
             )
 
-            val modes = listOf("icon", "percentage")
+            val modes = listOf("icon", "percentage", "both")
             val icons = listOf(
                 R.drawable.battery_android_frame_full_24px,
                 R.drawable.rounded_numbers_24,
+                R.drawable.battery_android_frame_plus_24px,
             )
             val labels = listOf(
                 stringResource(R.string.status_glance_battery_mode_icon),
                 stringResource(R.string.status_glance_battery_mode_percentage),
+                stringResource(R.string.status_glance_battery_mode_both),
             )
 
             RoundedCardContainer {
@@ -105,7 +113,8 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                                 .semantics { role = Role.RadioButton },
                             shapes = when (index) {
                                 0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
-                                else -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                modes.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
                             },
                         ) {
                             Row(
@@ -124,6 +133,27 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                             }
                         }
                     }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = viewModel.statusGlanceBatteryDisplayMode.value != "percentage",
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically(),
+            ) {
+                RoundedCardContainer(
+                    spacing = 2.dp,
+                    cornerRadius = 24.dp,
+                ) {
+                    ConfigSliderItem(
+                        title = stringResource(R.string.status_glance_battery_icon_size_title),
+                        value = viewModel.statusGlanceBatteryIconSize.floatValue,
+                        onValueChange = { viewModel.setStatusGlanceBatteryIconSize(it) },
+                        valueRange = 10f..24f,
+                        increment = 1f,
+                        iconRes = R.drawable.battery_android_frame_full_24px,
+                        valueFormatter = { "${it.toInt()} dp" },
+                    )
                 }
             }
 
@@ -181,3 +211,4 @@ fun StatusGlanceBatteryOptionsBottomSheet(
         }
     }
 }
+

--- a/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
+++ b/app/src/main/java/com/sameerasw/essentials/ui/features/display/sheets/StatusGlanceBatteryOptionsBottomSheet.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -94,11 +96,12 @@ fun StatusGlanceBatteryOptionsBottomSheet(
             RoundedCardContainer {
                 Row(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .background(
                             color = MaterialTheme.colorScheme.surfaceBright,
-                            shape = RoundedCornerShape(MaterialTheme.shapes.extraSmall.bottomEnd),
+                            shape = RoundedCornerShape(24.dp),
                         )
-                        .padding(10.dp),
+                        .padding(8.dp),
                     horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
                 ) {
                     modes.forEachIndexed { index, mode ->
@@ -119,16 +122,19 @@ fun StatusGlanceBatteryOptionsBottomSheet(
                         ) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                horizontalArrangement = Arrangement.Center,
                             ) {
                                 Icon(
                                     painter = painterResource(id = icons[index]),
                                     contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
+                                    modifier = Modifier.size(18.dp),
                                 )
+                                Spacer(modifier = Modifier.width(6.dp))
                                 Text(
                                     text = labels[index],
-                                    style = MaterialTheme.typography.labelLarge,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    maxLines = 1,
+                                    softWrap = false,
                                 )
                             }
                         }

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -182,6 +182,14 @@ class StatusGlanceView(context: Context) : View(context) {
             }
         }
 
+    var hideWhenLocked: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                updateVisibilityState()
+            }
+        }
+
     var isFullscreen: Boolean = false
         set(value) {
             if (field != value) {
@@ -824,7 +832,7 @@ class StatusGlanceView(context: Context) : View(context) {
     }
 
     fun updateVisibilityState(immediate: Boolean = false) {
-        val shouldHide = isLocked || isScreenOff || isLandscape || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
+        val shouldHide = (isLocked && hideWhenLocked) || isScreenOff || isLandscape || (isFullscreen && hideWhenFullscreen) || (isShadeExpanded && hideInQuickSettings)
         if (isVisibilityHidden == shouldHide && !immediate) return
         isVisibilityHidden = shouldHide
 

--- a/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
+++ b/app/src/main/java/com/sameerasw/essentials/utils/StatusGlanceView.kt
@@ -96,6 +96,15 @@ class StatusGlanceView(context: Context) : View(context) {
             reevaluateBatteryState()
         }
 
+    var batteryIconSizeDp: Float = 16f
+        set(value) {
+            if (field != value) {
+                field = value
+                batteryIconBitmapCache.clear()
+                reevaluateBatteryState()
+            }
+        }
+
     var showBatteryWhenLow: Boolean = true
         set(value) {
             field = value
@@ -799,11 +808,12 @@ class StatusGlanceView(context: Context) : View(context) {
         }
 
         if (isBatteryConditionMet() || batteryAlpha > 0f) {
-            val batteryWidth = if (batteryDisplayMode == "icon") {
-                22f * density
-            } else {
-                val pctText = "$batteryLevel%"
-                batteryTextPaint.measureText(pctText)
+            val iconSizePx = batteryIconSizeDp * density
+            val batteryWidth = when (batteryDisplayMode) {
+                "icon" -> iconSizePx
+                "percentage" -> batteryTextPaint.measureText("$batteryLevel%")
+                "both" -> iconSizePx + 2f * density + batteryTextPaint.measureText("$batteryLevel%")
+                else -> iconSizePx
             }
             val batterySpacing = 5f * density
             calculated += (batterySpacing + batteryWidth) * batteryAlpha
@@ -939,10 +949,12 @@ class StatusGlanceView(context: Context) : View(context) {
 
         // Compute reserved right space for battery
         val batteryReservedWidth = if (batteryAlpha > 0f) {
-            val itemW = if (batteryDisplayMode == "icon") {
-                16f * density
-            } else {
-                batteryTextPaint.measureText("$batteryLevel%")
+            val iconSizePx = batteryIconSizeDp * density
+            val itemW = when (batteryDisplayMode) {
+                "icon" -> iconSizePx
+                "percentage" -> batteryTextPaint.measureText("$batteryLevel%")
+                "both" -> iconSizePx + 2f * density + batteryTextPaint.measureText("$batteryLevel%")
+                else -> iconSizePx
             }
             (itemW + 5f * density) * batteryAlpha
         } else {
@@ -1058,26 +1070,47 @@ class StatusGlanceView(context: Context) : View(context) {
             val batteryPhaseAlpha = ((expandPhase - 0.3f) / 0.7f).coerceIn(0f, 1f)
             val combinedBatteryAlpha = (slotAlpha * alphaMultiplier * revealTextAlpha * batteryAlpha * batteryPhaseAlpha * 255).toInt().coerceIn(0, 255)
             if (combinedBatteryAlpha > 0) {
-                if (batteryDisplayMode == "icon") {
-                    val batteryIconSize = 16f * density
-                    val batteryIcon = getBatteryBitmap(batteryIconSize.toInt())
-                    if (batteryIcon != null) {
-                        iconPaint.alpha = combinedBatteryAlpha
-                        iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
-                        val batteryLeft = right - (5.5f * density) - batteryIconSize
-                        val batteryTop = glanceCenterY - batteryIconSize / 2f + offsetY
-                        val dstRect = RectF(batteryLeft, batteryTop, batteryLeft + batteryIconSize, batteryTop + batteryIconSize)
-                        canvas.drawBitmap(batteryIcon, null, dstRect, iconPaint)
+                val iconSizePx = batteryIconSizeDp * density
+                val pctText = "$batteryLevel%"
+                val pctWidth = batteryTextPaint.measureText(pctText)
+
+                when (batteryDisplayMode) {
+                    "icon" -> {
+                        val batteryIcon = getBatteryBitmap(iconSizePx.toInt())
+                        if (batteryIcon != null) {
+                            iconPaint.alpha = combinedBatteryAlpha
+                            iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                            val batteryLeft = right - (5.5f * density) - iconSizePx
+                            val batteryTop = glanceCenterY - iconSizePx / 2f + offsetY
+                            canvas.drawBitmap(batteryIcon, null, RectF(batteryLeft, batteryTop, batteryLeft + iconSizePx, batteryTop + iconSizePx), iconPaint)
+                        }
                     }
-                } else {
-                    val pctText = "$batteryLevel%"
-                    batteryTextPaint.alpha = combinedBatteryAlpha
-                    batteryTextPaint.color = currentTextColor
-                    batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
-                    val pctWidth = batteryTextPaint.measureText(pctText)
-                    val pctX = right - (5.5f * density) - pctWidth
-                    val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
-                    canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+                    "percentage" -> {
+                        batteryTextPaint.alpha = combinedBatteryAlpha
+                        batteryTextPaint.color = currentTextColor
+                        batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
+                        val pctX = right - (5.5f * density) - pctWidth
+                        val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
+                        canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+                    }
+                    "both" -> {
+                        // Draw percentage text first (rightmost), then icon to its left
+                        batteryTextPaint.alpha = combinedBatteryAlpha
+                        batteryTextPaint.color = currentTextColor
+                        batteryTextPaint.getTextBounds(pctText, 0, pctText.length, textBounds)
+                        val pctX = right - (5.5f * density) - pctWidth
+                        val pctY = glanceCenterY - textBounds.exactCenterY() + offsetY
+                        canvas.drawText(pctText, pctX, pctY, batteryTextPaint)
+
+                        val batteryIcon = getBatteryBitmap(iconSizePx.toInt())
+                        if (batteryIcon != null) {
+                            iconPaint.alpha = combinedBatteryAlpha
+                            iconPaint.colorFilter = PorterDuffColorFilter(currentTextColor, PorterDuff.Mode.SRC_IN)
+                            val batteryLeft = pctX - 2f * density - iconSizePx
+                            val batteryTop = glanceCenterY - iconSizePx / 2f + offsetY
+                            canvas.drawBitmap(batteryIcon, null, RectF(batteryLeft, batteryTop, batteryLeft + iconSizePx, batteryTop + iconSizePx), iconPaint)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -182,6 +182,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBatteryShowCharging = mutableStateOf(true)
     val isStatusGlanceBatteryShowFull = mutableStateOf(true)
     val isStatusGlanceBatteryShowOtherwise = mutableStateOf(true)
+    val statusGlanceBatteryIconSize = mutableFloatStateOf(16f)
     val statusGlanceTapAction = mutableStateOf<Action?>(null)
     val statusGlanceDoubleTapAction = mutableStateOf<Action?>(null)
     val statusGlanceLongPressAction = mutableStateOf<Action?>(null)
@@ -728,6 +729,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_BATTERY_SHOW_OTHERWISE ->
                         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_BATTERY_ICON_SIZE ->
+                        statusGlanceBatteryIconSize.floatValue = settingsRepository.getStatusGlanceBatteryIconSize()
 
                     SettingsRepository.KEY_STATUS_GLANCE_TAP_ACTION ->
                         statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
@@ -2016,6 +2020,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBatteryShowCharging.value = settingsRepository.isStatusGlanceBatteryShowChargingEnabled()
         isStatusGlanceBatteryShowFull.value = settingsRepository.isStatusGlanceBatteryShowFullEnabled()
         isStatusGlanceBatteryShowOtherwise.value = settingsRepository.isStatusGlanceBatteryShowOtherwiseEnabled()
+        statusGlanceBatteryIconSize.floatValue = settingsRepository.getStatusGlanceBatteryIconSize()
         statusGlanceTapAction.value = settingsRepository.getStatusGlanceTapAction()
         statusGlanceDoubleTapAction.value = settingsRepository.getStatusGlanceDoubleTapAction()
         statusGlanceLongPressAction.value = settingsRepository.getStatusGlanceLongPressAction()
@@ -4919,6 +4924,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceBatteryShowOtherwise(enabled: Boolean) {
         isStatusGlanceBatteryShowOtherwise.value = enabled
         settingsRepository.setStatusGlanceBatteryShowOtherwiseEnabled(enabled)
+    }
+
+    fun setStatusGlanceBatteryIconSize(size: Float) {
+        statusGlanceBatteryIconSize.floatValue = size
+        settingsRepository.setStatusGlanceBatteryIconSize(size)
     }
 
     fun setStatusGlanceTapAction(action: Action?) {

--- a/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/sameerasw/essentials/viewmodels/MainViewModel.kt
@@ -176,6 +176,7 @@ class MainViewModel : ViewModel() {
     val isStatusGlanceBackgroundPill = mutableStateOf(false)
     val isStatusGlanceHideWhenFullscreen = mutableStateOf(true)
     val isStatusGlanceHideInQuickSettings = mutableStateOf(true)
+    val isStatusGlanceHideWhenLocked = mutableStateOf(true)
     val isStatusGlanceShowBattery = mutableStateOf(false)
     val statusGlanceBatteryDisplayMode = mutableStateOf("icon")
     val isStatusGlanceBatteryShowLow = mutableStateOf(true)
@@ -711,6 +712,9 @@ class MainViewModel : ViewModel() {
 
                     SettingsRepository.KEY_STATUS_GLANCE_HIDE_IN_QUICK_SETTINGS ->
                         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+
+                    SettingsRepository.KEY_STATUS_GLANCE_HIDE_WHEN_LOCKED ->
+                        isStatusGlanceHideWhenLocked.value = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
 
                     SettingsRepository.KEY_STATUS_GLANCE_SHOW_BATTERY ->
                         isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
@@ -2014,6 +2018,7 @@ class MainViewModel : ViewModel() {
         isStatusGlanceBackgroundPill.value = settingsRepository.isStatusGlanceBackgroundPillEnabled()
         isStatusGlanceHideWhenFullscreen.value = settingsRepository.isStatusGlanceHideWhenFullscreenEnabled()
         isStatusGlanceHideInQuickSettings.value = settingsRepository.isStatusGlanceHideInQuickSettingsEnabled()
+        isStatusGlanceHideWhenLocked.value = settingsRepository.isStatusGlanceHideWhenLockedEnabled()
         isStatusGlanceShowBattery.value = settingsRepository.isStatusGlanceShowBatteryEnabled()
         statusGlanceBatteryDisplayMode.value = settingsRepository.getStatusGlanceBatteryDisplayMode()
         isStatusGlanceBatteryShowLow.value = settingsRepository.isStatusGlanceBatteryShowLowEnabled()
@@ -4894,6 +4899,11 @@ class MainViewModel : ViewModel() {
     fun setStatusGlanceHideInQuickSettings(enabled: Boolean) {
         isStatusGlanceHideInQuickSettings.value = enabled
         settingsRepository.setStatusGlanceHideInQuickSettingsEnabled(enabled)
+    }
+
+    fun setStatusGlanceHideWhenLocked(enabled: Boolean) {
+        isStatusGlanceHideWhenLocked.value = enabled
+        settingsRepository.setStatusGlanceHideWhenLockedEnabled(enabled)
     }
 
     fun setStatusGlanceShowBattery(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2539,7 +2539,7 @@
     <string name="status_glance_battery_options_title">Battery options</string>
     <string name="status_glance_battery_display_mode_title">Display mode</string>
     <string name="status_glance_battery_mode_icon">Icon</string>
-    <string name="status_glance_battery_mode_percentage">Percentage</string>
+    <string name="status_glance_battery_mode_percentage">Percent</string>
     <string name="status_glance_battery_mode_both">Both</string>
     <string name="status_glance_battery_icon_size_title">Battery icon size</string>
     <string name="status_glance_battery_show_low_title">Show when low battery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2538,6 +2538,8 @@
     <string name="status_glance_battery_display_mode_title">Display mode</string>
     <string name="status_glance_battery_mode_icon">Icon</string>
     <string name="status_glance_battery_mode_percentage">Percentage</string>
+    <string name="status_glance_battery_mode_both">Both</string>
+    <string name="status_glance_battery_icon_size_title">Battery icon size</string>
     <string name="status_glance_battery_show_low_title">Show when low battery</string>
     <string name="status_glance_battery_show_low_desc">When battery drops below 20%</string>
     <string name="status_glance_battery_show_charging_title">Show while charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2531,6 +2531,8 @@
     <string name="status_glance_background_pill_desc">Using material you colors</string>
     <string name="status_glance_hide_in_quick_settings_title">Hide in quick settings</string>
     <string name="status_glance_hide_in_quick_settings_desc">Automatically hide when notification shade or quick settings is expanded</string>
+    <string name="status_glance_hide_when_locked_title">Hide on lock screen</string>
+    <string name="status_glance_hide_when_locked_desc">Hide the chip while the device is locked</string>
     <string name="status_glance_slot_flashlight">Flashlight On</string>
     <string name="status_glance_show_battery_title">Battery</string>
     <string name="status_glance_show_battery_desc">Display battery indicator on the right side of the pill</string>


### PR DESCRIPTION
## What this adds

### 1. Battery "Both" mode & configurable icon size
- **Display mode**: Adds a third option — **Both** — alongside Icon and Percent so both can be seen simultaneously on the chip (`[ 🔋 82% ]`).
- **Icon size slider**: Configurable size (10 to 24 dp, default 16 dp) directly from the options sheet. Automatically hides when Percent-only is selected.
- **Cache refresh**: Bitmap cache clears on size change for crisp rendering.
- **Segmented button alignment**: Centered labels and icons on a 24dp curved card container with single-line text formatting.

### 2. Lock screen visibility & gesture support
- Added a **Hide on lock screen** toggle under Appearance settings (defaults to `true`).
- When turned off, Status Glance displays above the lock screen via `FLAG_SHOW_WHEN_LOCKED`.
- Touch interactions (like tapping to play/pause or swiping to skip media) remain responsive on the lock screen when unhidden.

## Files touched
- `StatusGlanceView.kt` — `batteryIconSizeDp` & `hideWhenLocked` properties, layout/draw routines
- `StatusGlanceHandler.kt` — syncs battery size, lock screen flags, and touch anchor logic
- `StatusGlanceSettingsUI.kt` — added lock screen toggle switch
- `StatusGlanceBatteryOptionsBottomSheet.kt` — 3-button segmented picker + animated icon size slider
- `SettingsRepository.kt` — new preference keys, getters, and setters
- `MainViewModel.kt` — state holders, preference listeners, and setters
- `ScreenOffAccessibilityService.kt` — preference observer for lock screen toggle
- `strings.xml` — localized string resources

Build verified: `:app:compileDebugKotlin` and `:app:assembleDebug` BUILD SUCCESSFUL, zero warnings.
